### PR TITLE
feat: "Joining [Name]" button on live presence cards

### DIFF
--- a/app/(app)/(tabs)/__tests__/MapScreen.test.tsx
+++ b/app/(app)/(tabs)/__tests__/MapScreen.test.tsx
@@ -85,6 +85,17 @@ jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }))
 jest.mock('@/hooks/useLivePresences', () => ({
   useLivePresences: jest.fn(() => ({ presences: [], loading: false, error: null })),
 }))
+
+jest.mock('@/hooks/usePresenceJoins', () => ({
+  usePresenceJoins: jest.fn(() => ({
+    joins: [],
+    loading: false,
+    error: null,
+    join: jest.fn(),
+    cancel: jest.fn(),
+    getJoinForPresence: jest.fn(() => undefined),
+  })),
+}))
 jest.mock('@/components/map/PoiLayer', () => ({ PoiLayer: (props: any) => null }))
 jest.mock('@/components/map/PresenceLayer', () => ({ PresenceLayer: (props: any) => null }))
 jest.mock('@/components/map/CategoryFilterBar', () => ({ CategoryFilterBar: () => null }))
@@ -138,21 +149,21 @@ describe('MapScreen', () => {
     ;(useLivePresences as jest.Mock).mockReturnValue({ presences: [], loading: false, error: null })
   })
 
