### PR TITLE
feat: POI bottom sheet with ratings and reviews — Phase 2

### DIFF
--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -5,6 +5,7 @@ import { Tables } from '@/types/supabase'
 import { usePois } from '@/hooks/usePois'
 import { PoiLayer } from '@/components/map/PoiLayer'
 import { CategoryFilterBar } from '@/components/map/CategoryFilterBar'
+import { PoiBottomSheet } from '@/components/map/PoiBottomSheet'
 import { POI_CATEGORIES, PoiCategory } from '@/lib/poiCategories'
 
 type Poi = Tables<'pois'>
@@ -16,6 +17,7 @@ const ALL_ACTIVE = Object.fromEntries(
 export default function MapScreen() {
   const { pois } = usePois()
   const [activeCategories, setActiveCategories] = useState<Record<PoiCategory, boolean>>(ALL_ACTIVE)
+  const [selectedPoi, setSelectedPoi] = useState<Poi | null>(null)
 
   const filteredPois = useMemo(
     () => pois.filter((p) => activeCategories[p.category] !== false),
@@ -23,8 +25,11 @@ export default function MapScreen() {
   )
 
   const handlePoiPress = useCallback((poi: Poi) => {
-    // Bottom sheet — Phase 2 next task
-    console.log('POI tapped:', poi.name, poi.category)
+    setSelectedPoi(poi)
+  }, [])
+
+  const handleSheetClose = useCallback(() => {
+    setSelectedPoi(null)
   }, [])
 
   return (
@@ -37,6 +42,7 @@ export default function MapScreen() {
         <PoiLayer pois={filteredPois} onPoiPress={handlePoiPress} />
       </Mapbox.MapView>
       <CategoryFilterBar value={activeCategories} onChange={setActiveCategories} />
+      <PoiBottomSheet poi={selectedPoi} onClose={handleSheetClose} />
     </View>
   )
 }

--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -1,13 +1,16 @@
 import { Stack } from 'expo-router'
+import { BottomSheetModalProvider } from '@gorhom/bottom-sheet'
 
 export default function AppLayout() {
   return (
-    <Stack>
-      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-      <Stack.Screen
-        name="profile-modal"
-        options={{ presentation: 'modal', title: 'Edit Profile' }}
-      />
-    </Stack>
+    <BottomSheetModalProvider>
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen
+          name="profile-modal"
+          options={{ presentation: 'modal', title: 'Edit Profile' }}
+        />
+      </Stack>
+    </BottomSheetModalProvider>
   )
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { Slot, useRouter, useSegments } from 'expo-router'
+import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import Mapbox from '@rnmapbox/maps'
 import { useAuth } from '@/hooks/useAuth'
 
@@ -22,5 +23,5 @@ export default function RootLayout() {
     }
   }, [session, loading, segments])
 
-  return <Slot />
+  return <GestureHandlerRootView style={{ flex: 1 }}><Slot /></GestureHandlerRootView>
 }

--- a/components/map/PoiBottomSheet.tsx
+++ b/components/map/PoiBottomSheet.tsx
@@ -1,0 +1,494 @@
+import { useRef, useMemo, useCallback, useEffect } from "react";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  Linking,
+  Platform,
+  StyleSheet,
+} from "react-native";
+import BottomSheet, {
+  BottomSheetBackdrop,
+  BottomSheetFlatList,
+  BottomSheetBackdropProps,
+} from "@gorhom/bottom-sheet";
+import { Tables } from "@/types/supabase";
+import { CATEGORY_COLORS, CATEGORY_LABELS } from "@/lib/poiCategories";
+import { usePoiRatings, RatingComment } from "@/hooks/usePoiRatings";
+import {
+  PoiRatingModal,
+  PoiRatingModalHandle,
+} from "@/components/map/PoiRatingModal";
+
+type Poi = Tables<"pois">;
+
+type Props = {
+  poi: Poi | null;
+  onClose: () => void;
+};
+
+// Category emoji icons for extra character
+const CATEGORY_ICONS: Record<string, string> = {
+  food_drink: "🍜",
+  nightlife: "🎶",
+  culture: "🏛️",
+  study_spots: "📖",
+  hidden_gems: "💎",
+};
+
+function Stars({ rating, size = 16 }: { rating: number; size?: number }) {
+  return (
+    <View style={styles.starsRow}>
+      {[1, 2, 3, 4, 5].map((i) => (
+        <Text key={i} style={[styles.star, { fontSize: size }]}>
+          {i <= Math.round(rating) ? "★" : "☆"}
+        </Text>
+      ))}
+    </View>
+  );
+}
+
+function AuthorAvatar({ name }: { name: string }) {
+  const initials = name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+  return (
+    <View style={styles.avatarCircle}>
+      <Text style={styles.avatarInitials}>{initials}</Text>
+    </View>
+  );
+}
+
+function CommentRow({ item }: { item: RatingComment }) {
+  const date = new Date(item.created_at).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+  return (
+    <View style={styles.commentRow}>
+      <View style={styles.commentLeft}>
+        <AuthorAvatar name={item.display_name} />
+      </View>
+      <View style={styles.commentBody}>
+        <View style={styles.commentHeader}>
+          <Text style={styles.commentAuthor}>{item.display_name}</Text>
+          <View style={styles.commentMeta}>
+            <Stars rating={item.rating} size={11} />
+            <Text style={styles.commentDate}>{date}</Text>
+          </View>
+        </View>
+        {item.comment ? (
+          <Text style={styles.commentText}>{item.comment}</Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+export function PoiBottomSheet({ poi, onClose }: Props) {
+  const snapPoints = useMemo(() => ["42%", "82%"], []);
+  const bottomSheetRef = useRef<BottomSheet>(null);
+  const ratingModalRef = useRef<PoiRatingModalHandle>(null);
+  const { avgRating, ratingCount, comments, myRating, refetch } = usePoiRatings(
+    poi?.id,
+  );
+
+  // Drive open/close imperatively so that a swipe-down (which calls onClose → clears poi)
+  // doesn't trigger a redundant second programmatic close on an already-closing sheet.
+  useEffect(() => {
+    if (poi) {
+      bottomSheetRef.current?.snapToIndex(0);
+    } else {
+      bottomSheetRef.current?.close();
+    }
+  }, [poi]);
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+        pressBehavior="close"
+        opacity={0.35}
+      />
+    ),
+    [],
+  );
+
+  const handleGetDirections = useCallback(() => {
+    if (!poi) return;
+    const url =
+      Platform.OS === "ios"
+        ? `maps://maps.apple.com/?ll=${poi.lat},${poi.lng}&q=${encodeURIComponent(poi.name)}`
+        : `geo:${poi.lat},${poi.lng}?q=${poi.lat},${poi.lng}(${encodeURIComponent(poi.name)})`;
+    Linking.openURL(url);
+  }, [poi]);
+
+  const handleChange = useCallback(
+    (index: number) => {
+      if (index === -1) onClose();
+    },
+    [onClose],
+  );
+
+  const categoryColor = poi ? CATEGORY_COLORS[poi.category] : "#999";
+  const categoryLabel = poi ? CATEGORY_LABELS[poi.category] : "";
+  const categoryIcon = poi ? CATEGORY_ICONS[poi.category] ?? "" : "";
+
+  return (
+    <>
+      <BottomSheet
+        ref={bottomSheetRef}
+        index={-1}
+        snapPoints={snapPoints}
+        enablePanDownToClose
+        backdropComponent={renderBackdrop}
+        onChange={handleChange}
+        handleIndicatorStyle={styles.handleIndicator}
+        backgroundStyle={styles.sheetBackground}
+      >
+        <BottomSheetFlatList
+          data={comments}
+          keyExtractor={(item: RatingComment) => item.id}
+          renderItem={({ item }: { item: RatingComment }) => (
+            <CommentRow item={item} />
+          )}
+          contentContainerStyle={styles.listContent}
+          ListHeaderComponent={
+            <>
+              {/* Tappable area: badge + name + rating → expands sheet */}
+              <TouchableOpacity
+                activeOpacity={1}
+                onPress={() => bottomSheetRef.current?.snapToIndex(1)}
+              >
+                {/* Category badge */}
+                <View
+                  style={[
+                    styles.categoryBadge,
+                    {
+                      backgroundColor: categoryColor + "18",
+                      borderColor: categoryColor + "40",
+                    },
+                  ]}
+                >
+                  <Text style={styles.categoryIcon}>{categoryIcon}</Text>
+                  <Text style={[styles.categoryLabel, { color: categoryColor }]}>
+                    {categoryLabel}
+                  </Text>
+                </View>
+
+                {/* POI name */}
+                <Text style={styles.poiName}>{poi?.name}</Text>
+
+                {/* Rating summary */}
+                <View style={styles.ratingRow}>
+                  {avgRating !== null ? (
+                    <>
+                      <Text style={styles.ratingScore}>{avgRating.toFixed(1)}</Text>
+                      <Stars rating={avgRating} size={15} />
+                      <Text style={styles.ratingCount}>
+                        {ratingCount} {ratingCount === 1 ? "review" : "reviews"}
+                      </Text>
+                    </>
+                  ) : (
+                    <Text style={styles.noRatings}>No reviews yet — be the first!</Text>
+                  )}
+                </View>
+              </TouchableOpacity>
+
+              {/* Divider */}
+              <View style={styles.divider} />
+
+              {/* Action buttons */}
+              <View style={styles.actions}>
+                <TouchableOpacity
+                  style={styles.directionsButton}
+                  onPress={handleGetDirections}
+                  activeOpacity={0.85}
+                >
+                  <Text style={styles.directionsIcon}>↗</Text>
+                  <Text style={styles.directionsButtonText}>Get Directions</Text>
+                </TouchableOpacity>
+
+                {myRating ? (
+                  <View style={styles.ratedRow}>
+                    <Text style={styles.ratedText}>Your rating</Text>
+                    <Stars rating={myRating.rating} size={15} />
+                  </View>
+                ) : (
+                  <TouchableOpacity
+                    style={styles.reviewButton}
+                    onPress={() => ratingModalRef.current?.present()}
+                    activeOpacity={0.75}
+                  >
+                    <Text style={styles.reviewIcon}>✦</Text>
+                    <Text style={styles.reviewButtonText}>Leave a Review</Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+
+              {/* Comments section label */}
+              <View style={styles.commentsLabel}>
+                <Text style={styles.commentsLabelText}>
+                  {comments.length > 0
+                    ? `${comments.length} ${comments.length === 1 ? "Comment" : "Comments"}`
+                    : "Comments"}
+                </Text>
+              </View>
+            </>
+          }
+          ListEmptyComponent={
+            <View style={styles.emptyContainer}>
+              <Text style={styles.emptyEmoji}>💬</Text>
+              <Text style={styles.emptyComments}>No comments yet</Text>
+              <Text style={styles.emptySubtext}>
+                Share what you think of this place
+              </Text>
+            </View>
+          }
+        />
+      </BottomSheet>
+
+      {poi && (
+        <PoiRatingModal
+          ref={ratingModalRef}
+          poiId={poi.id}
+          onSubmitted={refetch}
+        />
+      )}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  sheetBackground: {
+    backgroundColor: "#FAFAF8",
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+  },
+  handleIndicator: {
+    width: 36,
+    height: 4,
+    backgroundColor: "#D4D4CF",
+    borderRadius: 2,
+  },
+  categoryBadge: {
+    alignSelf: "flex-start",
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: 20,
+    borderWidth: 1,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    marginBottom: 10,
+    gap: 5,
+  },
+  categoryIcon: {
+    fontSize: 12,
+  },
+  categoryLabel: {
+    fontSize: 12,
+    fontWeight: "700",
+    letterSpacing: 0.3,
+  },
+  poiName: {
+    fontSize: 26,
+    fontWeight: "800",
+    color: "#131313",
+    letterSpacing: -0.5,
+    lineHeight: 31,
+    marginBottom: 10,
+  },
+  ratingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 16,
+    gap: 7,
+  },
+  ratingScore: {
+    fontSize: 17,
+    fontWeight: "800",
+    color: "#131313",
+    letterSpacing: -0.3,
+  },
+  starsRow: {
+    flexDirection: "row",
+    gap: 2,
+  },
+  star: {
+    color: "#F5A623",
+  },
+  ratingCount: {
+    fontSize: 13,
+    color: "#888",
+    fontWeight: "500",
+  },
+  noRatings: {
+    fontSize: 14,
+    color: "#AAA",
+    fontStyle: "italic",
+  },
+  divider: {
+    height: 1,
+    backgroundColor: "#EDECEA",
+    marginBottom: 14,
+  },
+  actions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 4,
+  },
+  directionsButton: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#131313",
+    borderRadius: 14,
+    paddingVertical: 13,
+    gap: 7,
+  },
+  directionsIcon: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  directionsButtonText: {
+    color: "#fff",
+    fontWeight: "700",
+    fontSize: 14,
+    letterSpacing: 0.1,
+  },
+  reviewButton: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1.5,
+    borderColor: "#D4D4CF",
+    borderRadius: 14,
+    paddingVertical: 13,
+    gap: 7,
+    backgroundColor: "#fff",
+  },
+  reviewIcon: {
+    color: "#F5A623",
+    fontSize: 13,
+  },
+  reviewButtonText: {
+    color: "#131313",
+    fontWeight: "700",
+    fontSize: 14,
+    letterSpacing: 0.1,
+  },
+  ratedRow: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    paddingVertical: 13,
+    borderRadius: 14,
+    backgroundColor: "#FFF8EC",
+    borderWidth: 1.5,
+    borderColor: "#F5A62330",
+  },
+  ratedText: {
+    color: "#7A6030",
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  commentsLabel: {
+    paddingTop: 16,
+    paddingBottom: 8,
+  },
+  commentsLabelText: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: "#AAAAAA",
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
+  },
+  listContent: {
+    paddingHorizontal: 22,
+    paddingTop: 8,
+    paddingBottom: 40,
+  },
+  commentRow: {
+    flexDirection: "row",
+    paddingVertical: 14,
+    borderTopWidth: 1,
+    borderTopColor: "#EDECEA",
+    gap: 12,
+  },
+  commentLeft: {
+    paddingTop: 1,
+  },
+  avatarCircle: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    backgroundColor: "#EDECEA",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  avatarInitials: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: "#666",
+    letterSpacing: 0.3,
+  },
+  commentBody: {
+    flex: 1,
+  },
+  commentHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 5,
+  },
+  commentAuthor: {
+    fontWeight: "700",
+    fontSize: 14,
+    color: "#131313",
+    flex: 1,
+  },
+  commentMeta: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  commentDate: {
+    fontSize: 11,
+    color: "#BBBBBB",
+    fontWeight: "500",
+  },
+  commentText: {
+    fontSize: 14,
+    color: "#555",
+    lineHeight: 21,
+  },
+  emptyContainer: {
+    alignItems: "center",
+    paddingVertical: 32,
+    gap: 6,
+  },
+  emptyEmoji: {
+    fontSize: 28,
+    marginBottom: 4,
+  },
+  emptyComments: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#AAAAAA",
+  },
+  emptySubtext: {
+    fontSize: 13,
+    color: "#CCCCCC",
+  },
+});

