### PR TITLE
feat: add CI workflow with TypeScript and Jest checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  typecheck:
+    name: TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run test:ci

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "test": "jest --watchAll"
+    "test": "jest",
+    "test:ci": "jest --ci",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with two parallel jobs: TypeScript (`tsc --noEmit`) and Jest (`jest --ci`)
- Triggers on push to any branch and on PRs targeting `main`
- Fixes `test` script (removes `--watchAll` which hangs in CI)
- Adds `test:ci` and `typecheck` scripts to `package.json`

## Test plan
- [ ] Confirm both CI jobs pass on this PR
- [ ] After merging, enable branch protection on `main`: Settings → Branches → Require status checks → select `TypeScript` and `Tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)