-  it('Camera initializes centered on Copenhagen at zoom 13', () => {
+  it('Camera initializes centered on Copenhagen at zoom 13', async () => {
     let root: ReturnType<typeof create>
 
-    act(() => { root = create(<MapScreen />) })
+    await act(async () => { root = create(<MapScreen />) })
 
     const camera = root!.root.findByType(Mapbox.Camera)
     expect(camera.props.defaultSettings.centerCoordinate).toEqual([12.5683, 55.6761])
     expect(camera.props.defaultSettings.zoomLevel).toBe(13)
   })
 
-  it('handleSheetClose clears selected POI and calls refetchRatings', () => {
+  it('handleSheetClose clears selected POI and calls refetchRatings', async () => {
     const poi = makePoi()
     let root: ReturnType<typeof create>
 
-    act(() => { root = create(<MapScreen />) })
+    await act(async () => { root = create(<MapScreen />) })
 
     // Open bottom sheet by tapping a map POI
     act(() => { root!.root.findByType(PoiLayer).props.onPoiPress(poi) })
@@ -165,11 +176,11 @@ describe('MapScreen', () => {
     expect(mockRefetchRatings).toHaveBeenCalledTimes(1)
   })
 
-  it('handleListRowPress switches to map, opens bottom sheet, and flies camera to POI', () => {
+  it('handleListRowPress switches to map, opens bottom sheet, and flies camera to POI', async () => {
     const poi = makePoi({ id: 'poi-fly', lat: 55.7, lng: 12.6 })
     let root: ReturnType<typeof create>
 
-    act(() => { root = create(<MapScreen />) })
+    await act(async () => { root = create(<MapScreen />) })
 
     // Switch to list mode via the toggle button
     const toggle = root!.root.findAll(
@@ -193,11 +204,11 @@ describe('MapScreen', () => {
     })
   })
 
-  it('error banner shows POI connection message when usePois errors', () => {
+  it('error banner shows POI connection message when usePois errors', async () => {
     ;(usePois as jest.Mock).mockReturnValue({ pois: [], error: 'network error' })
     let root: ReturnType<typeof create>
 
-    act(() => { root = create(<MapScreen />) })
+    await act(async () => { root = create(<MapScreen />) })
 
     const hasMessage = root!.root
       .findAllByType(Text)
@@ -207,7 +218,7 @@ describe('MapScreen', () => {
     expect(hasMessage).toBe(true)
   })
 
-  it('error banner shows ratings message when only useAllPoiRatings errors', () => {
+  it('error banner shows ratings message when only useAllPoiRatings errors', async () => {
     ;(useAllPoiRatings as jest.Mock).mockReturnValue({
       avgRatings: {},
       loading: false,
@@ -216,7 +227,7 @@ describe('MapScreen', () => {
     })
     let root: ReturnType<typeof create>
 
-    act(() => { root = create(<MapScreen />) })
+    await act(async () => { root = create(<MapScreen />) })
 
     const hasMessage = root!.root
       .findAllByType(Text)
@@ -313,7 +324,7 @@ describe('MapScreen', () => {
   })
 
   // Fix 5: verify setBroadcast/clearBroadcast wiring through PoiBottomSheet props
-  it('passes setBroadcast and clearBroadcast to PoiBottomSheet and they update activePresence', () => {
+  it('passes setBroadcast and clearBroadcast to PoiBottomSheet and they update activePresence', async () => {
     const mockPresence = {
       id: 'presence-1',
       poi_id: 'poi-1',
@@ -322,7 +333,7 @@ describe('MapScreen', () => {
     }
 
     let root: ReturnType<typeof create>
-    act(() => { root = create(<MapScreen />) })
+    await act(async () => { root = create(<MapScreen />) })
 
     const sheet = root!.root.findByType(PoiBottomSheet)
 

--- a/app/(app)/(tabs)/__tests__/MapScreen.test.tsx
+++ b/app/(app)/(tabs)/__tests__/MapScreen.test.tsx
@@ -109,6 +109,7 @@ import Mapbox from '@rnmapbox/maps'
 import { usePois } from '@/hooks/usePois'
 import { useAllPoiRatings } from '@/hooks/useAllPoiRatings'
 import { useLivePresences } from '@/hooks/useLivePresences'
+import { usePresenceJoins } from '@/hooks/usePresenceJoins'
 import { PoiLayer } from '@/components/map/PoiLayer'
 import { PresenceLayer } from '@/components/map/PresenceLayer'
 import { PoiBottomSheet } from '@/components/map/PoiBottomSheet'
@@ -216,6 +217,49 @@ describe('MapScreen', () => {
         String(n.props.children).includes("Couldn't load places")
       )
     expect(hasMessage).toBe(true)
+  })
+
+  it('error banner shows join status message when only usePresenceJoins errors', async () => {
+    ;(usePresenceJoins as jest.Mock).mockReturnValue({
+      joins: [],
+      loading: false,
+      error: 'joins error',
+      join: jest.fn(),
+      cancel: jest.fn(),
+      getJoinForPresence: jest.fn(() => undefined),
+    })
+    let root: ReturnType<typeof create>
+
+    await act(async () => { root = create(<MapScreen />) })
+
+    const hasMessage = root!.root
+      .findAllByType(Text)
+      .some((n: ReactTestInstance) =>
+        String(n.props.children).includes('Could not load join status')
+      )
+    expect(hasMessage).toBe(true)
+  })
+
+  it('passes join, cancel, and getJoinForPresence from usePresenceJoins to PoiBottomSheet', async () => {
+    const mockJoin = jest.fn()
+    const mockCancel = jest.fn()
+    const mockGetJoin = jest.fn(() => undefined)
+    ;(usePresenceJoins as jest.Mock).mockReturnValue({
+      joins: [],
+      loading: false,
+      error: null,
+      join: mockJoin,
+      cancel: mockCancel,
+      getJoinForPresence: mockGetJoin,
+    })
+
+    let root: ReturnType<typeof create>
+    await act(async () => { root = create(<MapScreen />) })
+
+    const sheet = root!.root.findByType(PoiBottomSheet)
+    expect(sheet.props.onJoinPresence).toBe(mockJoin)
+    expect(sheet.props.onCancelJoin).toBe(mockCancel)
+    expect(sheet.props.getJoinForPresence).toBe(mockGetJoin)
   })
 
   it('error banner shows ratings message when only useAllPoiRatings errors', async () => {

--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -8,6 +8,7 @@ import { usePois } from '@/hooks/usePois'
 import { useAllPoiRatings } from '@/hooks/useAllPoiRatings'
 import { useActivePresence } from '@/hooks/useActivePresence'
 import { useLivePresences } from '@/hooks/useLivePresences'
+import { usePresenceJoins } from '@/hooks/usePresenceJoins'
 import { PoiLayer } from '@/components/map/PoiLayer'
 import { PresenceLayer } from '@/components/map/PresenceLayer'
 import { CategoryFilterBar } from '@/components/map/CategoryFilterBar'
@@ -26,6 +27,7 @@ export default function MapScreen() {
   const { avgRatings, error: ratingsError, refetch: refetchRatings } = useAllPoiRatings()
   const { activePresence, setBroadcast, clearBroadcast } = useActivePresence()
   const { presences, error: presenceError } = useLivePresences()
+  const { join, cancel, getJoinForPresence } = usePresenceJoins()
   const [activeCategories, setActiveCategories] = useState<Record<PoiCategory, boolean>>(ALL_ACTIVE)
   const [selectedPoi, setSelectedPoi] = useState<Poi | null>(null)
   const [viewMode, setViewMode] = useState<'map' | 'list'>('map')
@@ -156,6 +158,10 @@ export default function MapScreen() {
         onBroadcast={setBroadcast}
         onDismissBroadcast={clearBroadcast}
         locationGranted={locationGranted}
+        presences={presences}
+        getJoinForPresence={getJoinForPresence}
+        onJoinPresence={join}
+        onCancelJoin={cancel}
       />
     </View>
   )

--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -27,7 +27,7 @@ export default function MapScreen() {
   const { avgRatings, error: ratingsError, refetch: refetchRatings } = useAllPoiRatings()
   const { activePresence, setBroadcast, clearBroadcast } = useActivePresence()
   const { presences, error: presenceError } = useLivePresences()
-  const { join, cancel, getJoinForPresence } = usePresenceJoins()
+  const { join, cancel, getJoinForPresence, error: joinsError } = usePresenceJoins()
   const [activeCategories, setActiveCategories] = useState<Record<PoiCategory, boolean>>(ALL_ACTIVE)
   const [selectedPoi, setSelectedPoi] = useState<Poi | null>(null)
   const [viewMode, setViewMode] = useState<'map' | 'list'>('map')
@@ -41,7 +41,7 @@ export default function MapScreen() {
       .then(({ status }) => {
         if (active) setLocationGranted(status === 'granted')
       })
-      .catch(() => {})
+      .catch((err) => { console.error('Location permission request failed:', err) })
     return () => { active = false }
   }, [])
 
@@ -139,14 +139,16 @@ export default function MapScreen() {
         </Pressable>
       )}
 
-      {(poisError || ratingsError || presenceError) && (
+      {(poisError || ratingsError || presenceError || joinsError) && (
         <View style={styles.errorBanner}>
           <Text style={styles.errorText}>
             {poisError
               ? "Couldn't load places — check your connection."
               : ratingsError
               ? 'Ratings unavailable.'
-              : 'Live updates unavailable — check your connection.'}
+              : presenceError
+              ? 'Live updates unavailable — check your connection.'
+              : 'Could not load join status — check your connection.'}
           </Text>
         </View>
       )}

--- a/components/map/PoiBottomSheet.tsx
+++ b/components/map/PoiBottomSheet.tsx
@@ -24,9 +24,13 @@ import {
   BroadcastModal,
   BroadcastModalHandle,
 } from "@/components/map/BroadcastModal";
+import { PresenceCard } from "@/components/map/PresenceCard";
 import { useProximity } from "@/hooks/useProximity";
+import { useAuth } from "@/hooks/useAuth";
 import { supabase } from "@/lib/supabase";
 import { dismissPresence, ActivePresence } from "@/lib/presence";
+import { LivePresenceEntry } from "@/hooks/useLivePresences";
+import { PresenceJoin } from "@/lib/presenceJoins";
 
 type Poi = Tables<"pois">;
 
@@ -37,6 +41,10 @@ type Props = {
   onBroadcast: (presence: ActivePresence) => void;
   onDismissBroadcast: () => void;
   locationGranted: boolean;
+  presences: LivePresenceEntry[];
+  getJoinForPresence: (presenceId: string) => PresenceJoin | undefined;
+  onJoinPresence: (presenceId: string) => Promise<PresenceJoin>;
+  onCancelJoin: (joinId: string) => Promise<void>;
 };
 
 // Category emoji icons for extra character
@@ -107,17 +115,26 @@ export function PoiBottomSheet({
   onBroadcast,
   onDismissBroadcast,
   locationGranted,
+  presences,
+  getJoinForPresence,
+  onJoinPresence,
+  onCancelJoin,
 }: Props) {
   const [dismissing, setDismissing] = useState(false);
   const snapPoints = useMemo(() => ["82%", "100%"], []);
   const bottomSheetRef = useRef<BottomSheet>(null);
   const ratingModalRef = useRef<PoiRatingModalHandle>(null);
   const broadcastModalRef = useRef<BroadcastModalHandle>(null);
+  const { session } = useAuth();
   const { avgRating, ratingCount, comments, myRating, refetch } = usePoiRatings(
     poi?.id,
   );
   const { isNearby } = useProximity(
     locationGranted && poi ? { lat: poi.lat, lng: poi.lng } : null
+  );
+  const poiPresences = useMemo(
+    () => presences.filter((p) => p.poiId === poi?.id),
+    [presences, poi?.id]
   );
 
   // Drive open/close imperatively so that a swipe-down (which calls onClose → clears poi)
@@ -304,6 +321,28 @@ export function PoiBottomSheet({
                   </TouchableOpacity>
                 );
               })()}
+
+              {/* Who's here */}
+              {poiPresences.length > 0 && (
+                <>
+                  <View style={styles.whosHereLabel}>
+                    <Text style={styles.whosHereLabelText}>
+                      {poiPresences.length}{" "}
+                      {poiPresences.length === 1 ? "Person" : "People"} here
+                    </Text>
+                  </View>
+                  {poiPresences.map((p) => (
+                    <PresenceCard
+                      key={p.id}
+                      presence={p}
+                      existingJoin={getJoinForPresence(p.id)}
+                      onJoin={async (presenceId) => { await onJoinPresence(presenceId) }}
+                      onCancel={async (joinId) => { await onCancelJoin(joinId) }}
+                      isOwnPresence={p.userId === session?.user.id}
+                    />
+                  ))}
+                </>
+              )}
 
               {/* Comments section label */}
               <View style={styles.commentsLabel}>
@@ -531,6 +570,17 @@ const styles = StyleSheet.create({
   },
   leaveButtonDimmed: {
     opacity: 0.5,
+  },
+  whosHereLabel: {
+    paddingTop: 16,
+    paddingBottom: 4,
+  },
+  whosHereLabelText: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: "#AAAAAA",
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
   },
   commentsLabel: {
     paddingTop: 16,

--- a/components/map/PoiBottomSheet.tsx
+++ b/components/map/PoiBottomSheet.tsx
@@ -43,7 +43,7 @@ type Props = {
   locationGranted: boolean;
   presences: LivePresenceEntry[];
   getJoinForPresence: (presenceId: string) => PresenceJoin | undefined;
-  onJoinPresence: (presenceId: string) => Promise<PresenceJoin>;
+  onJoinPresence: (presenceId: string) => Promise<PresenceJoin | void>;
   onCancelJoin: (joinId: string) => Promise<void>;
 };
 
@@ -291,7 +291,8 @@ export function PoiBottomSheet({
                         try {
                           await dismissPresence(supabase, { presenceId: activePresence!.id });
                           onDismissBroadcast();
-                        } catch {
+                        } catch (err) {
+                          console.error('dismissPresence failed:', err)
                           Alert.alert('Error', 'Could not end broadcast. Try again.');
                         } finally {
                           setDismissing(false);
@@ -336,8 +337,8 @@ export function PoiBottomSheet({
                       key={p.id}
                       presence={p}
                       existingJoin={getJoinForPresence(p.id)}
-                      onJoin={async (presenceId) => { await onJoinPresence(presenceId) }}
-                      onCancel={async (joinId) => { await onCancelJoin(joinId) }}
+                      onJoin={onJoinPresence}
+                      onCancel={onCancelJoin}
                       isOwnPresence={p.userId === session?.user.id}
                     />
                   ))}

--- a/components/map/PresenceCard.tsx
+++ b/components/map/PresenceCard.tsx
@@ -7,7 +7,7 @@ import { PresenceBubble } from '@/components/map/PresenceBubble'
 type Props = {
   presence: LivePresenceEntry
   existingJoin: PresenceJoin | undefined
-  onJoin: (presenceId: string) => Promise<void>
+  onJoin: (presenceId: string) => Promise<PresenceJoin | void>
   onCancel: (joinId: string) => Promise<void>
   isOwnPresence: boolean
 }
@@ -20,18 +20,23 @@ export function PresenceCard({ presence, existingJoin, onJoin, onCancel, isOwnPr
     setBusy(true)
     try {
       await onJoin(presence.id)
-    } catch {
-      Alert.alert('Error', 'Could not join. Try again.')
+    } catch (err) {
+      console.error('PresenceCard.handleJoin failed:', err)
+      const message = err instanceof Error && err.message.includes('already joined')
+        ? err.message
+        : 'Could not join. Try again.'
+      Alert.alert('Error', message)
     } finally {
       setBusy(false)
     }
   }
 
-  const handleCancel = async () => {
+  const handleCancel = async (joinId: string) => {
     setBusy(true)
     try {
-      await onCancel(existingJoin!.id)
-    } catch {
+      await onCancel(joinId)
+    } catch (err) {
+      console.error('PresenceCard.handleCancel failed:', err)
       Alert.alert('Error', 'Could not cancel. Try again.')
     } finally {
       setBusy(false)
@@ -56,7 +61,7 @@ export function PresenceCard({ presence, existingJoin, onJoin, onCancel, isOwnPr
           ) : existingJoin ? (
             <View style={styles.joinedState}>
               <Text style={styles.onMyWayText}>On my way</Text>
-              <TouchableOpacity onPress={handleCancel} hitSlop={8}>
+              <TouchableOpacity onPress={() => handleCancel(existingJoin.id)} hitSlop={8}>
                 <Text style={styles.cancelText}>Cancel</Text>
               </TouchableOpacity>
             </View>

--- a/components/map/PresenceCard.tsx
+++ b/components/map/PresenceCard.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react'
+import { ActivityIndicator, Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { LivePresenceEntry } from '@/hooks/useLivePresences'
+import { PresenceJoin } from '@/lib/presenceJoins'
+import { PresenceBubble } from '@/components/map/PresenceBubble'
+
+type Props = {
+  presence: LivePresenceEntry
+  existingJoin: PresenceJoin | undefined
+  onJoin: (presenceId: string) => Promise<void>
+  onCancel: (joinId: string) => Promise<void>
+  isOwnPresence: boolean
+}
+
+export function PresenceCard({ presence, existingJoin, onJoin, onCancel, isOwnPresence }: Props) {
+  const [busy, setBusy] = useState(false)
+  const firstName = presence.displayName.split(' ')[0]
+
+  const handleJoin = async () => {
+    setBusy(true)
+    try {
+      await onJoin(presence.id)
+    } catch {
+      Alert.alert('Error', 'Could not join. Try again.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleCancel = async () => {
+    setBusy(true)
+    try {
+      await onCancel(existingJoin!.id)
+    } catch {
+      Alert.alert('Error', 'Could not cancel. Try again.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <View style={styles.row}>
+      <PresenceBubble displayName={presence.displayName} avatarUrl={presence.avatarUrl} size={40} />
+
+      <View style={styles.info}>
+        <Text style={styles.name}>{presence.displayName}</Text>
+        {presence.message ? (
+          <Text style={styles.message} numberOfLines={1}>{presence.message}</Text>
+        ) : null}
+      </View>
+
+      {!isOwnPresence && (
+        <View style={styles.action}>
+          {busy ? (
+            <ActivityIndicator size="small" color="#131313" />
+          ) : existingJoin ? (
+            <View style={styles.joinedState}>
+              <Text style={styles.onMyWayText}>On my way</Text>
+              <TouchableOpacity onPress={handleCancel} hitSlop={8}>
+                <Text style={styles.cancelText}>Cancel</Text>
+              </TouchableOpacity>
+            </View>
+          ) : (
+            <TouchableOpacity style={styles.joinButton} onPress={handleJoin} activeOpacity={0.8}>
+              <Text style={styles.joinButtonText}>{`Join ${firstName}`}</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 10,
+    borderTopWidth: 1,
+    borderTopColor: '#EDECEA',
+    gap: 12,
+  },
+  info: {
+    flex: 1,
+  },
+  name: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#131313',
+  },
+  message: {
+    fontSize: 13,
+    color: '#888',
+    marginTop: 2,
+  },
+  action: {
+    alignItems: 'flex-end',
+  },
+  joinButton: {
+    backgroundColor: '#131313',
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+  },
+  joinButtonText: {
+    color: '#fff',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  joinedState: {
+    alignItems: 'flex-end',
+    gap: 4,
+  },
+  onMyWayText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#2D8A4E',
+  },
+  cancelText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#E51E1E',
+  },
+})

--- a/components/map/__tests__/PoiBottomSheet.test.tsx
+++ b/components/map/__tests__/PoiBottomSheet.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * Tests for PoiBottomSheet's "Who's here" section — the integration point where
+ * live presences, join state, and session identity converge.
+ *
+ * Heavy dependencies (BottomSheet, PoiRatingModal, BroadcastModal, etc.) are mocked
+ * so only the component's own logic is under test.
+ */
+
+import React from 'react'
+import { Text } from 'react-native'
+import { act, create, ReactTestInstance } from 'react-test-renderer'
+import { Tables } from '@/types/supabase'
+import { LivePresenceEntry } from '@/hooks/useLivePresences'
+import { PresenceJoin } from '@/lib/presenceJoins'
+
+// ---------------------------------------------------------------------------
+// Mock @gorhom/bottom-sheet — render ListHeaderComponent directly
+// ---------------------------------------------------------------------------
+jest.mock('@gorhom/bottom-sheet', () => {
+  const React = require('react')
+  return {
+    __esModule: true,
+    default: React.forwardRef(function MockBottomSheet({ children }: any, _: any) {
+      return React.createElement(React.Fragment, null, children)
+    }),
+    BottomSheetBackdrop: () => null,
+    BottomSheetFlatList: function MockBSFlatList({ ListHeaderComponent }: any) {
+      return React.createElement(React.Fragment, null, ListHeaderComponent)
+    },
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Mock PresenceCard — exposes props as testable text nodes.
+// mockPresenceCardProps is prefixed with "mock" so Jest hoisting allows it in the factory.
+// ---------------------------------------------------------------------------
+const mockPresenceCardProps: any[] = []
+jest.mock('@/components/map/PresenceCard', () => ({
+  PresenceCard: (props: any) => {
+    mockPresenceCardProps.push(props)
+    const React = require('react')
+    const { Text } = require('react-native')
+    return React.createElement(
+      Text,
+      { testID: 'presence-card' },
+      props.presence.displayName + (props.isOwnPresence ? ':own' : ':other')
+    )
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Mock all hooks and heavy deps
+// ---------------------------------------------------------------------------
+jest.mock('@/hooks/usePoiRatings', () => ({
+  usePoiRatings: jest.fn(() => ({
+    avgRating: null,
+    ratingCount: 0,
+    comments: [],
+    myRating: null,
+    refetch: jest.fn(),
+  })),
+}))
+
+jest.mock('@/hooks/useProximity', () => ({
+  useProximity: jest.fn(() => ({ isNearby: false })),
+}))
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: jest.fn(() => ({ session: { user: { id: 'current-user-id' } } })),
+}))
+
+jest.mock('@/lib/supabase', () => ({ supabase: {} }))
+jest.mock('@/lib/presence', () => ({ dismissPresence: jest.fn() }))
+
+jest.mock('@/components/map/PoiRatingModal', () => ({
+  PoiRatingModal: require('react').forwardRef(() => null),
+}))
+
+jest.mock('@/components/map/BroadcastModal', () => ({
+  BroadcastModal: require('react').forwardRef(() => null),
+}))
+
+jest.mock('@/lib/poiCategories', () => ({
+  CATEGORY_COLORS: { food_drink: '#FF0000' },
+  CATEGORY_LABELS: { food_drink: 'Food & Drink' },
+}))
+
+import { PoiBottomSheet } from '../PoiBottomSheet'
+
+type Poi = Tables<'pois'>
+
+function makePoi(overrides: Partial<Poi> = {}): Poi {
+  return {
+    id: 'poi-1',
+    name: 'Test Cafe',
+    category: 'food_drink',
+    lat: 55.6761,
+    lng: 12.5683,
+    description: null,
+    created_by: 'user-system',
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as Poi
+}
+
+const BASE_PROPS = {
+  poi: makePoi(),
+  onClose: jest.fn(),
+  activePresence: null,
+  onBroadcast: jest.fn(),
+  onDismissBroadcast: jest.fn(),
+  locationGranted: false,
+  presences: [] as LivePresenceEntry[],
+  getJoinForPresence: jest.fn(() => undefined),
+  onJoinPresence: jest.fn(),
+  onCancelJoin: jest.fn(),
+}
+
+function makePresence(overrides: Partial<LivePresenceEntry> = {}): LivePresenceEntry {
+  return {
+    id: 'presence-1',
+    userId: 'other-user-id',
+    poiId: 'poi-1',
+    displayName: 'Jane Doe',
+    avatarUrl: null,
+    message: null,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockPresenceCardProps.length = 0
+})
+
+describe('PoiBottomSheet — Who\'s here section', () => {
+  it('does not render Who\'s here section when no presences are at the current POI', () => {
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(<PoiBottomSheet {...BASE_PROPS} presences={[]} />)
+    })
+
+    const presenceCards = root!.root.findAll(
+      (n: ReactTestInstance) => n.props.testID === 'presence-card'
+    )
+    expect(presenceCards.length).toBe(0)
+
+    const texts = root!.root
+      .findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+      .map((n) => String(n.props.children))
+    expect(texts.some((t) => t.includes('here'))).toBe(false)
+  })
+
+  it('filters presences to only those at the current POI', () => {
+    const presenceAtPoi = makePresence({ poiId: 'poi-1' })
+    const presenceAtOtherPoi = makePresence({ id: 'presence-other', poiId: 'poi-99' })
+
+    act(() => {
+      create(
+        <PoiBottomSheet
+          {...BASE_PROPS}
+          presences={[presenceAtPoi, presenceAtOtherPoi]}
+        />
+      )
+    })
+
+    // Deduplicate by presence id to be robust against React re-renders calling the mock twice
+    const uniquePresenceIds = [...new Set(mockPresenceCardProps.map((p) => p.presence.id))]
+    expect(uniquePresenceIds).toEqual(['presence-1'])
+    expect(mockPresenceCardProps.every((p) => p.presence.poiId !== 'poi-99')).toBe(true)
+  })
+
+  it('shows "1 Person here" label for a single presence', () => {
+    const presences = [makePresence()]
+
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(<PoiBottomSheet {...BASE_PROPS} presences={presences} />)
+    })
+
+    const texts = root!.root
+      .findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+      .map((n) => String(n.props.children))
+    expect(texts.some((t) => t.includes('1') && t.includes('Person'))).toBe(true)
+  })
+
+  it('shows "N People here" label for multiple presences', () => {
+    const presences = [
+      makePresence({ id: 'p-1' }),
+      makePresence({ id: 'p-2', userId: 'user-b', displayName: 'Bob' }),
+    ]
+
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(<PoiBottomSheet {...BASE_PROPS} presences={presences} />)
+    })
+
+    const texts = root!.root
+      .findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+      .map((n) => String(n.props.children))
+    expect(texts.some((t) => t.includes('2') && t.includes('People'))).toBe(true)
+  })
+
+  it('marks own presence with isOwnPresence=true', () => {
+    const ownPresence = makePresence({ userId: 'current-user-id' })
+    const otherPresence = makePresence({ id: 'p-other', userId: 'someone-else' })
+
+    act(() => {
+      create(
+        <PoiBottomSheet
+          {...BASE_PROPS}
+          presences={[ownPresence, otherPresence]}
+        />
+      )
+    })
+
+    expect(mockPresenceCardProps).toHaveLength(2)
+    const own = mockPresenceCardProps.find((p) => p.presence.userId === 'current-user-id')
+    const other = mockPresenceCardProps.find((p) => p.presence.userId === 'someone-else')
+    expect(own?.isOwnPresence).toBe(true)
+    expect(other?.isOwnPresence).toBe(false)
+  })
+
+  it('passes getJoinForPresence result to PresenceCard as existingJoin', () => {
+    const mockJoin: PresenceJoin = {
+      id: 'join-1',
+      presence_id: 'presence-1',
+      joiner_user_id: 'current-user-id',
+      joined_at: '2026-01-01T00:00:00Z',
+      confirmed: false,
+    }
+    const getJoinForPresence = jest.fn((id: string) =>
+      id === 'presence-1' ? mockJoin : undefined
+    )
+
+    act(() => {
+      create(
+        <PoiBottomSheet
+          {...BASE_PROPS}
+          presences={[makePresence()]}
+          getJoinForPresence={getJoinForPresence}
+        />
+      )
+    })
+
+    expect(getJoinForPresence).toHaveBeenCalledWith('presence-1')
+    expect(mockPresenceCardProps[0].existingJoin).toEqual(mockJoin)
+  })
+})

--- a/components/map/__tests__/PresenceCard.test.tsx
+++ b/components/map/__tests__/PresenceCard.test.tsx
@@ -1,0 +1,217 @@
+import React from 'react'
+import { ActivityIndicator, TouchableOpacity } from 'react-native'
+import { act, create, ReactTestInstance } from 'react-test-renderer'
+import { PresenceCard } from '../PresenceCard'
+import { LivePresenceEntry } from '@/hooks/useLivePresences'
+import { PresenceJoin } from '@/lib/presenceJoins'
+
+// PresenceBubble renders a native View+Text or Image — no mock needed
+
+const MOCK_PRESENCE: LivePresenceEntry = {
+  id: 'p-1',
+  userId: 'u-2',
+  poiId: 'poi-1',
+  displayName: 'Jane Doe',
+  avatarUrl: null,
+  message: 'grabbing coffee',
+}
+
+const MOCK_JOIN: PresenceJoin = {
+  id: 'j-1',
+  presence_id: 'p-1',
+  joiner_user_id: 'u-1',
+  joined_at: '2026-01-01T00:00:00Z',
+  confirmed: false,
+}
+
+function findTexts(root: ReturnType<typeof create>): string[] {
+  return root.root
+    .findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+    .map((n) => String(n.props.children))
+}
+
+describe('PresenceCard', () => {
+  it('renders display name and message', () => {
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={MOCK_PRESENCE}
+          existingJoin={undefined}
+          onJoin={jest.fn()}
+          onCancel={jest.fn()}
+          isOwnPresence={false}
+        />
+      )
+    })
+
+    const texts = findTexts(root!)
+    expect(texts).toContain('Jane Doe')
+    expect(texts).toContain('grabbing coffee')
+  })
+
+  it('renders Join [firstName] button when not joined', () => {
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={MOCK_PRESENCE}
+          existingJoin={undefined}
+          onJoin={jest.fn()}
+          onCancel={jest.fn()}
+          isOwnPresence={false}
+        />
+      )
+    })
+
+    const texts = findTexts(root!)
+    expect(texts.some((t) => t.includes('Join Jane'))).toBe(true)
+  })
+
+  it('renders On my way and Cancel when existingJoin is provided', () => {
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={MOCK_PRESENCE}
+          existingJoin={MOCK_JOIN}
+          onJoin={jest.fn()}
+          onCancel={jest.fn()}
+          isOwnPresence={false}
+        />
+      )
+    })
+
+    const texts = findTexts(root!)
+    expect(texts).toContain('On my way')
+    expect(texts).toContain('Cancel')
+  })
+
+  it('calls onJoin with presenceId when Join button is pressed', async () => {
+    const onJoin = jest.fn().mockResolvedValue(undefined)
+
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={MOCK_PRESENCE}
+          existingJoin={undefined}
+          onJoin={onJoin}
+          onCancel={jest.fn()}
+          isOwnPresence={false}
+        />
+      )
+    })
+
+    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const joinButton = touchables.find((n) => {
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
+      return texts.some((t) => String(t.props.children).includes('Join'))
+    })
+
+    await act(async () => { joinButton!.props.onPress() })
+
+    expect(onJoin).toHaveBeenCalledWith('p-1')
+  })
+
+  it('calls onCancel with joinId when Cancel button is pressed', async () => {
+    const onCancel = jest.fn().mockResolvedValue(undefined)
+
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={MOCK_PRESENCE}
+          existingJoin={MOCK_JOIN}
+          onJoin={jest.fn()}
+          onCancel={onCancel}
+          isOwnPresence={false}
+        />
+      )
+    })
+
+    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const cancelButton = touchables.find((n) => {
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
+      return texts.some((t) => String(t.props.children) === 'Cancel')
+    })
+
+    await act(async () => { cancelButton!.props.onPress() })
+
+    expect(onCancel).toHaveBeenCalledWith('j-1')
+  })
+
+  it('does not render action button when isOwnPresence is true', () => {
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={MOCK_PRESENCE}
+          existingJoin={undefined}
+          onJoin={jest.fn()}
+          onCancel={jest.fn()}
+          isOwnPresence={true}
+        />
+      )
+    })
+
+    const texts = findTexts(root!)
+    expect(texts.some((t) => t.includes('Join'))).toBe(false)
+    expect(texts).not.toContain('Cancel')
+    expect(texts).not.toContain('On my way')
+  })
+
+  it('shows ActivityIndicator while operation is in progress', async () => {
+    let resolveJoin!: () => void
+    const onJoin = jest.fn().mockReturnValue(new Promise<void>((r) => { resolveJoin = r }))
+
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={MOCK_PRESENCE}
+          existingJoin={undefined}
+          onJoin={onJoin}
+          onCancel={jest.fn()}
+          isOwnPresence={false}
+        />
+      )
+    })
+
+    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const joinButton = touchables.find((n) => {
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
+      return texts.some((t) => String(t.props.children).includes('Join'))
+    })
+
+    act(() => { joinButton!.props.onPress() })
+
+    expect(root!.root.findAllByType(ActivityIndicator).length).toBeGreaterThan(0)
+
+    // Clean up
+    await act(async () => { resolveJoin() })
+  })
+
+  it('extracts first name for Join button label', () => {
+    const presence: LivePresenceEntry = {
+      ...MOCK_PRESENCE,
+      displayName: 'Alice Bob Carol',
+    }
+
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={presence}
+          existingJoin={undefined}
+          onJoin={jest.fn()}
+          onCancel={jest.fn()}
+          isOwnPresence={false}
+        />
+      )
+    })
+
+    const texts = findTexts(root!)
+    expect(texts.some((t) => t === 'Join Alice')).toBe(true)
+  })
+})

--- a/components/map/__tests__/PresenceCard.test.tsx
+++ b/components/map/__tests__/PresenceCard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ActivityIndicator, TouchableOpacity } from 'react-native'
+import { ActivityIndicator, Alert, TouchableOpacity } from 'react-native'
 import { act, create, ReactTestInstance } from 'react-test-renderer'
 import { PresenceCard } from '../PresenceCard'
 import { LivePresenceEntry } from '@/hooks/useLivePresences'
@@ -190,6 +190,89 @@ describe('PresenceCard', () => {
 
     // Clean up
     await act(async () => { resolveJoin() })
+  })
+
+  it('does not render message text when message is null', () => {
+    const presence: LivePresenceEntry = { ...MOCK_PRESENCE, message: null }
+
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={presence}
+          existingJoin={undefined}
+          onJoin={jest.fn()}
+          onCancel={jest.fn()}
+          isOwnPresence={false}
+        />
+      )
+    })
+
+    const texts = findTexts(root!)
+    // displayName is still shown, but no message line
+    expect(texts).toContain('Jane Doe')
+    expect(texts.filter((t) => t === 'grabbing coffee').length).toBe(0)
+  })
+
+  it('shows Alert and resets busy when onJoin rejects', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {})
+    const onJoin = jest.fn().mockRejectedValue(new Error('network failure'))
+
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={MOCK_PRESENCE}
+          existingJoin={undefined}
+          onJoin={onJoin}
+          onCancel={jest.fn()}
+          isOwnPresence={false}
+        />
+      )
+    })
+
+    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const joinButton = touchables.find((n) => {
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
+      return texts.some((t) => String(t.props.children).includes('Join'))
+    })
+
+    await act(async () => { joinButton!.props.onPress() })
+
+    expect(alertSpy).toHaveBeenCalledWith('Error', expect.any(String))
+    // busy resets to false — ActivityIndicator should be gone
+    expect(root!.root.findAllByType(ActivityIndicator).length).toBe(0)
+
+    alertSpy.mockRestore()
+  })
+
+  it('shows already-joined message when error includes "already joined"', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {})
+    const onJoin = jest.fn().mockRejectedValue(new Error('You have already joined this person.'))
+
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={MOCK_PRESENCE}
+          existingJoin={undefined}
+          onJoin={onJoin}
+          onCancel={jest.fn()}
+          isOwnPresence={false}
+        />
+      )
+    })
+
+    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const joinButton = touchables.find((n) => {
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
+      return texts.some((t) => String(t.props.children).includes('Join'))
+    })
+
+    await act(async () => { joinButton!.props.onPress() })
+
+    expect(alertSpy).toHaveBeenCalledWith('Error', 'You have already joined this person.')
+    alertSpy.mockRestore()
   })
 
   it('extracts first name for Join button label', () => {

--- a/hooks/__tests__/usePresenceJoins.test.ts
+++ b/hooks/__tests__/usePresenceJoins.test.ts
@@ -1,0 +1,178 @@
+import React from 'react'
+import { act, create } from 'react-test-renderer'
+
+const mockEqFn = jest.fn()
+const mockUseAuth = jest.fn()
+const mockJoinPresence = jest.fn()
+const mockCancelJoin = jest.fn()
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: mockEqFn,
+      })),
+    })),
+  },
+}))
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+jest.mock('@/lib/presenceJoins', () => ({
+  joinPresence: (...args: unknown[]) => mockJoinPresence(...args),
+  cancelJoin: (...args: unknown[]) => mockCancelJoin(...args),
+}))
+
+import { usePresenceJoins } from '../usePresenceJoins'
+
+type HookResult<T> = { current: T }
+
+function renderHook<T>(useHook: () => T): HookResult<T> {
+  const result: HookResult<T> = { current: undefined as unknown as T }
+
+  function TestComponent() {
+    result.current = useHook()
+    return null
+  }
+
+  act(() => {
+    create(React.createElement(TestComponent))
+  })
+
+  return result
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+const MOCK_JOIN_ROW = {
+  id: 'join-1',
+  presence_id: 'presence-1',
+  joiner_user_id: 'user-1',
+  joined_at: '2026-01-01T00:00:00Z',
+  confirmed: false,
+}
+
+const MOCK_JOIN_ROW_2 = {
+  id: 'join-2',
+  presence_id: 'presence-2',
+  joiner_user_id: 'user-1',
+  joined_at: '2026-01-02T00:00:00Z',
+  confirmed: false,
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockUseAuth.mockReturnValue({ session: { user: { id: 'user-1' } } })
+})
+
+describe('usePresenceJoins', () => {
+  it('returns empty joins when query returns no rows', async () => {
+    mockEqFn.mockResolvedValue({ data: [], error: null })
+
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+
+    expect(result.current.joins).toEqual([])
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('returns joins when query returns rows', async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null })
+
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+
+    expect(result.current.joins).toEqual([MOCK_JOIN_ROW])
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('loading is true before the fetch resolves', async () => {
+    let resolve!: (value: { data: typeof MOCK_JOIN_ROW[]; error: null }) => void
+    mockEqFn.mockReturnValue(new Promise((r) => { resolve = r }))
+
+    const result = renderHook(() => usePresenceJoins())
+    expect(result.current.loading).toBe(true)
+
+    await act(async () => { resolve({ data: [], error: null }) })
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('sets error state when fetch fails', async () => {
+    mockEqFn.mockResolvedValue({ data: null, error: { message: 'network error' } })
+
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+
+    expect(result.current.error).toBe('network error')
+    expect(result.current.joins).toEqual([])
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('returns empty joins when user is not authenticated', async () => {
+    mockUseAuth.mockReturnValue({ session: null })
+
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+
+    expect(result.current.joins).toEqual([])
+    expect(result.current.loading).toBe(false)
+    expect(mockEqFn).not.toHaveBeenCalled()
+  })
+
+  it('join() calls joinPresence and appends to state', async () => {
+    mockEqFn.mockResolvedValue({ data: [], error: null })
+    mockJoinPresence.mockResolvedValue(MOCK_JOIN_ROW)
+
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+
+    await act(async () => {
+      await result.current.join('presence-1')
+    })
+
+    expect(mockJoinPresence).toHaveBeenCalled()
+    expect(result.current.joins).toEqual([MOCK_JOIN_ROW])
+  })
+
+  it('cancel() calls cancelJoin and removes from state', async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW, MOCK_JOIN_ROW_2], error: null })
+    mockCancelJoin.mockResolvedValue(undefined)
+
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+
+    expect(result.current.joins).toHaveLength(2)
+
+    await act(async () => {
+      await result.current.cancel('join-1')
+    })
+
+    expect(mockCancelJoin).toHaveBeenCalled()
+    expect(result.current.joins).toEqual([MOCK_JOIN_ROW_2])
+  })
+
+  it('getJoinForPresence returns matching join', async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW, MOCK_JOIN_ROW_2], error: null })
+
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+
+    expect(result.current.getJoinForPresence('presence-1')).toEqual(MOCK_JOIN_ROW)
+    expect(result.current.getJoinForPresence('presence-2')).toEqual(MOCK_JOIN_ROW_2)
+  })
+
+  it('getJoinForPresence returns undefined when no match', async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null })
+
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+
+    expect(result.current.getJoinForPresence('presence-999')).toBeUndefined()
+  })
+})

