### PR TITLE
fix: Android UI and keyboard polish

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,6 +24,7 @@
     },
     "android": {
       "package": "com.dispatch.app",
+      "softwareKeyboardLayoutMode": "pan",
       "adaptiveIcon": {
         "foregroundImage": "./assets/android-icon-foreground.png",
         "backgroundImage": "./assets/android-icon-background.png",

--- a/app/(app)/(tabs)/__tests__/MapScreen.test.tsx
+++ b/app/(app)/(tabs)/__tests__/MapScreen.test.tsx
@@ -27,6 +27,9 @@ jest.mock('@rnmapbox/maps', () => {
         React.useImperativeHandle(ref, () => ({ setCamera: mockSetCamera }))
         return null
       }),
+      StyleURL: {
+        Light: 'mapbox://styles/mapbox/light-v10',
+      },
     },
   }
 })

--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -70,11 +70,15 @@ export default function MapScreen() {
     <View style={styles.container}>
       {/* MapView stays mounted in list mode (display: none) — unmounting would destroy the
           native Mapbox GL context and invalidate cameraRef, requiring a full re-init on switch back */}
-      <Mapbox.MapView style={[styles.map, viewMode === 'list' && styles.hidden]}>
+      <Mapbox.MapView style={[styles.map, viewMode === 'list' && styles.hidden]} styleURL={Mapbox.StyleURL.Light}>
         <Mapbox.Camera
           ref={cameraRef}
-          zoomLevel={13}
+          defaultSettings={{
+            centerCoordinate: [12.5683, 55.6761],
+            zoomLevel: 13,
+          }}
           centerCoordinate={[12.5683, 55.6761]}
+          zoomLevel={13}
         />
         <PoiLayer pois={filteredPois} onPoiPress={handlePoiPress} />
       </Mapbox.MapView>

--- a/app/(app)/profile-modal.tsx
+++ b/app/(app)/profile-modal.tsx
@@ -32,7 +32,7 @@ export default function ProfileModal() {
 
   async function pickAvatar() {
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: 'images',
       allowsEditing: true,
       aspect: [1, 1],
       quality: 0.8,
@@ -48,12 +48,13 @@ export default function ProfileModal() {
     if (authError) { console.error('Failed to get user:', authError.message); setLoading(false); return }
     if (!user) { setLoading(false); return }
 
-    const ext = uri.split('.').pop()
+    const ext = uri.split('.').pop() ?? 'jpg'
     const path = `${user.id}/avatar.${ext}`
-    const response = await fetch(uri)
-    const blob = await response.blob()
 
-    const { error } = await supabase.storage.from('avatars').upload(path, blob, { upsert: true })
+    const formData = new FormData()
+    formData.append('file', { uri, name: `avatar.${ext}`, type: `image/${ext}` } as any)
+
+    const { error } = await supabase.storage.from('avatars').upload(path, formData, { upsert: true })
     if (error) {
       console.error('Failed to upload avatar:', error.message)
       setError('Failed to upload avatar.')
@@ -126,7 +127,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#f0f0f0', justifyContent: 'center', alignItems: 'center',
   },
   avatarPlaceholderText: { fontSize: 13, color: '#999' },
-  input: { borderWidth: 1, borderColor: '#ddd', borderRadius: 8, padding: 14, marginBottom: 16, fontSize: 16 },
+  input: { borderWidth: 1, borderColor: '#ddd', borderRadius: 8, padding: 14, marginBottom: 16, fontSize: 16, color: '#000' },
   button: { backgroundColor: '#0066FF', borderRadius: 8, padding: 16, alignItems: 'center' },
   buttonText: { color: '#fff', fontWeight: '600', fontSize: 16 },
   error: { color: '#CC0000', marginBottom: 12, fontSize: 14 },

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -26,6 +26,7 @@ export default function LoginScreen() {
       <TextInput
         style={styles.input}
         placeholder="Email"
+        placeholderTextColor="#999"
         value={email}
         onChangeText={setEmail}
         autoCapitalize="none"
@@ -34,6 +35,7 @@ export default function LoginScreen() {
       <TextInput
         style={styles.input}
         placeholder="Password"
+        placeholderTextColor="#999"
         value={password}
         onChangeText={setPassword}
         secureTextEntry
@@ -56,7 +58,7 @@ const styles = StyleSheet.create({
   container: { flex: 1, padding: 24, justifyContent: 'center', backgroundColor: '#fff' },
   title: { fontSize: 32, fontWeight: '700', marginBottom: 4 },
   subtitle: { fontSize: 16, color: '#666', marginBottom: 32 },
-  input: { borderWidth: 1, borderColor: '#ddd', borderRadius: 8, padding: 14, marginBottom: 12, fontSize: 16 },
+  input: { borderWidth: 1, borderColor: '#ddd', borderRadius: 8, padding: 14, marginBottom: 12, fontSize: 16, color: '#000' },
   button: { backgroundColor: '#0066FF', borderRadius: 8, padding: 16, alignItems: 'center', marginTop: 8 },
   buttonText: { color: '#fff', fontWeight: '600', fontSize: 16 },
   link: { marginTop: 16, textAlign: 'center', color: '#0066FF' },

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -51,6 +51,7 @@ export default function SignupScreen() {
       <TextInput
         style={styles.input}
         placeholder="Display name"
+        placeholderTextColor="#999"
         value={displayName}
         onChangeText={setDisplayName}
         autoCapitalize="words"
@@ -58,6 +59,7 @@ export default function SignupScreen() {
       <TextInput
         style={styles.input}
         placeholder="University email (.edu)"
+        placeholderTextColor="#999"
         value={email}
         onChangeText={setEmail}
         autoCapitalize="none"
@@ -66,6 +68,7 @@ export default function SignupScreen() {
       <TextInput
         style={styles.input}
         placeholder="Password"
+        placeholderTextColor="#999"
         value={password}
         onChangeText={setPassword}
         secureTextEntry
@@ -102,6 +105,7 @@ const styles = StyleSheet.create({
     padding: 14,
     marginBottom: 12,
     fontSize: 16,
+    color: "#000",
   },
   button: {
     backgroundColor: "#0066FF",

--- a/components/map/PoiBottomSheet.tsx
+++ b/components/map/PoiBottomSheet.tsx
@@ -89,7 +89,7 @@ function CommentRow({ item }: { item: RatingComment }) {
 }
 
 export function PoiBottomSheet({ poi, onClose }: Props) {
-  const snapPoints = useMemo(() => ["42%", "82%"], []);
+  const snapPoints = useMemo(() => ["42%", "82%", "100%"], []);
   const bottomSheetRef = useRef<BottomSheet>(null);
   const ratingModalRef = useRef<PoiRatingModalHandle>(null);
   const { avgRating, ratingCount, comments, myRating, refetch } = usePoiRatings(
@@ -222,7 +222,10 @@ export function PoiBottomSheet({ poi, onClose }: Props) {
                 ) : (
                   <TouchableOpacity
                     style={styles.reviewButton}
-                    onPress={() => ratingModalRef.current?.present()}
+                    onPress={() => {
+                      bottomSheetRef.current?.snapToIndex(2);
+                      ratingModalRef.current?.present();
+                    }}
                     activeOpacity={0.75}
                   >
                     <Text style={styles.reviewIcon}>✦</Text>

--- a/components/map/PoiRatingModal.tsx
+++ b/components/map/PoiRatingModal.tsx
@@ -1,6 +1,16 @@
-import { forwardRef, useImperativeHandle, useRef, useMemo, useState } from 'react'
-import { View, Text, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native'
-import { BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet'
+import { forwardRef, useImperativeHandle, useState } from 'react'
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+  Modal,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+} from 'react-native'
 import { supabase } from '@/lib/supabase'
 import { submitRating } from '@/lib/ratings'
 
@@ -20,9 +30,7 @@ export const PoiRatingModal = forwardRef<PoiRatingModalHandle, Props>(function P
   { poiId, onSubmitted },
   ref
 ) {
-  const modalRef = useRef<BottomSheetModal>(null)
-  const snapPoints = useMemo(() => ['55%'], [])
-
+  const [visible, setVisible] = useState(false)
   const [selectedRating, setSelectedRating] = useState<number | null>(null)
   const [comment, setComment] = useState('')
   const [submitting, setSubmitting] = useState(false)
@@ -33,9 +41,9 @@ export const PoiRatingModal = forwardRef<PoiRatingModalHandle, Props>(function P
       setSelectedRating(null)
       setComment('')
       setError(null)
-      modalRef.current?.present()
+      setVisible(true)
     },
-    dismiss: () => modalRef.current?.dismiss(),
+    dismiss: () => setVisible(false),
   }))
 
   const handleSubmit = async () => {
@@ -43,13 +51,9 @@ export const PoiRatingModal = forwardRef<PoiRatingModalHandle, Props>(function P
     setSubmitting(true)
     setError(null)
     try {
-      await submitRating(supabase, {
-        poiId,
-        rating: selectedRating,
-        comment,
-      })
+      await submitRating(supabase, { poiId, rating: selectedRating, comment })
       onSubmitted()
-      modalRef.current?.dismiss()
+      setVisible(false)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Something went wrong')
     } finally {
@@ -60,114 +64,121 @@ export const PoiRatingModal = forwardRef<PoiRatingModalHandle, Props>(function P
   const isReady = !!selectedRating && !submitting
 
   return (
-    <BottomSheetModal
-      ref={modalRef}
-      snapPoints={snapPoints}
-      enablePanDownToClose
-      handleIndicatorStyle={styles.handleIndicator}
-      backgroundStyle={styles.modalBackground}
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={() => setVisible(false)}
     >
-      <BottomSheetView style={styles.container}>
-        {/* Header */}
-        <View style={styles.headerRow}>
-          <Text style={styles.title}>Leave a Review</Text>
-          <Text style={styles.subtitle}>How was your experience?</Text>
-        </View>
+      <KeyboardAvoidingView
+        style={styles.overlay}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        <Pressable style={styles.backdrop} onPress={() => setVisible(false)} />
 
-        {/* Star rating picker */}
-        <View style={styles.starsSection}>
-          <View style={styles.starsRow}>
-            {[1, 2, 3, 4, 5].map((i) => (
-              <TouchableOpacity
-                key={i}
-                onPress={() => setSelectedRating(i)}
-                hitSlop={6}
-                activeOpacity={0.7}
-                style={styles.starButton}
-              >
-                <Text
-                  style={[
-                    styles.star,
-                    selectedRating !== null && i <= selectedRating
-                      ? styles.starActive
-                      : styles.starInactive,
-                  ]}
+        <View style={styles.card}>
+          {/* Header */}
+          <View style={styles.headerRow}>
+            <Text style={styles.title}>Leave a Review</Text>
+            <Text style={styles.subtitle}>How was your experience?</Text>
+          </View>
+
+          {/* Star rating picker */}
+          <View style={styles.starsSection}>
+            <View style={styles.starsRow}>
+              {[1, 2, 3, 4, 5].map((i) => (
+                <TouchableOpacity
+                  key={i}
+                  onPress={() => setSelectedRating(i)}
+                  hitSlop={6}
+                  activeOpacity={0.7}
+                  style={styles.starButton}
                 >
-                  {selectedRating !== null && i <= selectedRating ? '★' : '☆'}
+                  <Text
+                    style={[
+                      styles.star,
+                      selectedRating !== null && i <= selectedRating
+                        ? styles.starActive
+                        : styles.starInactive,
+                    ]}
+                  >
+                    {selectedRating !== null && i <= selectedRating ? '★' : '☆'}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+            <Text style={styles.starLabel}>
+              {selectedRating ? STAR_LABELS[selectedRating] : 'Tap to rate'}
+            </Text>
+          </View>
+
+          {/* Comment input */}
+          <View style={styles.inputWrapper}>
+            <TextInput
+              style={styles.input}
+              placeholder="Share what you loved (or didn't)…"
+              placeholderTextColor="#C0BDB8"
+              multiline
+              maxLength={280}
+              value={comment}
+              onChangeText={setComment}
+            />
+            <Text style={styles.charCount}>{comment.length}/280</Text>
+          </View>
+
+          {/* Error */}
+          {error ? (
+            <View style={styles.errorRow}>
+              <Text style={styles.errorIcon}>⚠</Text>
+              <Text style={styles.error}>{error}</Text>
+            </View>
+          ) : null}
+
+          {/* Submit */}
+          <TouchableOpacity
+            style={[styles.submitButton, isReady ? styles.submitActive : styles.submitDisabled]}
+            onPress={handleSubmit}
+            disabled={!isReady}
+            activeOpacity={0.85}
+          >
+            {submitting ? (
+              <ActivityIndicator color="#fff" size="small" />
+            ) : (
+              <>
+                <Text style={styles.submitText}>
+                  {isReady ? 'Submit Review' : 'Select a rating first'}
                 </Text>
-              </TouchableOpacity>
-            ))}
-          </View>
-          <Text style={styles.starLabel}>
-            {selectedRating ? STAR_LABELS[selectedRating] : 'Tap to rate'}
-          </Text>
+                {isReady && <Text style={styles.submitArrow}>→</Text>}
+              </>
+            )}
+          </TouchableOpacity>
         </View>
-
-        {/* Comment input */}
-        <View style={styles.inputWrapper}>
-          <TextInput
-            style={styles.input}
-            placeholder="Share what you loved (or didn't)…"
-            placeholderTextColor="#C0BDB8"
-            multiline
-            maxLength={280}
-            value={comment}
-            onChangeText={setComment}
-          />
-          <Text style={styles.charCount}>{comment.length}/280</Text>
-        </View>
-
-        {/* Error */}
-        {error ? (
-          <View style={styles.errorRow}>
-            <Text style={styles.errorIcon}>⚠</Text>
-            <Text style={styles.error}>{error}</Text>
-          </View>
-        ) : null}
-
-        {/* Submit */}
-        <TouchableOpacity
-          style={[
-            styles.submitButton,
-            isReady ? styles.submitActive : styles.submitDisabled,
-          ]}
-          onPress={handleSubmit}
-          disabled={!isReady}
-          activeOpacity={0.85}
-        >
-          {submitting ? (
-            <ActivityIndicator color="#fff" size="small" />
-          ) : (
-            <>
-              <Text style={styles.submitText}>
-                {isReady ? 'Submit Review' : 'Select a rating first'}
-              </Text>
-              {isReady && <Text style={styles.submitArrow}>→</Text>}
-            </>
-          )}
-        </TouchableOpacity>
-      </BottomSheetView>
-    </BottomSheetModal>
+      </KeyboardAvoidingView>
+    </Modal>
   )
 })
 
 const styles = StyleSheet.create({
-  modalBackground: {
+  overlay: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+  },
+  card: {
+    width: '88%',
     backgroundColor: '#FAFAF8',
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20,
-  },
-  handleIndicator: {
-    width: 36,
-    height: 4,
-    backgroundColor: '#D4D4CF',
-    borderRadius: 2,
-  },
-  container: {
-    paddingHorizontal: 24,
-    paddingTop: 8,
-    paddingBottom: 32,
+    borderRadius: 24,
+    padding: 24,
     gap: 18,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.15,
+    shadowRadius: 24,
+    elevation: 12,
   },
   headerRow: {
     gap: 3,

--- a/supabase/migrations/010_remove_norrebro_park.sql
+++ b/supabase/migrations/010_remove_norrebro_park.sql
@@ -1,0 +1,2 @@
+-- Remove Nørrebro Park from pois (unwanted POI)
+DELETE FROM pois WHERE name ILIKE '%norrebro park%' OR name ILIKE '%nørrebro park%';


### PR DESCRIPTION
## Summary

- **Input colours** — added `color: '#000'` and `placeholderTextColor="#999"` to all text inputs on login, signup, and profile screens so text is visible on Android (system dark-mode was rendering it invisible)
- **Avatar upload** — replaced deprecated `MediaTypeOptions.Images` with `'images'` and swapped the `fetch`/`blob` upload path for `FormData` to fix Android file uploads to Supabase Storage
- **Review modal keyboard** — replaced `BottomSheetModal` in `PoiRatingModal` with a standard RN `Modal` + `KeyboardAvoidingView` card so the keyboard no longer covers the review input on Android
- **Bottom sheet** — added a `"100%"` snap point to `PoiBottomSheet` and snaps to it before opening the rating modal so the sheet doesn't fight the modal
- **Map cold start** — added `defaultSettings` to Mapbox Camera (Copenhagen coords + zoom 13) so the map opens in the right place immediately; switched style to `StyleURL.Light`
- **Keyboard layout** — added `softwareKeyboardLayoutMode: "pan"` to `app.json` for consistent Android keyboard behaviour
- **Data** — migration `010_remove_norrebro_park.sql` removes the Nørrebro Park POI

## Test plan

- [ ] Login and signup screens: placeholder text visible, typed text visible on Android
- [ ] Profile screen: display name input text visible; avatar picker works and uploads on Android
- [ ] Tap "Leave a Review" on a POI — bottom sheet expands to full screen, review modal appears, keyboard pushes the input up (not over it)
- [ ] App cold start opens map centred on Copenhagen with light style
- [ ] Nørrebro Park no longer appears in POI list/map after migration runs