### PR TITLE
feat: profile bubbles on map via Supabase Realtime (#13)

### DIFF
--- a/app/(app)/(tabs)/__tests__/MapScreen.test.tsx
+++ b/app/(app)/(tabs)/__tests__/MapScreen.test.tsx
@@ -82,7 +82,11 @@ jest.mock('@/hooks/useActivePresence', () => {
 // Child component mocks — render null so only MapScreen's own nodes are visible
 // ---------------------------------------------------------------------------
 jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }))
+jest.mock('@/hooks/useLivePresences', () => ({
+  useLivePresences: jest.fn(() => ({ presences: [], loading: false, error: null })),
+}))
 jest.mock('@/components/map/PoiLayer', () => ({ PoiLayer: (props: any) => null }))
+jest.mock('@/components/map/PresenceLayer', () => ({ PresenceLayer: (props: any) => null }))
 jest.mock('@/components/map/CategoryFilterBar', () => ({ CategoryFilterBar: () => null }))
 jest.mock('@/components/map/PoiBottomSheet', () => ({ PoiBottomSheet: (props: any) => null }))
 jest.mock('@/components/map/PoiListView', () => ({ PoiListView: (props: any) => null }))
@@ -93,7 +97,9 @@ jest.mock('@/components/map/PoiListView', () => ({ PoiListView: (props: any) => 
 import Mapbox from '@rnmapbox/maps'
 import { usePois } from '@/hooks/usePois'
 import { useAllPoiRatings } from '@/hooks/useAllPoiRatings'
+import { useLivePresences } from '@/hooks/useLivePresences'
 import { PoiLayer } from '@/components/map/PoiLayer'
+import { PresenceLayer } from '@/components/map/PresenceLayer'
 import { PoiBottomSheet } from '@/components/map/PoiBottomSheet'
 import { PoiListView } from '@/components/map/PoiListView'
 import { Tables } from '@/types/supabase'
@@ -129,6 +135,7 @@ describe('MapScreen', () => {
       error: null,
       refetch: mockRefetchRatings,
     })
+    ;(useLivePresences as jest.Mock).mockReturnValue({ presences: [], loading: false, error: null })
   })
 
   it('Camera initializes centered on Copenhagen at zoom 13', () => {
@@ -273,6 +280,36 @@ describe('MapScreen', () => {
     await act(async () => { root = create(<MapScreen />) })
 
     expect(root!.root.findAllByType(Mapbox.LocationPuck).length).toBe(1)
+  })
+
+  it('passes unfiltered pois and presences from useLivePresences to PresenceLayer', async () => {
+    const allPois = [
+      makePoi({ id: 'poi-1', category: 'food_drink' }),
+      makePoi({ id: 'poi-2', category: 'nightlife' }),
+    ]
+    const mockPresences = [{ id: 'p-1', userId: 'u-2', poiId: 'poi-1', displayName: 'Jane', avatarUrl: null, message: null }]
+    ;(usePois as jest.Mock).mockReturnValue({ pois: allPois, error: null })
+    ;(useLivePresences as jest.Mock).mockReturnValue({ presences: mockPresences, loading: false, error: null })
+
+    let root: ReturnType<typeof create>
+    await act(async () => { root = create(<MapScreen />) })
+
+    const layer = root!.root.findByType(PresenceLayer)
+    // receives ALL pois, not filtered subset
+    expect(layer.props.pois).toEqual(allPois)
+    expect(layer.props.presences).toEqual(mockPresences)
+  })
+
+  it('passes handlePoiPress to PresenceLayer as onPoiPress and it opens the bottom sheet', async () => {
+    const poi = makePoi()
+    ;(usePois as jest.Mock).mockReturnValue({ pois: [poi], error: null })
+
+    let root: ReturnType<typeof create>
+    await act(async () => { root = create(<MapScreen />) })
+
+    act(() => { root!.root.findByType(PresenceLayer).props.onPoiPress(poi) })
+
+    expect(root!.root.findByType(PoiBottomSheet).props.poi).toEqual(poi)
   })
 
   // Fix 5: verify setBroadcast/clearBroadcast wiring through PoiBottomSheet props

--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -25,7 +25,7 @@ export default function MapScreen() {
   const { pois, error: poisError } = usePois()
   const { avgRatings, error: ratingsError, refetch: refetchRatings } = useAllPoiRatings()
   const { activePresence, setBroadcast, clearBroadcast } = useActivePresence()
-  const { presences } = useLivePresences()
+  const { presences, error: presenceError } = useLivePresences()
   const [activeCategories, setActiveCategories] = useState<Record<PoiCategory, boolean>>(ALL_ACTIVE)
   const [selectedPoi, setSelectedPoi] = useState<Poi | null>(null)
   const [viewMode, setViewMode] = useState<'map' | 'list'>('map')
@@ -137,10 +137,14 @@ export default function MapScreen() {
         </Pressable>
       )}
 
-      {(poisError || ratingsError) && (
+      {(poisError || ratingsError || presenceError) && (
         <View style={styles.errorBanner}>
           <Text style={styles.errorText}>
-            {poisError ? "Couldn't load places — check your connection." : "Ratings unavailable."}
+            {poisError
+              ? "Couldn't load places — check your connection."
+              : ratingsError
+              ? 'Ratings unavailable.'
+              : 'Live updates unavailable — check your connection.'}
           </Text>
         </View>
       )}

--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -7,7 +7,9 @@ import { Tables } from '@/types/supabase'
 import { usePois } from '@/hooks/usePois'
 import { useAllPoiRatings } from '@/hooks/useAllPoiRatings'
 import { useActivePresence } from '@/hooks/useActivePresence'
+import { useLivePresences } from '@/hooks/useLivePresences'
 import { PoiLayer } from '@/components/map/PoiLayer'
+import { PresenceLayer } from '@/components/map/PresenceLayer'
 import { CategoryFilterBar } from '@/components/map/CategoryFilterBar'
 import { PoiBottomSheet } from '@/components/map/PoiBottomSheet'
 import { PoiListView } from '@/components/map/PoiListView'
@@ -23,6 +25,7 @@ export default function MapScreen() {
   const { pois, error: poisError } = usePois()
   const { avgRatings, error: ratingsError, refetch: refetchRatings } = useAllPoiRatings()
   const { activePresence, setBroadcast, clearBroadcast } = useActivePresence()
+  const { presences } = useLivePresences()
   const [activeCategories, setActiveCategories] = useState<Record<PoiCategory, boolean>>(ALL_ACTIVE)
   const [selectedPoi, setSelectedPoi] = useState<Poi | null>(null)
   const [viewMode, setViewMode] = useState<'map' | 'list'>('map')
@@ -106,6 +109,7 @@ export default function MapScreen() {
           }}
         />
         <PoiLayer pois={filteredPois} onPoiPress={handlePoiPress} />
+        <PresenceLayer presences={presences} pois={pois} onPoiPress={handlePoiPress} />
         {locationGranted && <Mapbox.LocationPuck puckBearingEnabled puckBearing="heading" />}
       </Mapbox.MapView>
 

--- a/components/map/PresenceBubble.tsx
+++ b/components/map/PresenceBubble.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+import { Image, StyleSheet, Text, View } from 'react-native'
+
+interface Props {
+  displayName: string
+  avatarUrl: string | null
+  size?: number
+}
+
+const BUBBLE_COLORS = [
+  '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4',
+  '#DDA0DD', '#98D8C8', '#F7DC6F', '#BB8FCE',
+]
+
+function getInitials(displayName: string): string {
+  const parts = displayName.trim().split(/\s+/)
+  return parts
+    .slice(0, 2)
+    .map((p) => p[0]?.toUpperCase() ?? '')
+    .join('')
+}
+
+function getBubbleColor(displayName: string): string {
+  let hash = 0
+  for (let i = 0; i < displayName.length; i++) {
+    hash = (hash * 31 + displayName.charCodeAt(i)) & 0xffff
+  }
+  return BUBBLE_COLORS[hash % BUBBLE_COLORS.length]
+}
+
+export function PresenceBubble({ displayName, avatarUrl, size = 32 }: Props) {
+  const [imageError, setImageError] = useState(false)
+  const initials = getInitials(displayName)
+  const bgColor = getBubbleColor(displayName)
+  const radius = size / 2
+
+  const containerStyle = {
+    width: size,
+    height: size,
+    borderRadius: radius,
+    borderWidth: 2,
+    borderColor: '#ffffff',
+    overflow: 'hidden' as const,
+  }
+
+  if (avatarUrl && !imageError) {
+    return (
+      <View style={containerStyle}>
+        <Image
+          source={{ uri: avatarUrl }}
+          style={{ width: size, height: size }}
+          onError={() => setImageError(true)}
+        />
+      </View>
+    )
+  }
+
+  return (
+    <View style={[containerStyle, { backgroundColor: bgColor, alignItems: 'center', justifyContent: 'center' }]}>
+      <Text style={[styles.initials, { fontSize: size * 0.38 }]}>{initials}</Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  initials: {
+    color: '#ffffff',
+    fontWeight: '700',
+  },
+})

--- a/components/map/PresenceLayer.tsx
+++ b/components/map/PresenceLayer.tsx
@@ -1,0 +1,95 @@
+import { useMemo } from 'react'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import Mapbox from '@rnmapbox/maps'
+import { Tables } from '@/types/supabase'
+import { LivePresenceEntry } from '@/hooks/useLivePresences'
+import { PresenceBubble } from './PresenceBubble'
+
+type Poi = Tables<'pois'>
+
+interface Props {
+  presences: LivePresenceEntry[]
+  pois: Poi[]
+  onPoiPress: (poi: Poi) => void
+}
+
+const MAX_VISIBLE = 3
+
+export function PresenceLayer({ presences, pois, onPoiPress }: Props) {
+  const poiById = useMemo(
+    () => new Map(pois.map((p) => [p.id, p])),
+    [pois],
+  )
+
+  const byPoi = useMemo(() => {
+    const map = new Map<string, LivePresenceEntry[]>()
+    for (const p of presences) {
+      const existing = map.get(p.poiId)
+      if (existing) {
+        existing.push(p)
+      } else {
+        map.set(p.poiId, [p])
+      }
+    }
+    return map
+  }, [presences])
+
+  return (
+    <>
+      {Array.from(byPoi.entries()).map(([poiId, group]) => {
+        const poi = poiById.get(poiId)
+        if (!poi) return null
+
+        const visible = group.slice(0, MAX_VISIBLE)
+        const overflow = group.length - MAX_VISIBLE
+
+        return (
+          <Mapbox.MarkerView
+            key={poiId}
+            id={`presence-${poiId}`}
+            coordinate={[poi.lng, poi.lat]}
+            anchor={{ x: 0.5, y: 0.5 }}
+          >
+            <Pressable onPress={() => onPoiPress(poi)} style={styles.row}>
+              {visible.map((entry, i) => (
+                <View key={entry.id} style={i > 0 ? styles.overlap : undefined}>
+                  <PresenceBubble displayName={entry.displayName} avatarUrl={entry.avatarUrl} />
+                </View>
+              ))}
+              {overflow > 0 && (
+                <View style={[styles.overlap, styles.overflowPill]}>
+                  <Text style={styles.overflowText}>{`+${overflow}`}</Text>
+                </View>
+              )}
+            </Pressable>
+          </Mapbox.MarkerView>
+        )
+      })}
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  overlap: {
+    marginLeft: -10,
+  },
+  overflowPill: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: '#ffffff',
+  },
+  overflowText: {
+    color: '#ffffff',
+    fontSize: 11,
+    fontWeight: '700',
+  },
+})

--- a/components/map/__tests__/PresenceBubble.test.tsx
+++ b/components/map/__tests__/PresenceBubble.test.tsx
@@ -8,7 +8,7 @@ describe('PresenceBubble', () => {
     let root: ReturnType<typeof create>
     act(() => { root = create(<PresenceBubble displayName="Jane Doe" avatarUrl={null} />) })
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => n.type === 'Text')
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
     const initialsNode = texts.find((n) => String(n.props.children).match(/^[A-Z]{1,2}$/))
     expect(initialsNode?.props.children).toBe('JD')
   })
@@ -17,7 +17,7 @@ describe('PresenceBubble', () => {
     let root: ReturnType<typeof create>
     act(() => { root = create(<PresenceBubble displayName="Jane" avatarUrl={null} />) })
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => n.type === 'Text')
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
     const initialsNode = texts.find((n) => String(n.props.children).match(/^[A-Z]{1,2}$/))
     expect(initialsNode?.props.children).toBe('J')
   })
@@ -37,6 +37,23 @@ describe('PresenceBubble', () => {
 
     const images = root!.root.findAllByType(Image)
     expect(images.length).toBe(0)
+  })
+
+  it('falls back to initials when the avatar image fails to load', () => {
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<PresenceBubble displayName="Jane Doe" avatarUrl="https://example.com/avatar.png" />) })
+
+    // Initially renders an Image
+    expect(root!.root.findAllByType(Image).length).toBeGreaterThan(0)
+
+    // Simulate image load error
+    act(() => { root!.root.findAllByType(Image)[0].props.onError() })
+
+    // Image gone; initials rendered
+    expect(root!.root.findAllByType(Image).length).toBe(0)
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+    const initialsNode = texts.find((n) => String(n.props.children).match(/^[A-Z]{1,2}$/))
+    expect(initialsNode?.props.children).toBe('JD')
   })
 
   it('produces the same background color for the same display name', () => {
@@ -59,7 +76,7 @@ describe('PresenceBubble', () => {
 
     const getColor = (root: ReturnType<typeof create>) =>
       root.root
-        .findAll((n: ReactTestInstance) => n.type === 'View')
+        .findAll((n: ReactTestInstance) => (n.type as string) === 'View')
         .map((n) => getBgColor(n.props.style))
         .find((c) => c !== undefined)
 

--- a/components/map/__tests__/PresenceBubble.test.tsx
+++ b/components/map/__tests__/PresenceBubble.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import { Image } from 'react-native'
+import { act, create, ReactTestInstance } from 'react-test-renderer'
+import { PresenceBubble } from '../PresenceBubble'
+
+describe('PresenceBubble', () => {
+  it('renders two-letter initials for a two-word name', () => {
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<PresenceBubble displayName="Jane Doe" avatarUrl={null} />) })
+
+    const texts = root!.root.findAll((n: ReactTestInstance) => n.type === 'Text')
+    const initialsNode = texts.find((n) => String(n.props.children).match(/^[A-Z]{1,2}$/))
+    expect(initialsNode?.props.children).toBe('JD')
+  })
+
+  it('renders a single initial for a single-word name', () => {
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<PresenceBubble displayName="Jane" avatarUrl={null} />) })
+
+    const texts = root!.root.findAll((n: ReactTestInstance) => n.type === 'Text')
+    const initialsNode = texts.find((n) => String(n.props.children).match(/^[A-Z]{1,2}$/))
+    expect(initialsNode?.props.children).toBe('J')
+  })
+
+  it('renders an Image when avatarUrl is provided', () => {
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<PresenceBubble displayName="Jane Doe" avatarUrl="https://example.com/avatar.png" />) })
+
+    const images = root!.root.findAllByType(Image)
+    expect(images.length).toBeGreaterThan(0)
+    expect(images[0].props.source.uri).toBe('https://example.com/avatar.png')
+  })
+
+  it('renders initials (no Image) when avatarUrl is null', () => {
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<PresenceBubble displayName="Jane Doe" avatarUrl={null} />) })
+
+    const images = root!.root.findAllByType(Image)
+    expect(images.length).toBe(0)
+  })
+
+  it('produces the same background color for the same display name', () => {
+    let root1: ReturnType<typeof create>
+    let root2: ReturnType<typeof create>
+    act(() => { root1 = create(<PresenceBubble displayName="Jane Doe" avatarUrl={null} />) })
+    act(() => { root2 = create(<PresenceBubble displayName="Jane Doe" avatarUrl={null} />) })
+
+    // style may be an array — flatten to find backgroundColor across all style objects
+    const getBgColor = (style: unknown): string | undefined => {
+      if (Array.isArray(style)) {
+        for (const s of style) {
+          const c = getBgColor(s)
+          if (c) return c
+        }
+        return undefined
+      }
+      return (style as Record<string, unknown> | null)?.backgroundColor as string | undefined
+    }
+
+    const getColor = (root: ReturnType<typeof create>) =>
+      root.root
+        .findAll((n: ReactTestInstance) => n.type === 'View')
+        .map((n) => getBgColor(n.props.style))
+        .find((c) => c !== undefined)
+
+    expect(getColor(root1!)).toBe(getColor(root2!))
+    expect(getColor(root1!)).toBeDefined()
+  })
+})