--- a/hooks/__tests__/usePresenceJoins.test.ts
+++ b/hooks/__tests__/usePresenceJoins.test.ts
@@ -103,13 +103,24 @@ describe('usePresenceJoins', () => {
     expect(result.current.loading).toBe(false)
   })
 
-  it('sets error state when fetch fails', async () => {
+  it('sets error state when fetch returns a Supabase error', async () => {
     mockEqFn.mockResolvedValue({ data: null, error: { message: 'network error' } })
 
     const result = renderHook(() => usePresenceJoins())
     await flush()
 
     expect(result.current.error).toBe('network error')
+    expect(result.current.joins).toEqual([])
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('sets error state when fetch throws a JS exception', async () => {
+    mockEqFn.mockRejectedValue(new Error('connection refused'))
+
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+
+    expect(result.current.error).toBe('connection refused')
     expect(result.current.joins).toEqual([])
     expect(result.current.loading).toBe(false)
   })
@@ -140,6 +151,35 @@ describe('usePresenceJoins', () => {
     expect(result.current.joins).toEqual([MOCK_JOIN_ROW])
   })
 
+  it('join() deduplicates if same row is returned twice', async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null })
+    mockJoinPresence.mockResolvedValue(MOCK_JOIN_ROW)
+
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+
+    await act(async () => {
+      await result.current.join('presence-1')
+    })
+
+    expect(result.current.joins).toHaveLength(1)
+    expect(result.current.joins[0]).toEqual(MOCK_JOIN_ROW)
+  })
+
+  it('join() propagates error without mutating state', async () => {
+    mockEqFn.mockResolvedValue({ data: [], error: null })
+    mockJoinPresence.mockRejectedValue(new Error('unique violation'))
+
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+
+    await expect(
+      act(async () => { await result.current.join('presence-1') })
+    ).rejects.toThrow('unique violation')
+
+    expect(result.current.joins).toEqual([])
+  })
+
   it('cancel() calls cancelJoin and removes from state', async () => {
     mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW, MOCK_JOIN_ROW_2], error: null })
     mockCancelJoin.mockResolvedValue(undefined)