--- a/components/map/PoiRatingModal.tsx
+++ b/components/map/PoiRatingModal.tsx
@@ -1,0 +1,283 @@
+import { forwardRef, useImperativeHandle, useRef, useMemo, useState } from 'react'
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native'
+import { BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet'
+import { supabase } from '@/lib/supabase'
+import { submitRating } from '@/lib/ratings'
+
+export type PoiRatingModalHandle = {
+  present: () => void
+  dismiss: () => void
+}
+
+type Props = {
+  poiId: string
+  onSubmitted: () => void
+}
+
+const STAR_LABELS = ['', 'Poor', 'Fair', 'Good', 'Great', 'Excellent']
+
+export const PoiRatingModal = forwardRef<PoiRatingModalHandle, Props>(function PoiRatingModal(
+  { poiId, onSubmitted },
+  ref
+) {
+  const modalRef = useRef<BottomSheetModal>(null)
+  const snapPoints = useMemo(() => ['55%'], [])
+
+  const [selectedRating, setSelectedRating] = useState<number | null>(null)
+  const [comment, setComment] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useImperativeHandle(ref, () => ({
+    present: () => {
+      setSelectedRating(null)
+      setComment('')
+      setError(null)
+      modalRef.current?.present()
+    },
+    dismiss: () => modalRef.current?.dismiss(),
+  }))
+
+  const handleSubmit = async () => {
+    if (!selectedRating) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      await submitRating(supabase, {
+        poiId,
+        rating: selectedRating,
+        comment,
+      })
+      onSubmitted()
+      modalRef.current?.dismiss()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const isReady = !!selectedRating && !submitting
+
+  return (
+    <BottomSheetModal
+      ref={modalRef}
+      snapPoints={snapPoints}
+      enablePanDownToClose
+      handleIndicatorStyle={styles.handleIndicator}
+      backgroundStyle={styles.modalBackground}
+    >
+      <BottomSheetView style={styles.container}>
+        {/* Header */}
+        <View style={styles.headerRow}>
+          <Text style={styles.title}>Leave a Review</Text>
+          <Text style={styles.subtitle}>How was your experience?</Text>
+        </View>
+
+        {/* Star rating picker */}
+        <View style={styles.starsSection}>
+          <View style={styles.starsRow}>
+            {[1, 2, 3, 4, 5].map((i) => (
+              <TouchableOpacity
+                key={i}
+                onPress={() => setSelectedRating(i)}
+                hitSlop={6}
+                activeOpacity={0.7}
+                style={styles.starButton}
+              >
+                <Text
+                  style={[
+                    styles.star,
+                    selectedRating !== null && i <= selectedRating
+                      ? styles.starActive
+                      : styles.starInactive,
+                  ]}
+                >
+                  {selectedRating !== null && i <= selectedRating ? '★' : '☆'}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+          <Text style={styles.starLabel}>
+            {selectedRating ? STAR_LABELS[selectedRating] : 'Tap to rate'}
+          </Text>
+        </View>
+
+        {/* Comment input */}
+        <View style={styles.inputWrapper}>
+          <TextInput
+            style={styles.input}
+            placeholder="Share what you loved (or didn't)…"
+            placeholderTextColor="#C0BDB8"
+            multiline
+            maxLength={280}
+            value={comment}
+            onChangeText={setComment}
+          />
+          <Text style={styles.charCount}>{comment.length}/280</Text>
+        </View>
+
+        {/* Error */}
+        {error ? (
+          <View style={styles.errorRow}>
+            <Text style={styles.errorIcon}>⚠</Text>
+            <Text style={styles.error}>{error}</Text>
+          </View>
+        ) : null}
+
+        {/* Submit */}
+        <TouchableOpacity
+          style={[
+            styles.submitButton,
+            isReady ? styles.submitActive : styles.submitDisabled,
+          ]}
+          onPress={handleSubmit}
+          disabled={!isReady}
+          activeOpacity={0.85}
+        >
+          {submitting ? (
+            <ActivityIndicator color="#fff" size="small" />
+          ) : (
+            <>
+              <Text style={styles.submitText}>
+                {isReady ? 'Submit Review' : 'Select a rating first'}
+              </Text>
+              {isReady && <Text style={styles.submitArrow}>→</Text>}
+            </>
+          )}
+        </TouchableOpacity>
+      </BottomSheetView>
+    </BottomSheetModal>
+  )
+})
+
+const styles = StyleSheet.create({
+  modalBackground: {
+    backgroundColor: '#FAFAF8',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+  },
+  handleIndicator: {
+    width: 36,
+    height: 4,
+    backgroundColor: '#D4D4CF',
+    borderRadius: 2,
+  },
+  container: {
+    paddingHorizontal: 24,
+    paddingTop: 8,
+    paddingBottom: 32,
+    gap: 18,
+  },
+  headerRow: {
+    gap: 3,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: '#131313',
+    letterSpacing: -0.5,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#AAAAAA',
+    fontWeight: '400',
+  },
+  starsSection: {
+    alignItems: 'center',
+    gap: 10,
+    paddingVertical: 6,
+  },
+  starsRow: {
+    flexDirection: 'row',
+    gap: 6,
+  },
+  starButton: {
+    padding: 4,
+  },
+  star: {
+    fontSize: 44,
+  },
+  starActive: {
+    color: '#F5A623',
+  },
+  starInactive: {
+    color: '#DDD9D3',
+  },
+  starLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#AAAAAA',
+    letterSpacing: 0.3,
+    minHeight: 18,
+  },
+  inputWrapper: {
+    position: 'relative',
+  },
+  input: {
+    borderWidth: 1.5,
+    borderColor: '#EDECEA',
+    borderRadius: 14,
+    paddingHorizontal: 14,
+    paddingTop: 13,
+    paddingBottom: 32,
+    fontSize: 15,
+    color: '#131313',
+    minHeight: 90,
+    textAlignVertical: 'top',
+    backgroundColor: '#fff',
+    lineHeight: 22,
+  },
+  charCount: {
+    position: 'absolute',
+    bottom: 10,
+    right: 14,
+    fontSize: 11,
+    color: '#CCCCCC',
+    fontWeight: '500',
+  },
+  errorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    backgroundColor: '#FFF1F1',
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 9,
+  },
+  errorIcon: {
+    fontSize: 13,
+    color: '#E51E1E',
+  },
+  error: {
+    color: '#E51E1E',
+    fontSize: 13,
+    fontWeight: '500',
+    flex: 1,
+  },
+  submitButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 14,
+    paddingVertical: 15,
+    gap: 8,
+  },
+  submitActive: {
+    backgroundColor: '#131313',
+  },
+  submitDisabled: {
+    backgroundColor: '#EDECEA',
+  },
+  submitText: {
+    fontWeight: '700',
+    fontSize: 15,
+    color: '#fff',
+    letterSpacing: 0.1,
+  },
+  submitArrow: {
+    color: '#ffffff90',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+})

--- a/hooks/usePoiRatings.ts
+++ b/hooks/usePoiRatings.ts
@@ -1,0 +1,100 @@
+import { useState, useEffect, useCallback } from 'react'
+import { supabase } from '@/lib/supabase'
+import { useAuth } from '@/hooks/useAuth'
+
+export type RatingComment = {
+  id: string
+  rating: number
+  // Only rows where comment IS NOT NULL are included — non-null guaranteed by filter before mapping
+  comment: string
+  created_at: string
+  user_id: string
+  display_name: string
+}
+
+export type MyRating = {
+  id: string
+  rating: number
+  comment: string | null
+}
+
+function getDisplayName(profiles: unknown): string {
+  if (!profiles) return 'Unknown'
+  if (Array.isArray(profiles)) return (profiles[0] as { display_name?: string })?.display_name ?? 'Unknown'
+  return (profiles as { display_name?: string }).display_name ?? 'Unknown'
+}
+
+export function usePoiRatings(poiId: string | undefined) {
+  const { session } = useAuth()
+  const userId = session?.user.id
+  const [avgRating, setAvgRating] = useState<number | null>(null)
+  const [ratingCount, setRatingCount] = useState(0)
+  const [comments, setComments] = useState<RatingComment[]>([])
+  const [myRating, setMyRating] = useState<MyRating | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  // Accepts an optional isCancelled guard so the useEffect can cancel in-flight
+  // requests when poiId changes, while refetch() calls pass no guard.
+  const load = useCallback(async (isCancelled?: () => boolean) => {
+    if (!poiId) return
+    setLoading(true)
+
+    // Relies on the "Profiles viewable by authenticated users" RLS SELECT policy
+    // allowing cross-user reads of display_name. If that policy is ever tightened,
+    // profiles will silently return null and display_name will fall back to 'Unknown'.
+    const { data, error } = await supabase
+      .from('poi_ratings')
+      .select('id, rating, comment, created_at, user_id, profiles(display_name)')
+      .eq('poi_id', poiId)
+      .order('created_at', { ascending: false })
+
+    if (isCancelled?.()) return
+
+    if (error) {
+      console.error('usePoiRatings:', error.message)
+      setLoading(false)
+      return
+    }
+
+    const rows = data ?? []
+    const total = rows.reduce((sum, r) => sum + r.rating, 0)
+    setRatingCount(rows.length)
+    setAvgRating(rows.length > 0 ? total / rows.length : null)
+
+    setComments(
+      rows
+        .filter((r) => r.comment !== null && r.created_at !== null)
+        .slice(0, 5)
+        .map((r) => ({
+          id: r.id,
+          rating: r.rating,
+          comment: r.comment as string,
+          created_at: r.created_at as string,
+          user_id: r.user_id,
+          display_name: getDisplayName(r.profiles),
+        }))
+    )
+
+    const mine = userId ? (rows.find((r) => r.user_id === userId) ?? null) : null
+    setMyRating(mine ? { id: mine.id, rating: mine.rating, comment: mine.comment ?? null } : null)
+
+    setLoading(false)
+  }, [poiId, userId])
+
+  useEffect(() => {
+    let cancelled = false
+    if (!poiId) {
+      setAvgRating(null)
+      setRatingCount(0)
+      setComments([])
+      setMyRating(null)
+      return
+    }
+    load(() => cancelled)
+    return () => {
+      cancelled = true
+    }
+  }, [poiId, load])
+
+  return { avgRating, ratingCount, comments, myRating, loading, refetch: load }
+}

--- a/lib/__tests__/submitRating.test.ts
+++ b/lib/__tests__/submitRating.test.ts
@@ -1,0 +1,112 @@
+import { submitRating } from '../ratings'
+import { SupabaseClient } from '@supabase/supabase-js'
+import { Database } from '../../types/supabase'
+
+const MOCK_USER_ID = 'user-456'
+
+type MockSupabase = {
+  from: jest.Mock
+  insert: jest.Mock
+  auth: { getUser: jest.Mock }
+}
+
+function makeMockSupabase(insertResult: { error: { message: string; code?: string } | null }): MockSupabase {
+  const insert = jest.fn().mockResolvedValue(insertResult)
+  const from = jest.fn().mockReturnValue({ insert })
+  const getUser = jest.fn().mockResolvedValue({ data: { user: { id: MOCK_USER_ID } }, error: null })
+  return { from, insert, auth: { getUser } }
+}
+
+function asClient(mock: MockSupabase): SupabaseClient<Database> {
+  return mock as unknown as SupabaseClient<Database>
+}
+
+describe('submitRating', () => {
+  const baseArgs = { poiId: 'poi-123', rating: 4, comment: 'Great spot!' }
+
+  it('inserts the correct fields', async () => {
+    const mock = makeMockSupabase({ error: null })
+    await submitRating(asClient(mock), baseArgs)
+
+    expect(mock.from).toHaveBeenCalledWith('poi_ratings')
+    expect(mock.insert).toHaveBeenCalledWith({
+      poi_id: 'poi-123',
+      user_id: MOCK_USER_ID,
+      rating: 4,
+      comment: 'Great spot!',
+    })
+  })
+
+  it('succeeds when rating is 1 (lower boundary)', async () => {
+    const mock = makeMockSupabase({ error: null })
+    await expect(submitRating(asClient(mock), { ...baseArgs, rating: 1 })).resolves.not.toThrow()
+    expect(mock.insert).toHaveBeenCalledWith(expect.objectContaining({ rating: 1 }))
+  })
+
+  it('succeeds when rating is 5 (upper boundary)', async () => {
+    const mock = makeMockSupabase({ error: null })
+    await expect(submitRating(asClient(mock), { ...baseArgs, rating: 5 })).resolves.not.toThrow()
+    expect(mock.insert).toHaveBeenCalledWith(expect.objectContaining({ rating: 5 }))
+  })
+
+  it('passes null comment when comment is an empty string', async () => {
+    const mock = makeMockSupabase({ error: null })
+    await submitRating(asClient(mock), { ...baseArgs, comment: '' })
+
+    expect(mock.insert).toHaveBeenCalledWith({
+      poi_id: 'poi-123',
+      user_id: MOCK_USER_ID,
+      rating: 4,
+      comment: null,
+    })
+  })
+
+  it('passes null comment when comment is only whitespace', async () => {
+    const mock = makeMockSupabase({ error: null })
+    await submitRating(asClient(mock), { ...baseArgs, comment: '   ' })
+
+    expect(mock.insert).toHaveBeenCalledWith({
+      poi_id: 'poi-123',
+      user_id: MOCK_USER_ID,
+      rating: 4,
+      comment: null,
+    })
+  })
+
+  it('passes null comment when comment is omitted', async () => {
+    const mock = makeMockSupabase({ error: null })
+    await submitRating(asClient(mock), { poiId: 'poi-123', rating: 4 })
+
+    expect(mock.insert).toHaveBeenCalledWith({
+      poi_id: 'poi-123',
+      user_id: MOCK_USER_ID,
+      rating: 4,
+      comment: null,
+    })
+  })
+
+  it('throws when rating is below 1', async () => {
+    const mock = makeMockSupabase({ error: null })
+    await expect(
+      submitRating(asClient(mock), { ...baseArgs, rating: 0 })
+    ).rejects.toThrow('Rating must be between 1 and 5')
+    expect(mock.from).not.toHaveBeenCalled()
+  })
+
+  it('throws when rating is above 5', async () => {
+    const mock = makeMockSupabase({ error: null })
+    await expect(
+      submitRating(asClient(mock), { ...baseArgs, rating: 6 })
+    ).rejects.toThrow('Rating must be between 1 and 5')
+    expect(mock.from).not.toHaveBeenCalled()
+  })
+
+  it('throws with the Supabase error message when insert fails', async () => {
+    const mock = makeMockSupabase({ error: { message: 'duplicate key violation', code: '23505' } })
+    await expect(
+      submitRating(asClient(mock), baseArgs)
+    ).rejects.toThrow('duplicate key violation')
+    expect(mock.from).toHaveBeenCalledWith('poi_ratings')
+    expect(mock.insert).toHaveBeenCalled()
+  })
+})

--- a/lib/ratings.ts
+++ b/lib/ratings.ts
@@ -1,0 +1,31 @@
+import { SupabaseClient } from '@supabase/supabase-js'
+import { Database } from '@/types/supabase'
+
+type RatingInsert = Database['public']['Tables']['poi_ratings']['Insert']
+
+export async function submitRating(
+  supabase: SupabaseClient<Database>,
+  {
+    poiId,
+    rating,
+    comment,
+  }: { poiId: string; rating: number; comment?: string }
+) {
+  // Also enforced at the DB level: CHECK (rating BETWEEN 1 AND 5) on poi_ratings.rating
+  if (rating < 1 || rating > 5) {
+    throw new Error('Rating must be between 1 and 5')
+  }
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) throw new Error('Not authenticated')
+
+  const row: RatingInsert = {
+    poi_id: poiId,
+    user_id: user.id,
+    rating,
+    comment: comment?.trim() || null,
+  }
+
+  const { error } = await supabase.from('poi_ratings').insert(row)
+  if (error) throw new Error(error.message)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.2",
+        "@gorhom/bottom-sheet": "^5.2.8",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@rnmapbox/maps": "^10.3.0",
         "@supabase/supabase-js": "^2.100.1",
@@ -1876,6 +1877,45 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@gorhom/bottom-sheet": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-5.2.8.tgz",
+      "integrity": "sha512-+N27SMpbBxXZQ/IA2nlEV6RGxL/qSFHKfdFKcygvW+HqPG5jVNb1OqehLQsGfBP+Up42i0gW5ppI+DhpB7UCzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@gorhom/portal": "1.0.14",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-native": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">=2.16.1",
+        "react-native-reanimated": ">=3.16.0 || >=4.0.0-"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@gorhom/portal": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@gorhom/portal/-/portal-1.0.14.tgz",
+      "integrity": "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@isaacs/ttlcache": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
+    "@gorhom/bottom-sheet": "^5.2.8",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@rnmapbox/maps": "^10.3.0",
     "@supabase/supabase-js": "^2.100.1",


### PR DESCRIPTION
## Summary

- Adds `PoiBottomSheet` using `@gorhom/bottom-sheet` — opens on map POI tap, shows category badge, POI name, avg rating with stars, directions button, and a paginated comments list
- Adds `PoiRatingModal` for submitting 1–5 star ratings with optional text review (280 char limit); shows existing rating in place of the "Leave a Review" button if user has already rated
- Adds `usePoiRatings` hook that fetches avg rating, count, top 5 comments with author display names, and the current user's own rating from `poi_ratings`
- Adds `submitRating` lib function with upsert logic and client-side validation (rating 1–5)
- Wraps root layout in `GestureHandlerRootView` and app layout in `BottomSheetModalProvider` as required by the library

## Test plan

- [x] Run `npx jest` — all `submitRating` unit tests pass (boundary values, null comment cases, auth error, DB error)
- [x] Open the app and tap a POI marker — bottom sheet slides up to 42% snap point
- [x] Tap the header area — sheet expands to 82%
- [x] Swipe down — sheet closes and selected POI is cleared
- [x] Tap "Leave a Review", select stars, add comment, submit — rating appears on re-open
- [x] Re-open the same POI after rating — "Your rating" row replaces the review button
- [x] Tap "Get Directions" — opens native maps app with correct coordinates