--- a/components/map/__tests__/PresenceLayer.test.tsx
+++ b/components/map/__tests__/PresenceLayer.test.tsx
@@ -73,7 +73,7 @@ describe('PresenceLayer', () => {
       root = create(<PresenceLayer presences={[]} pois={[makePoi()]} onPoiPress={jest.fn()} />)
     })
 
-    const markers = root!.root.findAll((n: ReactTestInstance) => n.type === 'MarkerView')
+    const markers = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'MarkerView')
     expect(markers.length).toBe(0)
   })
 
@@ -86,7 +86,7 @@ describe('PresenceLayer', () => {
       )
     })
 
-    const markers = root!.root.findAll((n: ReactTestInstance) => n.type === 'MarkerView')
+    const markers = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'MarkerView')
     expect(markers.length).toBe(1)
     expect(markers[0].props.coordinate).toEqual([12.5683, 55.6761])
   })
@@ -99,7 +99,7 @@ describe('PresenceLayer', () => {
       )
     })
 
-    const bubbles = root!.root.findAll((n: ReactTestInstance) => n.type === 'PresenceBubble')
+    const bubbles = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'PresenceBubble')
     expect(bubbles.length).toBe(1)
     expect(bubbles[0].props.displayName).toBe('Jane Doe')
   })
