### PR TITLE
fix: security audit fixes

### DIFF
--- a/app/(app)/profile-modal.tsx
+++ b/app/(app)/profile-modal.tsx
@@ -67,8 +67,8 @@ export default function ProfileModal() {
 
   async function saveProfile() {
     setError(null)
-    if (!displayName.trim()) {
-      setError('Display name cannot be empty.')
+    if (displayName.trim().length < 2) {
+      setError('Display name must be at least 2 characters.')
       return
     }
     setLoading(true)

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -18,6 +18,10 @@ export default function SignupScreen() {
       setError("Please enter a display name.");
       return;
     }
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters.");
+      return;
+    }
     // TODO: re-enable before launch
     // if (!isEduEmail(email)) {
     //   setError('Please use your .edu university email to sign up.')

--- a/lib/presenceJoins.ts
+++ b/lib/presenceJoins.ts
@@ -24,7 +24,7 @@ export async function joinPresence(
 
   try {
     // Push notification stub — replace with Expo Push when infra is built in Phase 7
-    console.log(`[Push stub] ${user.id} is joining presence ${presenceId}`)
+    console.log('[Push stub] join notification queued')
   } catch (pushErr) {
     console.error('[Push stub] Failed to send join notification:', pushErr)
     // Join succeeded — push failure is non-fatal
@@ -51,7 +51,7 @@ export async function cancelJoin(
 
   try {
     // Push notification stub — replace with Expo Push when infra is built in Phase 7
-    console.log(`[Push stub] ${user.id} cancelled join ${joinId}`)
+    console.log('[Push stub] cancel notification queued')
   } catch (pushErr) {
     console.error('[Push stub] Failed to send cancel notification:', pushErr)
     // Cancel succeeded — push failure is non-fatal

--- a/supabase/migrations/016_fix_profiles_update_policy.sql
+++ b/supabase/migrations/016_fix_profiles_update_policy.sql
@@ -1,0 +1,10 @@
+-- Drop and recreate the profiles UPDATE policy to add WITH CHECK (auth.uid() = id).
+-- Without WITH CHECK, the USING clause only restricts which rows can be targeted,
+-- but doesn't prevent a crafted request from writing a different id value into the row.
+
+drop policy if exists "Users can update own profile" on public.profiles;
+
+create policy "Users can update own profile"
+  on public.profiles for update to authenticated
+  using (auth.uid() = id)
+  with check (auth.uid() = id);


### PR DESCRIPTION
## Summary

- **RLS** — `profiles` UPDATE policy now has `WITH CHECK (auth.uid() = id)`; previously USING-only left a gap where a crafted request could write an unexpected `id` value into the row
- **Log hygiene** — removed user IDs from push stub `console.log` calls in `lib/presenceJoins.ts`
- **Password validation** — signup now rejects passwords shorter than 8 characters client-side, before hitting Supabase
- **Display name validation** — profile modal validates `>= 2 chars` to match the DB `CHECK` constraint; error message was misleading ("cannot be empty")

## Migration

`016_fix_profiles_update_policy.sql` — drops and recreates the profiles UPDATE policy with `WITH CHECK`. Already applied to remote via `supabase db push`.

## Test plan

- [ ] 175 tests passing (`npx jest --ci`)
- [ ] Signup rejects password < 8 chars with inline error before submission
- [ ] Profile modal rejects single-character display name with correct error
- [ ] Confirm no user IDs appear in console output during join/cancel flows