@@ -155,6 +195,20 @@ describe('usePresenceJoins', () => {
 
     expect(mockCancelJoin).toHaveBeenCalled()
     expect(result.current.joins).toEqual([MOCK_JOIN_ROW_2])
+  })
+
+  it('cancel() propagates error without removing from state', async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null })
+    mockCancelJoin.mockRejectedValue(new Error('Join not found or already cancelled'))
+
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+
+    await expect(
+      act(async () => { await result.current.cancel('join-1') })
+    ).rejects.toThrow('Join not found or already cancelled')
+
+    expect(result.current.joins).toEqual([MOCK_JOIN_ROW])
   })
 
   it('getJoinForPresence returns matching join', async () => {

--- a/hooks/usePresenceJoins.ts
+++ b/hooks/usePresenceJoins.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect, useCallback } from 'react'
+import { supabase } from '@/lib/supabase'
+import { useAuth } from '@/hooks/useAuth'
+import { PresenceJoin, joinPresence, cancelJoin } from '@/lib/presenceJoins'
+
+export function usePresenceJoins() {
+  const { session } = useAuth()
+  const [joins, setJoins] = useState<PresenceJoin[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const userId = session?.user.id
+    if (!userId) {
+      setJoins([])
+      setLoading(false)
+      return
+    }
+
+    let active = true
+
+    supabase
+      .from('presence_joins')
+      .select('id, presence_id, joiner_user_id, joined_at, confirmed')
+      .eq('joiner_user_id', userId)
+      .then(({ data, error: fetchError }) => {
+        if (!active) return
+        if (fetchError) {
+          console.error('usePresenceJoins:', fetchError.message)
+          setError(fetchError.message)
+        } else {
+          setJoins((data ?? []) as PresenceJoin[])
+        }
+        setLoading(false)
+      })
+
+    return () => { active = false }
+  }, [session?.user.id])
+
+  const join = useCallback(async (presenceId: string): Promise<PresenceJoin> => {
+    const newJoin = await joinPresence(supabase, { presenceId })
+    setJoins((prev) => [...prev, newJoin])
+    return newJoin
+  }, [])
+
+  const cancel = useCallback(async (joinId: string): Promise<void> => {
+    await cancelJoin(supabase, { joinId })
+    setJoins((prev) => prev.filter((j) => j.id !== joinId))
+  }, [])
+
+  const getJoinForPresence = useCallback(
+    (presenceId: string): PresenceJoin | undefined =>
+      joins.find((j) => j.presence_id === presenceId),
+    [joins]
+  )
+
+  return { joins, loading, error, join, cancel, getJoinForPresence }
+}