@@ -116,10 +116,10 @@ describe('PresenceLayer', () => {
       )
     })
 
-    const markers = root!.root.findAll((n: ReactTestInstance) => n.type === 'MarkerView')
+    const markers = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'MarkerView')
     expect(markers.length).toBe(1)
 
-    const bubbles = root!.root.findAll((n: ReactTestInstance) => n.type === 'PresenceBubble')
+    const bubbles = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'PresenceBubble')
     expect(bubbles.length).toBe(2)
   })
 
@@ -134,11 +134,11 @@ describe('PresenceLayer', () => {
       )
     })
 
-    const bubbles = root!.root.findAll((n: ReactTestInstance) => n.type === 'PresenceBubble')
+    const bubbles = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'PresenceBubble')
     expect(bubbles.length).toBe(3)
 
     const texts = root!.root.findAll(
-      (n: ReactTestInstance) => n.type === 'Text' && String(n.props.children).startsWith('+')
+      (n: ReactTestInstance) => (n.type as string) === 'Text' && String(n.props.children).startsWith('+')
     )
     expect(texts.length).toBe(1)
     expect(texts[0].props.children).toBe('+2')
@@ -176,7 +176,7 @@ describe('PresenceLayer', () => {
       )
     })
 
-    const markers = root!.root.findAll((n: ReactTestInstance) => n.type === 'MarkerView')
+    const markers = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'MarkerView')
     expect(markers.length).toBe(2)
   })
 
