### PR TITLE
fix: map bounds and smooth keyboard animation

### DIFF
--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -109,6 +109,11 @@ export default function MapScreen() {
             centerCoordinate: [12.5683, 55.6761],
             zoomLevel: 13,
           }}
+          maxBounds={{
+            ne: [13.15, 55.85],
+            sw: [11.85, 55.45],
+          }}
+          minZoomLevel={9}
         />
         <PoiLayer pois={filteredPois} onPoiPress={handlePoiPress} />
         <PresenceLayer presences={presences} pois={pois} onPoiPress={handlePoiPress} />

--- a/components/map/PoiRatingModal.tsx
+++ b/components/map/PoiRatingModal.tsx
@@ -72,7 +72,7 @@ export const PoiRatingModal = forwardRef<PoiRatingModalHandle, Props>(function P
     >
       <KeyboardAvoidingView
         style={styles.overlay}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        behavior="padding"
       >
         <Pressable style={styles.backdrop} onPress={() => setVisible(false)} />
 


### PR DESCRIPTION
## Summary
- Restrict Mapbox Camera to Copenhagen region (Roskilde to Malmö with balanced north/south distance) via `maxBounds` and `minZoomLevel: 9` — prevents accidental navigation outside DIS-relevant area
- Fix PoiRatingModal keyboard animation jump on Android by changing `KeyboardAvoidingView` `behavior` from platform-conditional to `'padding'` on both iOS and Android — `behavior: 'height'` conflicted with `softwareKeyboardLayoutMode: 'pan'` and caused visible jump

## Test plan
- [x] On Android: tap comment input in rating modal — keyboard should appear smoothly without screen jump
- [x] On Android/iOS: pan and zoom map — should hit bounds wall at Roskilde (west), Malmö (east), and north/south edges
- [x] zoom level 9 prevents zooming out beyond bounded region

🤖 Generated with [Claude Code](https://claude.com/claude-code)