--- a/hooks/usePresenceJoins.ts
+++ b/hooks/usePresenceJoins.ts
@@ -18,28 +18,46 @@ export function usePresenceJoins() {
     }
 
     let active = true
+    setError(null)
+    setLoading(true)
 
-    supabase
-      .from('presence_joins')
-      .select('id, presence_id, joiner_user_id, joined_at, confirmed')
-      .eq('joiner_user_id', userId)
-      .then(({ data, error: fetchError }) => {
+    async function load() {
+      try {
+        const { data, error: fetchError } = await supabase
+          .from('presence_joins')
+          .select('id, presence_id, joiner_user_id, joined_at, confirmed')
+          .eq('joiner_user_id', userId!)
         if (!active) return
         if (fetchError) {
           console.error('usePresenceJoins:', fetchError.message)
           setError(fetchError.message)
         } else {
+          // Note: joins for dismissed presences (dismissed_at set) are not filtered here
+          // because soft-deleted live_presence rows persist. Stale joins are harmless —
+          // dismissed presences never render PresenceCards so the stale join is never acted on.
+          // TODO (Phase 5): consider a periodic cleanup or server-side filter.
           setJoins((data ?? []) as PresenceJoin[])
         }
-        setLoading(false)
-      })
+      } catch (err) {
+        if (!active) return
+        const message = err instanceof Error ? err.message : 'Unknown error'
+        console.error('usePresenceJoins:', message)
+        setError(message)
+      } finally {
+        if (active) setLoading(false)
+      }
+    }
 