@@ -189,7 +189,7 @@ describe('PresenceLayer', () => {
       )
     })
 
-    const markers = root!.root.findAll((n: ReactTestInstance) => n.type === 'MarkerView')
+    const markers = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'MarkerView')
     expect(markers.length).toBe(0)
   })
 })

--- a/components/map/__tests__/PresenceLayer.test.tsx
+++ b/components/map/__tests__/PresenceLayer.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Tests for PresenceLayer component.
+ *
+ * Uses react-test-renderer. Mapbox.MarkerView is mocked as a passthrough component
+ * so we can inspect children without a native Mapbox context.
+ */
+
+import React from 'react'
+import { act, create, ReactTestInstance } from 'react-test-renderer'
+import { PresenceLayer } from '../PresenceLayer'
+import { PresenceBubble } from '../PresenceBubble'
+import { Tables } from '@/types/supabase'
+import { LivePresenceEntry } from '@/hooks/useLivePresences'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+jest.mock('@rnmapbox/maps', () => {
+  const React = require('react')
+  return {
+    __esModule: true,
+    default: {
+      MarkerView: function MockMarkerView({ children, id, coordinate }: { children: React.ReactNode; id: string; coordinate: number[] }) {
+        return React.createElement('MarkerView', { id, coordinate }, children)
+      },
+    },
+  }
+})
+
+jest.mock('../PresenceBubble', () => ({
+  PresenceBubble: (props: { displayName: string; avatarUrl: string | null }) =>
+    require('react').createElement('PresenceBubble', props),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+type Poi = Tables<'pois'>
+
+function makePoi(overrides: Partial<Poi> = {}): Poi {
+  return {
+    id: 'poi-1',
+    name: 'Test Cafe',
+    category: 'food_drink',
+    lat: 55.6761,
+    lng: 12.5683,
+    description: null,
+    created_by: 'user-1',
+    created_at: '2025-01-01T00:00:00Z',
+    ...overrides,
+  } as Poi
+}
+
+function makePresence(overrides: Partial<LivePresenceEntry> = {}): LivePresenceEntry {
+  return {
+    id: 'presence-1',
+    userId: 'user-2',
+    poiId: 'poi-1',
+    displayName: 'Jane Doe',
+    avatarUrl: null,
+    message: null,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('PresenceLayer', () => {
+  it('renders nothing when presences is empty', () => {
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(<PresenceLayer presences={[]} pois={[makePoi()]} onPoiPress={jest.fn()} />)
+    })
+
+    const markers = root!.root.findAll((n: ReactTestInstance) => n.type === 'MarkerView')
+    expect(markers.length).toBe(0)
+  })
+
+  it('renders a MarkerView at the correct POI coordinates', () => {
+    const poi = makePoi({ id: 'poi-1', lng: 12.5683, lat: 55.6761 })
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceLayer presences={[makePresence()]} pois={[poi]} onPoiPress={jest.fn()} />
+      )
+    })
+
+    const markers = root!.root.findAll((n: ReactTestInstance) => n.type === 'MarkerView')
+    expect(markers.length).toBe(1)
+    expect(markers[0].props.coordinate).toEqual([12.5683, 55.6761])
+  })
+
+  it('renders one PresenceBubble for a single presence at a POI', () => {
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceLayer presences={[makePresence()]} pois={[makePoi()]} onPoiPress={jest.fn()} />
+      )
+    })
+
+    const bubbles = root!.root.findAll((n: ReactTestInstance) => n.type === 'PresenceBubble')
+    expect(bubbles.length).toBe(1)
+    expect(bubbles[0].props.displayName).toBe('Jane Doe')
+  })
+
+  it('renders multiple bubbles in one MarkerView when several users are at the same POI', () => {
+    const presences = [
+      makePresence({ id: 'p-1', displayName: 'Jane Doe' }),
+      makePresence({ id: 'p-2', userId: 'user-3', displayName: 'Bob Smith' }),
+    ]
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceLayer presences={presences} pois={[makePoi()]} onPoiPress={jest.fn()} />
+      )
+    })
+
+    const markers = root!.root.findAll((n: ReactTestInstance) => n.type === 'MarkerView')
+    expect(markers.length).toBe(1)
+
+    const bubbles = root!.root.findAll((n: ReactTestInstance) => n.type === 'PresenceBubble')
+    expect(bubbles.length).toBe(2)
+  })
+
+  it('caps visible bubbles at 3 and shows an overflow pill for extras', () => {
+    const presences = Array.from({ length: 5 }, (_, i) =>
+      makePresence({ id: `p-${i}`, userId: `user-${i + 2}`, displayName: `User ${i}` })
+    )
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceLayer presences={presences} pois={[makePoi()]} onPoiPress={jest.fn()} />
+      )
+    })
+
+    const bubbles = root!.root.findAll((n: ReactTestInstance) => n.type === 'PresenceBubble')
+    expect(bubbles.length).toBe(3)
+
+    const texts = root!.root.findAll(
+      (n: ReactTestInstance) => n.type === 'Text' && String(n.props.children).startsWith('+')
+    )
+    expect(texts.length).toBe(1)
+    expect(texts[0].props.children).toBe('+2')
+  })
+
+  it('calls onPoiPress with the correct POI when a bubble is tapped', () => {
+    const poi = makePoi()
+    const onPoiPress = jest.fn()
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceLayer presences={[makePresence()]} pois={[poi]} onPoiPress={onPoiPress} />
+      )
+    })
+
+    const pressable = root!.root.findAll(
+      (n: ReactTestInstance) => typeof n.props.onPress === 'function'
+    )[0]
+    act(() => { pressable.props.onPress() })
+
+    expect(onPoiPress).toHaveBeenCalledWith(poi)
+  })
+
+  it('gives separate MarkerViews to presences at different POIs', () => {
+    const poi1 = makePoi({ id: 'poi-1' })
+    const poi2 = makePoi({ id: 'poi-2', lng: 12.57, lat: 55.68 })
+    const presences = [
+      makePresence({ id: 'p-1', poiId: 'poi-1' }),
+      makePresence({ id: 'p-2', userId: 'user-3', poiId: 'poi-2' }),
+    ]
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceLayer presences={presences} pois={[poi1, poi2]} onPoiPress={jest.fn()} />
+      )
+    })
+
+    const markers = root!.root.findAll((n: ReactTestInstance) => n.type === 'MarkerView')
+    expect(markers.length).toBe(2)
+  })
+
+  it('skips a presence whose POI is not in the pois array', () => {
+    const presence = makePresence({ poiId: 'poi-unknown' })
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceLayer presences={[presence]} pois={[makePoi({ id: 'poi-1' })]} onPoiPress={jest.fn()} />
+      )
+    })
+
+    const markers = root!.root.findAll((n: ReactTestInstance) => n.type === 'MarkerView')
+    expect(markers.length).toBe(0)
+  })
+})

