### PR TITLE
chore: gitignore android/ios dirs; switch scripts to expo run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ dist/
 web-build/
 
 # Native
+android/
+ios/
 *.orig.*
 *.jks
 *.p8

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "jest",
     "test:ci": "jest --ci",


### PR DESCRIPTION
## Summary
- Adds `android/` and `ios/` to `.gitignore` — these are generated by `npx expo run:android/ios` (prebuild) and should not be tracked
- Updates `android`/`ios` npm scripts from `expo start --android/--ios` to `expo run:android/run:ios` to match the dev build workflow

## Test plan
- [ ] `npx expo run:android` builds and launches on emulator