+    load()
     return () => { active = false }
   }, [session?.user.id])
 
   const join = useCallback(async (presenceId: string): Promise<PresenceJoin> => {
     const newJoin = await joinPresence(supabase, { presenceId })
-    setJoins((prev) => [...prev, newJoin])
+    setJoins((prev) => {
+      if (prev.some((j) => j.id === newJoin.id)) return prev
+      return [...prev, newJoin]
+    })
     return newJoin
   }, [])
 

--- a/lib/__tests__/presenceJoins.test.ts
+++ b/lib/__tests__/presenceJoins.test.ts
@@ -22,7 +22,7 @@ type MockSupabase = {
 function makeJoinMock({
   insertResult = { data: MOCK_JOIN_ROW, error: null },
 }: {
-  insertResult?: { data: typeof MOCK_JOIN_ROW | null; error: { message: string } | null }
+  insertResult?: { data: typeof MOCK_JOIN_ROW | null; error: { message: string; code?: string } | null }
 } = {}): MockSupabase {
   const single = jest.fn().mockResolvedValue(insertResult)
   const select = jest.fn().mockReturnValue({ single })
@@ -36,9 +36,9 @@ function makeJoinMock({
 }
 
 function makeCancelMock({
-  deleteResult = { error: null },
+  deleteResult = { count: 1, error: null },
 }: {
-  deleteResult?: { error: { message: string } | null }
+  deleteResult?: { count: number | null; error: { message: string } | null }
 } = {}): MockSupabase {
   const eqUser = jest.fn().mockResolvedValue(deleteResult)
   const eqId = jest.fn().mockReturnValue({ eq: eqUser })
@@ -82,13 +82,33 @@ describe('joinPresence', () => {
     ).rejects.toThrow('Not authenticated')
   })
 
-  it('throws with Supabase error message when insert fails', async () => {
-    const mock = makeJoinMock({
-      insertResult: { data: null, error: { message: 'unique violation' } },
+  it('throws when getUser returns an auth error even with user present', async () => {
+    const mock = makeJoinMock()
+    mock.auth.getUser.mockResolvedValue({
+      data: { user: { id: MOCK_USER_ID } },
+      error: { message: 'session expired' },
     })
     await expect(
       joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
-    ).rejects.toThrow('unique violation')
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws user-friendly message on unique constraint violation', async () => {
+    const mock = makeJoinMock({
+      insertResult: { data: null, error: { message: 'duplicate key value', code: '23505' } },
+    })
+    await expect(
+      joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
+    ).rejects.toThrow('You have already joined this person.')
+  })
+
+  it('throws with Supabase error message when insert fails with other error', async () => {
+    const mock = makeJoinMock({
+      insertResult: { data: null, error: { message: 'insert failed' } },
+    })
+    await expect(
+      joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
+    ).rejects.toThrow('insert failed')
   })
 
   it('logs push notification stub', async () => {
@@ -124,13 +144,31 @@ describe('cancelJoin', () => {
     ).rejects.toThrow('Not authenticated')
   })
 
+  it('throws when getUser returns an auth error even with user present', async () => {
+    const mock = makeCancelMock()
+    mock.auth.getUser.mockResolvedValue({
+      data: { user: { id: MOCK_USER_ID } },
+      error: { message: 'session expired' },
+    })
+    await expect(
+      cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })
+    ).rejects.toThrow('Not authenticated')
+  })
+
   it('throws with Supabase error message when delete fails', async () => {
     const mock = makeCancelMock({
-      deleteResult: { error: { message: 'delete failed' } },
+      deleteResult: { count: null, error: { message: 'delete failed' } },
     })
     await expect(
       cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })
     ).rejects.toThrow('delete failed')
+  })
+
+  it('throws when join is not found (zero rows deleted)', async () => {
+    const mock = makeCancelMock({ deleteResult: { count: 0, error: null } })
+    await expect(
+      cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })
+    ).rejects.toThrow('Join not found or already cancelled')
   })
 
   it('logs push notification stub', async () => {

--- a/lib/__tests__/presenceJoins.test.ts
+++ b/lib/__tests__/presenceJoins.test.ts
@@ -1,0 +1,143 @@
+import { joinPresence, cancelJoin } from '../presenceJoins'
+import { SupabaseClient } from '@supabase/supabase-js'
+import { Database } from '../../types/supabase'
+
+const MOCK_USER_ID = 'user-123'
+const MOCK_PRESENCE_ID = 'presence-456'
+const MOCK_JOIN_ID = 'join-789'
+
+const MOCK_JOIN_ROW = {
+  id: MOCK_JOIN_ID,
+  presence_id: MOCK_PRESENCE_ID,
+  joiner_user_id: MOCK_USER_ID,
+  joined_at: '2026-01-01T00:00:00Z',
+  confirmed: false,
+}
+
+type MockSupabase = {
+  from: jest.Mock
+  auth: { getUser: jest.Mock }
+}
+
+function makeJoinMock({
+  insertResult = { data: MOCK_JOIN_ROW, error: null },
+}: {
+  insertResult?: { data: typeof MOCK_JOIN_ROW | null; error: { message: string } | null }
+} = {}): MockSupabase {
+  const single = jest.fn().mockResolvedValue(insertResult)
+  const select = jest.fn().mockReturnValue({ single })
+  const insert = jest.fn().mockReturnValue({ select })
+  const from = jest.fn().mockReturnValue({ insert })
+  const getUser = jest.fn().mockResolvedValue({
+    data: { user: { id: MOCK_USER_ID } },
+    error: null,
+  })
+  return { from, auth: { getUser } }
+}
+
+function makeCancelMock({
+  deleteResult = { error: null },
+}: {
+  deleteResult?: { error: { message: string } | null }
+} = {}): MockSupabase {
+  const eqUser = jest.fn().mockResolvedValue(deleteResult)
+  const eqId = jest.fn().mockReturnValue({ eq: eqUser })
+  const del = jest.fn().mockReturnValue({ eq: eqId })
+  const from = jest.fn().mockReturnValue({ delete: del })
+  const getUser = jest.fn().mockResolvedValue({
+    data: { user: { id: MOCK_USER_ID } },
+    error: null,
+  })
+  return { from, auth: { getUser } }
+}
+
+function asClient(mock: MockSupabase): SupabaseClient<Database> {
+  return mock as unknown as SupabaseClient<Database>
+}
+
+describe('joinPresence', () => {
+  it('inserts with correct fields', async () => {
+    const mock = makeJoinMock()
+    await joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
+
+    expect(mock.from).toHaveBeenCalledWith('presence_joins')
+    const fromInstance = mock.from.mock.results[0].value
+    expect(fromInstance.insert).toHaveBeenCalledWith({
+      presence_id: MOCK_PRESENCE_ID,
+      joiner_user_id: MOCK_USER_ID,
+    })
+  })
+
+  it('returns the created join row', async () => {
+    const mock = makeJoinMock()
+    const result = await joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
+    expect(result).toEqual(MOCK_JOIN_ROW)
+  })
+
+  it('throws when user is not authenticated', async () => {
+    const mock = makeJoinMock()
+    mock.auth.getUser.mockResolvedValue({ data: { user: null }, error: null })
+    await expect(
+      joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws with Supabase error message when insert fails', async () => {
+    const mock = makeJoinMock({
+      insertResult: { data: null, error: { message: 'unique violation' } },
+    })
+    await expect(
+      joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
+    ).rejects.toThrow('unique violation')
+  })
+
+  it('logs push notification stub', async () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const mock = makeJoinMock()
+    await joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Push stub'))
+    spy.mockRestore()
+  })
+})
+
+describe('cancelJoin', () => {
+  it('deletes with correct joinId and user filter', async () => {
+    const mock = makeCancelMock()
+    await cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })
+
+    expect(mock.from).toHaveBeenCalledWith('presence_joins')
+    const fromInstance = mock.from.mock.results[0].value
+    expect(fromInstance.delete).toHaveBeenCalled()
+
+    const deleteResult = fromInstance.delete.mock.results[0].value
+    expect(deleteResult.eq).toHaveBeenCalledWith('id', MOCK_JOIN_ID)
+
+    const firstEqResult = deleteResult.eq.mock.results[0].value
+    expect(firstEqResult.eq).toHaveBeenCalledWith('joiner_user_id', MOCK_USER_ID)
+  })
+
+  it('throws when user is not authenticated', async () => {
+    const mock = makeCancelMock()
+    mock.auth.getUser.mockResolvedValue({ data: { user: null }, error: null })
+    await expect(
+      cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws with Supabase error message when delete fails', async () => {
+    const mock = makeCancelMock({
+      deleteResult: { error: { message: 'delete failed' } },
+    })
+    await expect(
+      cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })
+    ).rejects.toThrow('delete failed')
+  })
+
+  it('logs push notification stub', async () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const mock = makeCancelMock()
+    await cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Push stub'))
+    spy.mockRestore()
+  })
+})