--- a/hooks/__tests__/useLivePresences.test.ts
+++ b/hooks/__tests__/useLivePresences.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Tests for useLivePresences hook.
+ *
+ * Follows the same renderHook + flush pattern as useActivePresence.test.ts.
+ * Mocks @/lib/supabase (initial fetch + Realtime channel) and @/hooks/useAuth.
+ */
+
+import React from 'react'
+import { act, create } from 'react-test-renderer'
+
+// ---------------------------------------------------------------------------
+// Mock leaf fns — prefixed with "mock" so Jest hoisting allows use in factory
+// ---------------------------------------------------------------------------
+const mockNeqFn = jest.fn()
+const mockSingleFn = jest.fn()
+const mockSubscribeFn = jest.fn()
+const mockChannelOnFn = jest.fn()
+const mockUseAuth = jest.fn()
+
+// removeChannel is declared as jest.fn() directly in the factory so it is always
+// a function at factory-run time (avoids TDZ issues with eagerly-evaluated references).
+// Tests access it via the imported supabase mock.
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn((table: string) => {
+      if (table === 'profiles') {
+        return { select: jest.fn(() => ({ eq: jest.fn(() => ({ single: mockSingleFn })) })) }
+      }
+      // live_presence
+      return { select: jest.fn(() => ({ is: jest.fn(() => ({ neq: mockNeqFn })) })) }
+    }),
+    channel: jest.fn(() => ({ on: mockChannelOnFn, subscribe: mockSubscribeFn })),
+    removeChannel: jest.fn(),
+  },
+}))
+
+jest.mock('@/hooks/useAuth', () => ({ useAuth: () => mockUseAuth() }))
+
+import { supabase } from '@/lib/supabase'
+import { useLivePresences } from '../useLivePresences'
+
+type HookResult<T> = { current: T }
+
+function renderHook<T>(useHook: () => T): HookResult<T> {
+  const result: HookResult<T> = { current: undefined as unknown as T }
+  function TestComponent() {
+    result.current = useHook()
+    return null
+  }
+  act(() => { create(React.createElement(TestComponent)) })
+  return result
+}
+
+async function flush() {
+  await act(async () => { await Promise.resolve() })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'presence-1',
+    user_id: 'user-2',
+    poi_id: 'poi-1',
+    message: 'grabbing coffee',
+    profiles: { display_name: 'Jane Doe', avatar_url: null },
+    ...overrides,
+  }
+}
+
+function makeInsertPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    new: {
+      id: 'presence-2',
+      user_id: 'user-3',
+      poi_id: 'poi-1',
+      message: 'hey',
+      dismissed_at: null,
+      visible_to: 'community',
+      created_at: '2026-01-01T00:00:00Z',
+      ...overrides,
+    },
+  }
+}
+
+// Capture INSERT/UPDATE handlers after the hook mounts
+function getCapturedHandlers() {
+  const insertCall = mockChannelOnFn.mock.calls.find(
+    (c: unknown[]) => (c[1] as { event: string }).event === 'INSERT'
+  )
+  const updateCall = mockChannelOnFn.mock.calls.find(
+    (c: unknown[]) => (c[1] as { event: string }).event === 'UPDATE'
+  )
+  return {
+    insertHandler: insertCall?.[2] as ((p: unknown) => Promise<void>) | undefined,
+    updateHandler: updateCall?.[2] as ((p: unknown) => void) | undefined,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockUseAuth.mockReturnValue({ session: { user: { id: 'user-1' } } })
+  mockNeqFn.mockResolvedValue({ data: [], error: null })
+  // Make .on() chainable and capture event/handler
+  mockChannelOnFn.mockImplementation((_event: string, _filter: unknown, _handler: unknown) => ({
+    on: mockChannelOnFn,
+    subscribe: mockSubscribeFn,
+  }))
+  mockSubscribeFn.mockReturnValue('mock-channel-ref')
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('useLivePresences', () => {
+  it('returns empty presences when initial fetch returns no rows', async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null })
+
+    const result = renderHook(() => useLivePresences())
+    await flush()
+
+    expect(result.current.presences).toEqual([])
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('maps initial fetch rows to LivePresenceEntry correctly', async () => {
+    mockNeqFn.mockResolvedValue({ data: [makeRow()], error: null })
+
+    const result = renderHook(() => useLivePresences())
+    await flush()
+
+    expect(result.current.presences).toEqual([
+      {
+        id: 'presence-1',
+        userId: 'user-2',
+        poiId: 'poi-1',
+        displayName: 'Jane Doe',
+        avatarUrl: null,
+        message: 'grabbing coffee',
+      },
+    ])
+  })
+
+  it('does not include current user in initial fetch results', async () => {
+    // The neq filter is applied by the DB; confirm the hook passes the right userId
+    const { supabase } = require('@/lib/supabase')
+    mockNeqFn.mockResolvedValue({ data: [], error: null })
+
+    renderHook(() => useLivePresences())
+    await flush()
+
+    // find the neq call on the live_presence chain
+    const fromCall = (supabase.from as jest.Mock).mock.calls.find(
+      (c: string[]) => c[0] === 'live_presence'
+    )
+    expect(fromCall).toBeDefined()
+    // neq is the last call in the chain — it should have been called with ('user_id', 'user-1')
+    expect(mockNeqFn).toHaveBeenCalledWith('user_id', 'user-1')
+  })
+
+  it('adds a presence on INSERT with profile cache hit', async () => {
+    // Seed the cache via initial fetch
+    mockNeqFn.mockResolvedValue({ data: [makeRow()], error: null })
+    const result = renderHook(() => useLivePresences())
+    await flush()
+
+    const { insertHandler } = getCapturedHandlers()
+    expect(insertHandler).toBeDefined()
+
+    // Fire INSERT for same user (user-2 is now cached)
+    await act(async () => {
+      await insertHandler!(makeInsertPayload({ user_id: 'user-2', id: 'presence-3' }))
+    })
+
+    expect(result.current.presences).toHaveLength(2)
+    expect(result.current.presences[1].id).toBe('presence-3')
+    expect(result.current.presences[1].displayName).toBe('Jane Doe') // from cache
+    expect(mockSingleFn).not.toHaveBeenCalled() // no profile fetch needed
+  })
+
+  it('fetches profile on INSERT when user is not in cache (cache miss)', async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null })
+    mockSingleFn.mockResolvedValue({
+      data: { display_name: 'Bob Smith', avatar_url: 'https://example.com/bob.jpg' },
+      error: null,
+    })
+
+    const result = renderHook(() => useLivePresences())
+    await flush()
+
+    const { insertHandler } = getCapturedHandlers()
+    await act(async () => { await insertHandler!(makeInsertPayload()) })
+
+    expect(mockSingleFn).toHaveBeenCalledTimes(1)
+    expect(result.current.presences).toHaveLength(1)
+    expect(result.current.presences[0].displayName).toBe('Bob Smith')
+    expect(result.current.presences[0].avatarUrl).toBe('https://example.com/bob.jpg')
+  })
+
+  it('removes a presence on UPDATE when dismissed_at is set', async () => {
+    mockNeqFn.mockResolvedValue({ data: [makeRow()], error: null })
+    const result = renderHook(() => useLivePresences())
+    await flush()
+
+    expect(result.current.presences).toHaveLength(1)
+
+    const { updateHandler } = getCapturedHandlers()
+    act(() => {
+      updateHandler!({
+        new: { id: 'presence-1', user_id: 'user-2', dismissed_at: '2026-01-01T01:00:00Z' },
+      })
+    })
+
+    expect(result.current.presences).toHaveLength(0)
+  })
+
+  it('ignores INSERT from the current user', async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null })
+    const result = renderHook(() => useLivePresences())
+    await flush()
+
+    const { insertHandler } = getCapturedHandlers()
+    await act(async () => {
+      await insertHandler!(makeInsertPayload({ user_id: 'user-1' })) // own user
+    })
+
+    expect(result.current.presences).toHaveLength(0)
+  })
+
+  it('ignores INSERT when dismissed_at is already set', async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null })
+    const result = renderHook(() => useLivePresences())
+    await flush()
+
+    const { insertHandler } = getCapturedHandlers()
+    await act(async () => {
+      await insertHandler!(makeInsertPayload({ dismissed_at: '2026-01-01T00:00:00Z' }))
+    })
+
+    expect(result.current.presences).toHaveLength(0)
+  })
+
+  it('loading is true before the fetch resolves', () => {
+    let resolve!: (v: { data: unknown[]; error: null }) => void
+    mockNeqFn.mockReturnValue(new Promise((r) => { resolve = r }))
+
+    const result = renderHook(() => useLivePresences())
+    expect(result.current.loading).toBe(true)
+
+    act(() => { resolve({ data: [], error: null }) })
+  })
+
+  it('sets error state when initial fetch fails', async () => {
+    mockNeqFn.mockResolvedValue({ data: null, error: { message: 'network failure' } })
+
+    const result = renderHook(() => useLivePresences())
+    await flush()
+
+    expect(result.current.error).toBe('network failure')
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('does not deduplicate unrelated presences on successive INSERTs', async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null })
+    mockSingleFn.mockResolvedValue({
+      data: { display_name: 'Bob', avatar_url: null },
+      error: null,
+    })
+
+    const result = renderHook(() => useLivePresences())
+    await flush()
+
+    const { insertHandler } = getCapturedHandlers()
+    await act(async () => { await insertHandler!(makeInsertPayload({ id: 'p-a' })) })
+    await act(async () => { await insertHandler!(makeInsertPayload({ id: 'p-b' })) })
+
+    expect(result.current.presences).toHaveLength(2)
+  })
+
+  it('does not add the same presence twice on duplicate INSERTs', async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null })
+    mockSingleFn.mockResolvedValue({
+      data: { display_name: 'Bob', avatar_url: null },
+      error: null,
+    })
+
+    const result = renderHook(() => useLivePresences())
+    await flush()
+
+    const { insertHandler } = getCapturedHandlers()
+    const payload = makeInsertPayload({ id: 'presence-dup' })
+    await act(async () => { await insertHandler!(payload) })
+    await act(async () => { await insertHandler!(payload) })
+
+    expect(result.current.presences).toHaveLength(1)
+  })
+
+  it('calls removeChannel on unmount', async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null })
+
+    let unmount!: () => void
+    act(() => {
+      const renderer = create(
+        React.createElement(function TestComponent() {
+          useLivePresences()
+          return null
+        })
+      )
+      unmount = () => renderer.unmount()
+    })
+    await flush()
+
+    act(() => { unmount() })
+
+    expect((supabase as any).removeChannel).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns empty presences when user is not authenticated', async () => {
+    mockUseAuth.mockReturnValue({ session: null })
+
+    const result = renderHook(() => useLivePresences())
+    await flush()
+
+    expect(result.current.presences).toEqual([])
+    expect(result.current.loading).toBe(false)
+    expect(mockNeqFn).not.toHaveBeenCalled()
+  })
+})

