### PR TITLE
feat: user location puck and return-to-location button

### DIFF
--- a/app/(app)/(tabs)/__tests__/MapScreen.test.tsx
+++ b/app/(app)/(tabs)/__tests__/MapScreen.test.tsx
@@ -27,12 +27,21 @@ jest.mock('@rnmapbox/maps', () => {
         React.useImperativeHandle(ref, () => ({ setCamera: mockSetCamera }))
         return null
       }),
+      LocationPuck: function MockLocationPuck() { return null },
       StyleURL: {
         Light: 'mapbox://styles/mapbox/light-v10',
       },
     },
   }
 })
+
+jest.mock('expo-location', () => ({
+  requestForegroundPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  getCurrentPositionAsync: jest.fn(() =>
+    Promise.resolve({ coords: { latitude: 55.6761, longitude: 12.5683 } })
+  ),
+  Accuracy: { High: 3 },
+}))
 
 // ---------------------------------------------------------------------------
 // Hook mocks
@@ -111,8 +120,8 @@ describe('MapScreen', () => {
     act(() => { root = create(<MapScreen />) })
 
     const camera = root!.root.findByType(Mapbox.Camera)
-    expect(camera.props.centerCoordinate).toEqual([12.5683, 55.6761])
-    expect(camera.props.zoomLevel).toBe(13)
+    expect(camera.props.defaultSettings.centerCoordinate).toEqual([12.5683, 55.6761])
+    expect(camera.props.defaultSettings.zoomLevel).toBe(13)
   })
 
   it('handleSheetClose clears selected POI and calls refetchRatings', () => {
@@ -191,5 +200,61 @@ describe('MapScreen', () => {
         String(n.props.children).includes('Ratings unavailable')
       )
     expect(hasMessage).toBe(true)
+  })
+
+  it('return-to-location button calls setCamera with user coordinates', async () => {
+    // render with async act so locationGranted flushes to true
+    let root: ReturnType<typeof create>
+    await act(async () => { root = create(<MapScreen />) })
+
+    const btn = root!.root.findAll(
+      (n: ReactTestInstance) => n.props.testID === 'return-to-location' && typeof n.props.onPress === 'function'
+    )[0]
+    expect(btn).toBeDefined()
+
+    await act(async () => { btn.props.onPress() })
+
+    expect(mockSetCamera).toHaveBeenCalledWith({
+      centerCoordinate: [12.5683, 55.6761],
+      zoomLevel: 15,
+      animationDuration: 800,
+    })
+  })
+
+  it('hides LocationPuck and return-to-location button when permission is denied', async () => {
+    const Location = require('expo-location')
+    Location.requestForegroundPermissionsAsync.mockResolvedValueOnce({ status: 'denied' })
+
+    let root: ReturnType<typeof create>
+    await act(async () => { root = create(<MapScreen />) })
+
+    expect(root!.root.findAllByType(Mapbox.LocationPuck).length).toBe(0)
+    const btns = root!.root.findAll(
+      (n: ReactTestInstance) => n.props.testID === 'return-to-location'
+    )
+    expect(btns.length).toBe(0)
+  })
+
+  it('hides return-to-location button in list mode', async () => {
+    let root: ReturnType<typeof create>
+    await act(async () => { root = create(<MapScreen />) })
+
+    // switch to list mode
+    const toggle = root!.root.findAll(
+      (n: ReactTestInstance) => n.props.testID === 'view-mode-toggle' && typeof n.props.onPress === 'function'
+    )[0]
+    act(() => { toggle.props.onPress() })
+
+    const btns = root!.root.findAll(
+      (n: ReactTestInstance) => n.props.testID === 'return-to-location'
+    )
+    expect(btns.length).toBe(0)
+  })
+
+  it('renders LocationPuck when location permission is granted', async () => {
+    let root: ReturnType<typeof create>
+    await act(async () => { root = create(<MapScreen />) })
+
+    expect(root!.root.findAllByType(Mapbox.LocationPuck).length).toBe(1)
   })
 })