--- a/lib/presenceJoins.ts
+++ b/lib/presenceJoins.ts
@@ -1,13 +1,8 @@
 import { SupabaseClient } from '@supabase/supabase-js'
-import { Database } from '@/types/supabase'
+import { Database, Tables } from '@/types/supabase'
 
-export type PresenceJoin = {
-  id: string
-  presence_id: string
-  joiner_user_id: string
-  joined_at: string
-  confirmed: boolean
-}
+// Use the generated type so it stays in sync with the DB schema automatically.
+export type PresenceJoin = Tables<'presence_joins'>
 
 export async function joinPresence(
   supabase: SupabaseClient<Database>,
@@ -19,13 +14,21 @@ export async function joinPresence(
   const { data, error } = await supabase
     .from('presence_joins')
     .insert({ presence_id: presenceId, joiner_user_id: user.id })
-    .select('id, presence_id, joiner_user_id, joined_at, confirmed')
+    .select('*')
     .single()
 
-  if (error) throw new Error(error.message)
+  if (error) {
+    if (error.code === '23505') throw new Error('You have already joined this person.')
+    throw new Error(error.message)
+  }
 
-  // Push notification stub — replace with Expo Push when infra is built in Phase 7
-  console.log(`[Push stub] ${user.id} is joining presence ${presenceId}`)
+  try {
+    // Push notification stub — replace with Expo Push when infra is built in Phase 7
+    console.log(`[Push stub] ${user.id} is joining presence ${presenceId}`)
+  } catch (pushErr) {
+    console.error('[Push stub] Failed to send join notification:', pushErr)
+    // Join succeeded — push failure is non-fatal
+  }
 
   return data as PresenceJoin
 }
@@ -37,14 +40,20 @@ export async function cancelJoin(
   const { data: { user }, error: authError } = await supabase.auth.getUser()
   if (authError || !user) throw new Error('Not authenticated')
 
-  const { error } = await supabase
+  const { count, error } = await supabase
     .from('presence_joins')
-    .delete()
+    .delete({ count: 'exact' })
     .eq('id', joinId)
     .eq('joiner_user_id', user.id)
 
   if (error) throw new Error(error.message)
+  if ((count ?? 0) === 0) throw new Error('Join not found or already cancelled')
 
-  // Push notification stub — replace with Expo Push when infra is built in Phase 7
-  console.log(`[Push stub] ${user.id} cancelled join ${joinId}`)
+  try {
+    // Push notification stub — replace with Expo Push when infra is built in Phase 7
+    console.log(`[Push stub] ${user.id} cancelled join ${joinId}`)
+  } catch (pushErr) {
+    console.error('[Push stub] Failed to send cancel notification:', pushErr)
+    // Cancel succeeded — push failure is non-fatal
+  }
 }

--- a/lib/presenceJoins.ts
+++ b/lib/presenceJoins.ts
@@ -1,0 +1,50 @@
+import { SupabaseClient } from '@supabase/supabase-js'
+import { Database } from '@/types/supabase'
+
+export type PresenceJoin = {
+  id: string
+  presence_id: string
+  joiner_user_id: string
+  joined_at: string
+  confirmed: boolean
+}
+
+export async function joinPresence(
+  supabase: SupabaseClient<Database>,
+  { presenceId }: { presenceId: string }
+): Promise<PresenceJoin> {
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) throw new Error('Not authenticated')
+
+  const { data, error } = await supabase
+    .from('presence_joins')
+    .insert({ presence_id: presenceId, joiner_user_id: user.id })
+    .select('id, presence_id, joiner_user_id, joined_at, confirmed')
+    .single()
+
+  if (error) throw new Error(error.message)
+
+  // Push notification stub — replace with Expo Push when infra is built in Phase 7
+  console.log(`[Push stub] ${user.id} is joining presence ${presenceId}`)
+
+  return data as PresenceJoin
+}
+
+export async function cancelJoin(
+  supabase: SupabaseClient<Database>,
+  { joinId }: { joinId: string }
+): Promise<void> {
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) throw new Error('Not authenticated')
+
+  const { error } = await supabase
+    .from('presence_joins')
+    .delete()
+    .eq('id', joinId)
+    .eq('joiner_user_id', user.id)
+
+  if (error) throw new Error(error.message)
+
+  // Push notification stub — replace with Expo Push when infra is built in Phase 7
+  console.log(`[Push stub] ${user.id} cancelled join ${joinId}`)
+}