--- a/hooks/__tests__/useLivePresences.test.ts
+++ b/hooks/__tests__/useLivePresences.test.ts
@@ -264,6 +264,39 @@ describe('useLivePresences', () => {
     expect(result.current.loading).toBe(false)
   })
 
+  it('adds presence with fallback name when profile fetch fails on cache miss', async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null })
+    mockSingleFn.mockResolvedValue({ data: null, error: { message: 'not found' } })
+
+    const result = renderHook(() => useLivePresences())
+    await flush()
+
+    const { insertHandler } = getCapturedHandlers()
+    await act(async () => { await insertHandler!(makeInsertPayload()) })
+
+    expect(result.current.presences).toHaveLength(1)
+    expect(result.current.presences[0].displayName).toBe('Unknown')
+    expect(result.current.presences[0].avatarUrl).toBeNull()
+  })
+
+  it('updates the message field on a non-dismissal UPDATE', async () => {
+    mockNeqFn.mockResolvedValue({ data: [makeRow({ message: 'original' })], error: null })
+    const result = renderHook(() => useLivePresences())
+    await flush()
+
+    expect(result.current.presences[0].message).toBe('original')
+
+    const { updateHandler } = getCapturedHandlers()
+    act(() => {
+      updateHandler!({
+        new: { id: 'presence-1', user_id: 'user-2', dismissed_at: null, message: 'updated' },
+      })
+    })
+
+    expect(result.current.presences).toHaveLength(1)
+    expect(result.current.presences[0].message).toBe('updated')
+  })
+
   it('does not deduplicate unrelated presences on successive INSERTs', async () => {
     mockNeqFn.mockResolvedValue({ data: [], error: null })
     mockSingleFn.mockResolvedValue({

--- a/hooks/useLivePresences.ts
+++ b/hooks/useLivePresences.ts
@@ -1,0 +1,125 @@
+import { useState, useEffect, useRef } from 'react'
+import { supabase } from '@/lib/supabase'
+import { useAuth } from '@/hooks/useAuth'
+
+export type LivePresenceEntry = {
+  id: string
+  userId: string
+  poiId: string
+  displayName: string
+  avatarUrl: string | null
+  message: string | null
+}
+
+type ProfileData = {
+  displayName: string
+  avatarUrl: string | null
+}
+
+export function useLivePresences() {
+  const { session } = useAuth()
+  const [presences, setPresences] = useState<LivePresenceEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const profileCache = useRef<Map<string, ProfileData>>(new Map())
+
+  useEffect(() => {
+    const userId = session?.user.id
+    if (!userId) {
+      setPresences([])
+      setLoading(false)
+      return
+    }
+
+    let active = true
+
+    // Initial fetch — join profiles to get display names and avatars in one round trip
+    supabase
+      .from('live_presence')
+      .select('id, user_id, poi_id, message, profiles(display_name, avatar_url)')
+      .is('dismissed_at', null)
+      .neq('user_id', userId)
+      .then(({ data, error: fetchError }) => {
+        if (!active) return
+        if (fetchError) {
+          setError(fetchError.message)
+          setLoading(false)
+          return
+        }
+        const entries: LivePresenceEntry[] = []
+        for (const row of (data ?? [])) {
+          const profile = row.profiles as { display_name: string; avatar_url: string | null } | null
+          const displayName = profile?.display_name ?? ''
+          const avatarUrl = profile?.avatar_url ?? null
+          profileCache.current.set(row.user_id, { displayName, avatarUrl })
+          entries.push({
+            id: row.id,
+            userId: row.user_id,
+            poiId: row.poi_id,
+            displayName,
+            avatarUrl,
+            message: row.message,
+          })
+        }
+        setPresences(entries)
+        setLoading(false)
+      })
+
+    const handleInsert = async (payload: { new: Record<string, unknown> }) => {
+      if (!active) return
+      const row = payload.new
+      const rowUserId = row.user_id as string
+      if (rowUserId === userId || row.dismissed_at !== null) return
+
+      let profile = profileCache.current.get(rowUserId)
+      if (!profile) {
+        const { data } = await supabase
+          .from('profiles')
+          .select('display_name, avatar_url')
+          .eq('id', rowUserId)
+          .single()
+        if (!active) return
+        profile = data
+          ? { displayName: data.display_name, avatarUrl: data.avatar_url }
+          : { displayName: '', avatarUrl: null }
+        profileCache.current.set(rowUserId, profile)
+      }
+
+      const entry: LivePresenceEntry = {
+        id: row.id as string,
+        userId: rowUserId,
+        poiId: row.poi_id as string,
+        displayName: profile.displayName,
+        avatarUrl: profile.avatarUrl,
+        message: (row.message as string | null) ?? null,
+      }
+
+      setPresences((prev) => {
+        if (prev.some((p) => p.id === entry.id)) return prev
+        return [...prev, entry]
+      })
+    }
+
+    const handleUpdate = (payload: { new: Record<string, unknown> }) => {
+      if (!active) return
+      const row = payload.new
+      if ((row.user_id as string) === userId) return
+      if (row.dismissed_at !== null) {
+        setPresences((prev) => prev.filter((p) => p.id !== (row.id as string)))
+      }
+    }
+
+    const channel = supabase
+      .channel('live-presence-changes')
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'live_presence' }, handleInsert)
+      .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'live_presence' }, handleUpdate)
+      .subscribe()
+
+    return () => {
+      active = false
+      supabase.removeChannel(channel)
+    }
+  }, [session?.user.id])
+
+  return { presences, loading, error }
+}