--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -1,5 +1,6 @@
 import Mapbox from '@rnmapbox/maps'
 import { Ionicons } from '@expo/vector-icons'
+import * as Location from 'expo-location'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Pressable, StyleSheet, Text, View } from 'react-native'
 import { Tables } from '@/types/supabase'
@@ -23,8 +24,19 @@ export default function MapScreen() {
   const [activeCategories, setActiveCategories] = useState<Record<PoiCategory, boolean>>(ALL_ACTIVE)
   const [selectedPoi, setSelectedPoi] = useState<Poi | null>(null)
   const [viewMode, setViewMode] = useState<'map' | 'list'>('map')
+  const [locationGranted, setLocationGranted] = useState(false)
   const cameraRef = useRef<Mapbox.Camera>(null)
   const pendingCamera = useRef<Poi | null>(null)
+
+  useEffect(() => {
+    let active = true
+    Location.requestForegroundPermissionsAsync()
+      .then(({ status }) => {
+        if (active) setLocationGranted(status === 'granted')
+      })
+      .catch(() => {})
+    return () => { active = false }
+  }, [])
 
   const filteredPois = useMemo(
     () => pois.filter((p) => activeCategories[p.category] !== false),
@@ -66,6 +78,19 @@ export default function MapScreen() {
     setViewMode((v) => (v === 'map' ? 'list' : 'map'))
   }, [])
 
+  const handleReturnToLocation = useCallback(async () => {
+    try {
+      const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High })
+      cameraRef.current?.setCamera({
+        centerCoordinate: [loc.coords.longitude, loc.coords.latitude],
+        zoomLevel: 15,
+        animationDuration: 800,
+      })
+    } catch {
+      // Location unavailable (e.g. emulator without mock GPS) — do nothing
+    }
+  }, [])
+
   return (
     <View style={styles.container}>
       {/* MapView stays mounted in list mode (display: none) — unmounting would destroy the
@@ -77,10 +102,9 @@ export default function MapScreen() {
             centerCoordinate: [12.5683, 55.6761],
             zoomLevel: 13,
           }}
-          centerCoordinate={[12.5683, 55.6761]}
-          zoomLevel={13}
         />
         <PoiLayer pois={filteredPois} onPoiPress={handlePoiPress} />
+        {locationGranted && <Mapbox.LocationPuck puckBearingEnabled puckBearing="heading" />}
       </Mapbox.MapView>
 
       {viewMode === 'list' && (
@@ -100,6 +124,12 @@ export default function MapScreen() {
           color="#fff"
         />
       </Pressable>
+
+      {locationGranted && viewMode === 'map' && (
+        <Pressable style={styles.locationButton} onPress={handleReturnToLocation} testID="return-to-location">
+          <Ionicons name="locate" size={20} color="#fff" />
+        </Pressable>
+      )}
 
       {(poisError || ratingsError) && (
         <View style={styles.errorBanner}>
@@ -136,6 +166,22 @@ const styles = StyleSheet.create({
   toggleButton: {
     position: 'absolute',
     top: 56,
+    right: 16,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#131313',
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.15,
+    shadowRadius: 4,
+    elevation: 4,
+  },
+  locationButton: {
+    position: 'absolute',
+    top: 104,
     right: 16,
     width: 40,
     height: 40,


### PR DESCRIPTION
## Summary

- Renders `Mapbox.LocationPuck` (blue dot with heading indicator) on the map when foreground location permission is granted
- Adds a "return to my location" button (dark pill, top-right below the map/list toggle) that flies the camera to the user's current GPS position at zoom 15; hidden in list mode and when permission is denied
- Fixes a pre-existing bug where `Mapbox.Camera` had both `defaultSettings` and duplicate top-level `centerCoordinate`/`zoomLevel` props — the controlled props were re-issuing a fly-to animation on every render, fighting user panning and programmatic camera moves

## Test plan

- [x] Grant location permission on device → blue dot appears, return-to-location button visible
- [x] Deny location permission → no dot, no button, map still works
- [x] Pan away from your location → tap button → camera snaps back
- [x] Switch to list mode → button disappears
- [x] 69 unit tests passing (`npx jest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)