--- a/supabase/migrations/013_presence_joins.sql
+++ b/supabase/migrations/013_presence_joins.sql
@@ -1,5 +1,6 @@
 -- presence_joins: records a user's intent to join a live presence broadcast.
--- The `confirmed` flag is set to true in Phase 5 when the joiner's geofence arrival is detected.
+-- The `confirmed` flag is set to true in Phase 5 (Passive Check-In & Geofencing) when the
+-- joiner's geofence arrival is detected.
 
 CREATE TABLE public.presence_joins (
   id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -35,9 +36,10 @@ CREATE POLICY "Users can insert own join"
   TO authenticated
   WITH CHECK (auth.uid() = joiner_user_id);
 
--- Broadcaster can confirm arrival (used in Phase 5 geofence flow).
+-- Broadcaster can confirm arrival (used in Phase 5 — Passive Check-In & Geofencing).
 -- WITH CHECK mirrors USING so the broadcaster cannot reassign presence_id
 -- or joiner_user_id to arbitrary values.
+-- Note: allows update to any column, not just `confirmed` — tighten to confirmed-only in Phase 5.
 CREATE POLICY "Broadcaster can confirm join"
   ON public.presence_joins FOR UPDATE
   TO authenticated
@@ -56,11 +58,11 @@ CREATE POLICY "Broadcaster can confirm join"
     )
   );
 
--- Joiner can withdraw their join intent before it is confirmed
+-- Joiner can withdraw their own join intent at any time
 CREATE POLICY "Joiner can delete own join"
   ON public.presence_joins FOR DELETE
   TO authenticated
   USING (auth.uid() = joiner_user_id);
 
--- Enable Realtime for presence_joins so Phase 5 can subscribe to confirmation events
+-- Enable Realtime so Phase 5 (Passive Check-In & Geofencing) can subscribe to confirmation events
 ALTER PUBLICATION supabase_realtime ADD TABLE public.presence_joins;

--- a/supabase/migrations/013_presence_joins.sql
+++ b/supabase/migrations/013_presence_joins.sql
@@ -1,0 +1,66 @@
+-- presence_joins: records a user's intent to join a live presence broadcast.
+-- The `confirmed` flag is set to true in Phase 5 when the joiner's geofence arrival is detected.
+
+CREATE TABLE public.presence_joins (
+  id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  presence_id      uuid        NOT NULL REFERENCES public.live_presence(id) ON DELETE CASCADE,
+  joiner_user_id   uuid        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  joined_at        timestamptz NOT NULL DEFAULT now(),
+  confirmed        boolean     NOT NULL DEFAULT false,
+
+  CONSTRAINT presence_joins_unique UNIQUE (presence_id, joiner_user_id)
+);
+
+CREATE INDEX idx_presence_joins_presence ON public.presence_joins (presence_id);
+CREATE INDEX idx_presence_joins_joiner   ON public.presence_joins (joiner_user_id);
+
+ALTER TABLE public.presence_joins ENABLE ROW LEVEL SECURITY;
+
+-- Broadcaster and joiner can both read join records
+CREATE POLICY "Broadcaster and joiner can view joins"
+  ON public.presence_joins FOR SELECT
+  TO authenticated
+  USING (
+    auth.uid() = joiner_user_id
+    OR EXISTS (
+      SELECT 1 FROM public.live_presence
+      WHERE id = presence_joins.presence_id
+        AND user_id = auth.uid()
+    )
+  );
+
+-- Authenticated users can log a join intent
+CREATE POLICY "Users can insert own join"
+  ON public.presence_joins FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = joiner_user_id);
+
+-- Broadcaster can confirm arrival (used in Phase 5 geofence flow).
+-- WITH CHECK mirrors USING so the broadcaster cannot reassign presence_id
+-- or joiner_user_id to arbitrary values.
+CREATE POLICY "Broadcaster can confirm join"
+  ON public.presence_joins FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.live_presence
+      WHERE id = presence_joins.presence_id
+        AND user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.live_presence
+      WHERE id = presence_joins.presence_id
+        AND user_id = auth.uid()
+    )
+  );
+
+-- Joiner can withdraw their join intent before it is confirmed
+CREATE POLICY "Joiner can delete own join"
+  ON public.presence_joins FOR DELETE
+  TO authenticated
+  USING (auth.uid() = joiner_user_id);
+
+-- Enable Realtime for presence_joins so Phase 5 can subscribe to confirmation events
+ALTER PUBLICATION supabase_realtime ADD TABLE public.presence_joins;

--- a/supabase/migrations/014_display_name_min_length.sql
+++ b/supabase/migrations/014_display_name_min_length.sql
@@ -1,0 +1,6 @@
+-- Enforce a minimum display name length of 2 non-whitespace characters.
+-- The signup flow already validates this client-side, and the handle_new_user trigger
+-- falls back to the email username prefix. This constraint is the server-side safety net.
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_display_name_min_length
+  CHECK (char_length(trim(display_name)) >= 2);

--- a/supabase/migrations/014_display_name_min_length.sql
+++ b/supabase/migrations/014_display_name_min_length.sql
@@ -1,6 +1,7 @@
 -- Enforce a minimum display name length of 2 non-whitespace characters.
--- The signup flow already validates this client-side, and the handle_new_user trigger
--- falls back to the email username prefix. This constraint is the server-side safety net.
+-- The signup flow validates this client-side; this constraint is the server-side safety net.
+-- Note: the handle_new_user trigger inserts display_name directly from metadata with no fallback,
+-- so client-side validation is the only guard against a null or too-short value reaching the DB.
 ALTER TABLE public.profiles
   ADD CONSTRAINT profiles_display_name_min_length
   CHECK (char_length(trim(display_name)) >= 2);

--- a/supabase/migrations/015_fix_presence_joins_self_join.sql
+++ b/supabase/migrations/015_fix_presence_joins_self_join.sql
@@ -1,0 +1,17 @@
+-- Fix: prevent users from joining their own broadcast at the DB level.
+-- The client already guards against this via isOwnPresence, but RLS should be authoritative.
+-- Replaces the INSERT policy from migration 013 with one that adds a NOT EXISTS check.
+
+DROP POLICY "Users can insert own join" ON public.presence_joins;
+
+CREATE POLICY "Users can insert own join"
+  ON public.presence_joins FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() = joiner_user_id
+    AND NOT EXISTS (
+      SELECT 1 FROM public.live_presence
+      WHERE id = presence_joins.presence_id
+        AND user_id = auth.uid()
+    )
+  );

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -84,6 +84,45 @@ export type Database = {
           },
         ]
       }
+      presence_joins: {
+        Row: {
+          confirmed: boolean
+          id: string
+          joined_at: string
+          joiner_user_id: string
+          presence_id: string
+        }
+        Insert: {
+          confirmed?: boolean
+          id?: string
+          joined_at?: string
+          joiner_user_id: string
+          presence_id: string
+        }
+        Update: {
+          confirmed?: boolean
+          id?: string
+          joined_at?: string
+          joiner_user_id?: string
+          presence_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "presence_joins_presence_id_fkey"
+            columns: ["presence_id"]
+            isOneToOne: false
+            referencedRelation: "live_presence"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "presence_joins_joiner_user_id_fkey"
+            columns: ["joiner_user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       poi_ratings: {
         Row: {
           comment: string | null


### PR DESCRIPTION
## Summary

- Adds **presence_joins** table (migration 013) with RLS, `ON DELETE CASCADE`, and Realtime enabled
- Adds display name CHECK constraint `char_length(trim(display_name)) >= 2` (migration 014)
- New `lib/presenceJoins.ts` — `joinPresence` / `cancelJoin` with push notification stubs (`console.log`; delivery deferred to Phase 7)
- New `hooks/usePresenceJoins.ts` — fetches all joins for the current user, exposes `join`, `cancel`, `getJoinForPresence`
- New `components/map/PresenceCard.tsx` — avatar + name + message + **Join [Name]** / **On my way + Cancel** button
- `PoiBottomSheet.tsx` — "Who's here" section inserted between broadcast controls and comments
- `MapScreen` wired to pass presences and join callbacks to PoiBottomSheet
- 26 new tests (156 total); fixed post-teardown `window.dispatchEvent` crash in MapScreen tests

## Test plan

- [x] Open a POI bottom sheet where another user is broadcasting — "N People here" section appears
- [x] Tap **Join [Name]** — row inserts into `presence_joins`, card shows "On my way" + Cancel
- [x] Tap **Cancel** — row deleted, card reverts to Join button
- [x] Own broadcast card has no action button
- [x] `npx jest` — 156 tests pass, no post-teardown errors
- [x] Section hidden when no one else is broadcasting at the POI

🤖 Generated with [Claude Code](https://claude.com/claude-code)