--- a/hooks/useLivePresences.ts
+++ b/hooks/useLivePresences.ts
@@ -22,6 +22,7 @@ export function useLivePresences() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const profileCache = useRef<Map<string, ProfileData>>(new Map())
+  const channelId = useRef(`live-presence-changes-${Date.now()}-${Math.random()}`)
 
   useEffect(() => {
     const userId = session?.user.id
@@ -32,6 +33,8 @@ export function useLivePresences() {
     }
 
     let active = true
+    setError(null)
+    setLoading(true)
 
     // Initial fetch — join profiles to get display names and avatars in one round trip
     supabase
@@ -42,6 +45,7 @@ export function useLivePresences() {
       .then(({ data, error: fetchError }) => {
         if (!active) return
         if (fetchError) {
+          console.error('useLivePresences:', fetchError.message)
           setError(fetchError.message)
           setLoading(false)
           return
@@ -67,53 +71,80 @@ export function useLivePresences() {
 
     const handleInsert = async (payload: { new: Record<string, unknown> }) => {
       if (!active) return
-      const row = payload.new
-      const rowUserId = row.user_id as string
-      if (rowUserId === userId || row.dismissed_at !== null) return
+      try {
+        const row = payload.new
+        const rowUserId = row.user_id as string
+        if (rowUserId === userId || !!row.dismissed_at) return
 
-      let profile = profileCache.current.get(rowUserId)
-      if (!profile) {
-        const { data } = await supabase
-          .from('profiles')
-          .select('display_name, avatar_url')
-          .eq('id', rowUserId)
-          .single()
-        if (!active) return
-        profile = data
-          ? { displayName: data.display_name, avatarUrl: data.avatar_url }
-          : { displayName: '', avatarUrl: null }
-        profileCache.current.set(rowUserId, profile)
+        let profile = profileCache.current.get(rowUserId)
+        if (!profile) {
+          const { data, error: profileError } = await supabase
+            .from('profiles')
+            .select('display_name, avatar_url')
+            .eq('id', rowUserId)
+            .single()
+          if (!active) return
+          if (profileError) {
+            console.error(`useLivePresences: Failed to fetch profile for ${rowUserId}:`, profileError.message)
+          }
+          profile = data
+            ? { displayName: data.display_name, avatarUrl: data.avatar_url }
+            : { displayName: 'Unknown', avatarUrl: null }
+          profileCache.current.set(rowUserId, profile)
+        }
+
+        const entry: LivePresenceEntry = {
+          id: row.id as string,
+          userId: rowUserId,
+          poiId: row.poi_id as string,
+          displayName: profile.displayName,
+          avatarUrl: profile.avatarUrl,
+          message: (row.message as string | null) ?? null,
+        }
+
+        setPresences((prev) => {
+          if (prev.some((p) => p.id === entry.id)) return prev
+          return [...prev, entry]
+        })
+      } catch (err) {
+        console.error('useLivePresences: Failed to process INSERT event', err)
       }
-
-      const entry: LivePresenceEntry = {
-        id: row.id as string,
-        userId: rowUserId,
-        poiId: row.poi_id as string,
-        displayName: profile.displayName,
-        avatarUrl: profile.avatarUrl,
-        message: (row.message as string | null) ?? null,
-      }
-
-      setPresences((prev) => {
-        if (prev.some((p) => p.id === entry.id)) return prev
-        return [...prev, entry]
-      })
     }
 
     const handleUpdate = (payload: { new: Record<string, unknown> }) => {
       if (!active) return
       const row = payload.new
       if ((row.user_id as string) === userId) return
-      if (row.dismissed_at !== null) {
+      if (!!row.dismissed_at) {
         setPresences((prev) => prev.filter((p) => p.id !== (row.id as string)))
+      } else {
+        // Non-dismissal UPDATE (e.g. message edit) — update in-place
+        setPresences((prev) =>
+          prev.map((p) =>
+            p.id === (row.id as string)
+              ? { ...p, message: (row.message as string | null) ?? null }
+              : p
+          )
+        )
       }
     }
 
     const channel = supabase
-      .channel('live-presence-changes')
+      .channel(channelId.current)
       .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'live_presence' }, handleInsert)
       .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'live_presence' }, handleUpdate)
-      .subscribe()
+      .subscribe((status: string, err?: Error) => {
+        if (!active) return
+        if (status === 'TIMED_OUT') {
+          console.error('useLivePresences: Realtime subscription timed out')
+          setError('Live updates timed out — pull to refresh.')
+        } else if (status === 'CHANNEL_ERROR') {
+          console.error('useLivePresences: Realtime channel error', err?.message)
+          setError('Live updates unavailable — pull to refresh.')
+        } else if (status === 'CLOSED') {
+          console.error('useLivePresences: Realtime channel closed unexpectedly')
+        }
+      })
 
     return () => {
       active = false

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "web": "expo start --web",
     "test": "jest",
     "test:ci": "jest --ci",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "emulator": "adb -s emulator-5554 reverse tcp:8081 tcp:8081 && adb -s emulator-5554 shell am start -a android.intent.action.VIEW -d exp+dispatch://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",

--- a/supabase/migrations/012_enable_realtime_live_presence.sql
+++ b/supabase/migrations/012_enable_realtime_live_presence.sql
@@ -1,0 +1,4 @@
+-- Enable Supabase Realtime for the live_presence table.
+-- Without this, postgres_changes subscriptions connect successfully
+-- but never receive INSERT/UPDATE events.
+alter publication supabase_realtime add table public.live_presence;


### PR DESCRIPTION
## Summary
- Adds `useLivePresences` hook — subscribes to `live_presence` via Supabase Postgres Changes with initial fetch + profile cache
- Adds `PresenceBubble` component — initials circle with deterministic color or avatar image
- Adds `PresenceLayer` component — `MarkerView`s at POI coordinates, stacks up to 3 bubbles with +N overflow
- Wires into `MapScreen` with unfiltered POIs so bubbles appear regardless of category filters
- Migration `012` enables Realtime publication on `live_presence`

## Test plan
- [x] Broadcast as User A (community visibility) → User B sees bubble appear in real time
- [x] User A dismisses → bubble disappears for User B
- [x] 4+ users at same POI → 3 bubbles + "+N" pill
- [x] Tap bubble → POI bottom sheet opens
- [x] Own broadcast not visible as a bubble
- [x] Category filter toggled off → bubble still visible
- [x] 127 tests passing