### PR TITLE
feat: send/accept/decline friend requests + friends list (Phase 4)

### DIFF
--- a/app/(app)/(tabs)/__tests__/FriendsScreen.test.tsx
+++ b/app/(app)/(tabs)/__tests__/FriendsScreen.test.tsx
@@ -46,7 +46,7 @@ import FriendsScreen from '../friends'
 const EMPTY_FRIENDSHIPS = {
   friends: [],
   incomingRequests: [],
-  outgoingRequestMap: new Map<string, string>(),
+  outgoingRequestMap: new Map<string, string>() as ReadonlyMap<string, string>,
   pendingCount: 0,
   loading: false,
   error: null,
@@ -55,6 +55,8 @@ const EMPTY_FRIENDSHIPS = {
   acceptRequest: jest.fn(),
   declineRequest: jest.fn(),
   unfriend: jest.fn(),
+  getStatusForUser: jest.fn().mockReturnValue('none'),
+  getFriendshipId: jest.fn().mockReturnValue(null),
 }
 
 const IDLE_SEARCH = { results: [], state: 'idle' as const, error: null }

--- a/app/(app)/(tabs)/__tests__/FriendsScreen.test.tsx
+++ b/app/(app)/(tabs)/__tests__/FriendsScreen.test.tsx
@@ -2,9 +2,14 @@ import React from 'react'
 import { act, create, ReactTestInstance } from 'react-test-renderer'
 
 const mockUseUserSearch = jest.fn()
+const mockUseFriendships = jest.fn()
 
 jest.mock('@/hooks/useUserSearch', () => ({
   useUserSearch: (...args: unknown[]) => mockUseUserSearch(...args),
+}))
+
+jest.mock('@/hooks/useFriendships', () => ({
+  useFriendships: () => mockUseFriendships(),
 }))
 
 jest.mock('@/components/friends/UserSearchResult', () => {
@@ -16,16 +21,52 @@ jest.mock('@/components/friends/UserSearchResult', () => {
   }
 })
 
+jest.mock('@/components/friends/FriendRow', () => {
+  const React = require('react')
+  const { Text } = require('react-native')
+  return {
+    FriendRow: ({ entry }: { entry: { displayName: string } }) =>
+      React.createElement(Text, null, entry.displayName),
+  }
+})
+
+jest.mock('@/components/friends/IncomingRequestsSection', () => {
+  const React = require('react')
+  const { Text } = require('react-native')
+  return {
+    IncomingRequestsSection: ({ requests }: { requests: { displayName: string }[] }) =>
+      requests.length > 0
+        ? React.createElement(Text, null, `${requests.length} incoming request(s)`)
+        : null,
+  }
+})
+
 import FriendsScreen from '../friends'
+
+const EMPTY_FRIENDSHIPS = {
+  friends: [],
+  incomingRequests: [],
+  outgoingRequestMap: new Map<string, string>(),
+  pendingCount: 0,
+  loading: false,
+  error: null,
+  sendRequest: jest.fn(),
+  cancelRequest: jest.fn(),
+  acceptRequest: jest.fn(),
+  declineRequest: jest.fn(),
+  unfriend: jest.fn(),
+}
+
+const IDLE_SEARCH = { results: [], state: 'idle' as const, error: null }
 
 beforeEach(() => {
   jest.clearAllMocks()
+  mockUseFriendships.mockReturnValue(EMPTY_FRIENDSHIPS)
+  mockUseUserSearch.mockReturnValue(IDLE_SEARCH)
 })
 
 describe('FriendsScreen', () => {
   it('renders a search input', () => {
-    mockUseUserSearch.mockReturnValue({ results: [], state: 'idle', error: null })
-
     let root: ReturnType<typeof create>
     act(() => { root = create(<FriendsScreen />) })
 
@@ -33,19 +74,53 @@ describe('FriendsScreen', () => {
     expect(inputs.length).toBeGreaterThan(0)
   })
 
-  it('shows idle hint text when state is idle', () => {
-    mockUseUserSearch.mockReturnValue({ results: [], state: 'idle', error: null })
+  it('shows "Search for friends by name" hint when idle with no friends', () => {
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<FriendsScreen />) })
+
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+    expect(texts.some((n) => String(n.props.children) === 'Search for friends by name')).toBe(true)
+  })
+
+  it('renders friends list entries when friends exist', () => {
+    mockUseFriendships.mockReturnValue({
+      ...EMPTY_FRIENDSHIPS,
+      friends: [{ friendshipId: 'fs-1', userId: 'u1', displayName: 'Alice', avatarUrl: null }],
+    })
 
     let root: ReturnType<typeof create>
     act(() => { root = create(<FriendsScreen />) })
 
     const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    const hint = texts.find((n) => String(n.props.children) === 'Search for friends by name')
-    expect(hint).toBeDefined()
+    expect(texts.some((n) => String(n.props.children) === 'Alice')).toBe(true)
   })
 
-  it('shows ActivityIndicator when state is searching', () => {
-    mockUseUserSearch.mockReturnValue({ results: [], state: 'searching', error: null })
+  it('shows IncomingRequestsSection when incoming requests exist', () => {
+    mockUseFriendships.mockReturnValue({
+      ...EMPTY_FRIENDSHIPS,
+      incomingRequests: [
+        { friendshipId: 'fs-req-1', requesterId: 'u2', displayName: 'Bob', avatarUrl: null },
+      ],
+      pendingCount: 1,
+    })
+
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<FriendsScreen />) })
+
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+    expect(texts.some((n) => String(n.props.children) === '1 incoming request(s)')).toBe(true)
+  })
+
+  it('hides IncomingRequestsSection when no incoming requests', () => {
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<FriendsScreen />) })
+
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+    expect(texts.some((n) => String(n.props.children).includes('incoming request'))).toBe(false)
+  })
+
+  it('shows ActivityIndicator while friendships are loading', () => {
+    mockUseFriendships.mockReturnValue({ ...EMPTY_FRIENDSHIPS, loading: true })
 
     let root: ReturnType<typeof create>
     act(() => { root = create(<FriendsScreen />) })
@@ -54,43 +129,47 @@ describe('FriendsScreen', () => {
     expect(spinners.length).toBeGreaterThan(0)
   })
 
-  it('shows No users found when state is results with empty array', () => {
-    mockUseUserSearch.mockReturnValue({ results: [], state: 'results', error: null })
-
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendsScreen />) })
-
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    const msg = texts.find((n) => String(n.props.children) === 'No users found')
-    expect(msg).toBeDefined()
-  })
-
-  it('renders result rows when state is results with data', () => {
+  it('shows search results when query is non-empty', () => {
     mockUseUserSearch.mockReturnValue({
-      results: [
-        { id: 'u-1', display_name: 'Jane Doe', avatar_url: null },
-        { id: 'u-2', display_name: 'James Smith', avatar_url: null },
-      ],
       state: 'results',
+      results: [{ id: 'u-1', display_name: 'Jane Doe', avatar_url: null }],
       error: null,
     })
 
     let root: ReturnType<typeof create>
     act(() => { root = create(<FriendsScreen />) })
 
+    // Simulate typing in the search bar
+    const inputs = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'TextInput')
+    act(() => { inputs[0].props.onChangeText('jane') })
+
     const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
     expect(texts.some((n) => String(n.props.children) === 'Jane Doe')).toBe(true)
-    expect(texts.some((n) => String(n.props.children) === 'James Smith')).toBe(true)
   })
 
-  it('shows error text when state is error', () => {
-    mockUseUserSearch.mockReturnValue({ results: [], state: 'error', error: 'network failure' })
+  it('shows "No users found" when search returns empty results', () => {
+    mockUseUserSearch.mockReturnValue({ state: 'results', results: [], error: null })
 
     let root: ReturnType<typeof create>
     act(() => { root = create(<FriendsScreen />) })
 
+    const inputs = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'TextInput')
+    act(() => { inputs[0].props.onChangeText('xyz') })
+
     const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    const errMsg = texts.find((n) => String(n.props.children) === 'network failure')
-    expect(errMsg).toBeDefined()
+    expect(texts.some((n) => String(n.props.children) === 'No users found')).toBe(true)
+  })
+
+  it('shows error text when search state is error', () => {
+    mockUseUserSearch.mockReturnValue({ state: 'error', results: [], error: 'network failure' })
+
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<FriendsScreen />) })
+
+    const inputs = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'TextInput')
+    act(() => { inputs[0].props.onChangeText('a') })
+
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+    expect(texts.some((n) => String(n.props.children) === 'network failure')).toBe(true)
   })
 })

--- a/app/(app)/(tabs)/_layout.tsx
+++ b/app/(app)/(tabs)/_layout.tsx
@@ -1,7 +1,10 @@
 import { Tabs } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
+import { usePendingRequestCount } from '@/hooks/usePendingRequestCount'
 
 export default function TabLayout() {
+  const pendingCount = usePendingRequestCount()
+
   return (
     <Tabs screenOptions={{ tabBarActiveTintColor: '#0066FF' }}>
       <Tabs.Screen
@@ -23,6 +26,7 @@ export default function TabLayout() {
         name="friends"
         options={{
           title: 'Friends',
+          tabBarBadge: pendingCount > 0 ? pendingCount : undefined,
           tabBarIcon: ({ color }) => <Ionicons name="people" size={24} color={color} />,
         }}
       />

--- a/app/(app)/(tabs)/friends.tsx
+++ b/app/(app)/(tabs)/friends.tsx
@@ -5,14 +5,6 @@ import { useFriendships } from '@/hooks/useFriendships'
 import { UserSearchResult } from '@/components/friends/UserSearchResult'
 import { FriendRow } from '@/components/friends/FriendRow'
 import { IncomingRequestsSection } from '@/components/friends/IncomingRequestsSection'
-import { FriendshipStatus } from '@/lib/friendships'
-
-function getStatus(userId: string, friendships: ReturnType<typeof useFriendships>): FriendshipStatus {
-  if (friendships.friends.some((f) => f.userId === userId)) return 'accepted'
-  if (friendships.outgoingRequestMap.has(userId)) return 'pending_sent'
-  if (friendships.incomingRequests.some((r) => r.requesterId === userId)) return 'pending_received'
-  return 'none'
-}
 
 export default function FriendsScreen() {
   const [query, setQuery] = useState('')
@@ -99,22 +91,21 @@ export default function FriendsScreen() {
               data={search.results}
               keyExtractor={(item) => item.id}
               renderItem={({ item }) => {
-                const status = getStatus(item.id, friendships)
-                const friendshipId = friendships.outgoingRequestMap.get(item.id) ??
-                  friendships.incomingRequests.find((r) => r.requesterId === item.id)?.friendshipId ??
-                  friendships.friends.find((f) => f.userId === item.id)?.friendshipId ??
-                  null
+                const status = friendships.getStatusForUser(item.id)
+                const friendshipId = friendships.getFriendshipId(item.id)
                 return (
                   <UserSearchResult
                     user={item}
                     status={status}
                     onSendRequest={() => friendships.sendRequest(item.id)}
-                    onCancelRequest={() =>
-                      friendships.cancelRequest(friendshipId ?? '')
-                    }
-                    onAcceptRequest={() =>
-                      friendships.acceptRequest(friendshipId ?? '')
-                    }
+                    onCancelRequest={() => {
+                      if (!friendshipId) return Promise.resolve()
+                      return friendships.cancelRequest(friendshipId)
+                    }}
+                    onAcceptRequest={() => {
+                      if (!friendshipId) return Promise.resolve()
+                      return friendships.acceptRequest(friendshipId)
+                    }}
                   />
                 )
               }}

--- a/app/(app)/(tabs)/friends.tsx
+++ b/app/(app)/(tabs)/friends.tsx
@@ -1,11 +1,25 @@
 import { useState } from 'react'
 import { ActivityIndicator, FlatList, StyleSheet, Text, TextInput, View } from 'react-native'
 import { useUserSearch } from '@/hooks/useUserSearch'
+import { useFriendships } from '@/hooks/useFriendships'
 import { UserSearchResult } from '@/components/friends/UserSearchResult'
+import { FriendRow } from '@/components/friends/FriendRow'
+import { IncomingRequestsSection } from '@/components/friends/IncomingRequestsSection'
+import { FriendshipStatus } from '@/lib/friendships'
+
+function getStatus(userId: string, friendships: ReturnType<typeof useFriendships>): FriendshipStatus {
+  if (friendships.friends.some((f) => f.userId === userId)) return 'accepted'
+  if (friendships.outgoingRequestMap.has(userId)) return 'pending_sent'
+  if (friendships.incomingRequests.some((r) => r.requesterId === userId)) return 'pending_received'
+  return 'none'
+}
 
 export default function FriendsScreen() {
   const [query, setQuery] = useState('')
   const search = useUserSearch(query)
+  const friendships = useFriendships()
+
+  const isSearching = query.trim().length > 0
 
   return (
     <View style={styles.container}>
@@ -22,37 +36,98 @@ export default function FriendsScreen() {
         />
       </View>
 
-      {search.state === 'idle' && (
-        <View style={styles.center}>
-          <Text style={styles.hint}>Search for friends by name</Text>
-        </View>
+      {/* Idle view: incoming requests + friends list */}
+      {!isSearching && (
+        <>
+          <IncomingRequestsSection
+            requests={friendships.incomingRequests}
+            onAccept={friendships.acceptRequest}
+            onDecline={friendships.declineRequest}
+          />
+
+          {friendships.friends.length > 0 ? (
+            <FlatList
+              data={friendships.friends}
+              keyExtractor={(item) => item.friendshipId}
+              renderItem={({ item }) => (
+                <FriendRow
+                  entry={item}
+                  onUnfriend={() => friendships.unfriend(item.friendshipId)}
+                />
+              )}
+              contentContainerStyle={styles.list}
+            />
+          ) : (
+            !friendships.loading && (
+              <View style={styles.center}>
+                <Text style={styles.hint}>Search for friends by name</Text>
+              </View>
+            )
+          )}
+
+          {friendships.loading && (
+            <View style={styles.center}>
+              <ActivityIndicator size="small" color="#131313" />
+            </View>
+          )}
+
+          {friendships.error && !friendships.loading && (
+            <View style={styles.center}>
+              <Text style={styles.errorText}>{friendships.error}</Text>
+            </View>
+          )}
+        </>
       )}
 
-      {search.state === 'searching' && (
-        <View style={styles.center}>
-          <ActivityIndicator size="small" color="#131313" />
-        </View>
-      )}
+      {/* Search results */}
+      {isSearching && (
+        <>
+          {search.state === 'searching' && (
+            <View style={styles.center}>
+              <ActivityIndicator size="small" color="#131313" />
+            </View>
+          )}
 
-      {search.state === 'results' && search.results.length === 0 && (
-        <View style={styles.center}>
-          <Text style={styles.hint}>No users found</Text>
-        </View>
-      )}
+          {search.state === 'results' && search.results.length === 0 && (
+            <View style={styles.center}>
+              <Text style={styles.hint}>No users found</Text>
+            </View>
+          )}
 
-      {search.state === 'results' && search.results.length > 0 && (
-        <FlatList
-          data={search.results}
-          keyExtractor={(item) => item.id}
-          renderItem={({ item }) => <UserSearchResult user={item} />}
-          contentContainerStyle={styles.list}
-        />
-      )}
+          {search.state === 'results' && search.results.length > 0 && (
+            <FlatList
+              data={search.results}
+              keyExtractor={(item) => item.id}
+              renderItem={({ item }) => {
+                const status = getStatus(item.id, friendships)
+                const friendshipId = friendships.outgoingRequestMap.get(item.id) ??
+                  friendships.incomingRequests.find((r) => r.requesterId === item.id)?.friendshipId ??
+                  friendships.friends.find((f) => f.userId === item.id)?.friendshipId ??
+                  null
+                return (
+                  <UserSearchResult
+                    user={item}
+                    status={status}
+                    onSendRequest={() => friendships.sendRequest(item.id)}
+                    onCancelRequest={() =>
+                      friendships.cancelRequest(friendshipId ?? '')
+                    }
+                    onAcceptRequest={() =>
+                      friendships.acceptRequest(friendshipId ?? '')
+                    }
+                  />
+                )
+              }}
+              contentContainerStyle={styles.list}
+            />
+          )}
 
-      {search.state === 'error' && (
-        <View style={styles.center}>
-          <Text style={styles.errorText}>{search.error}</Text>
-        </View>
+          {search.state === 'error' && (
+            <View style={styles.center}>
+              <Text style={styles.errorText}>{search.error}</Text>
+            </View>
+          )}
+        </>
       )}
     </View>
   )

--- a/components/friends/FriendRequestRow.tsx
+++ b/components/friends/FriendRequestRow.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react'
+import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { UserAvatar } from '@/components/UserAvatar'
+import { RequestEntry } from '@/hooks/useFriendships'
+
+interface Props {
+  entry: RequestEntry
+  onAccept: () => Promise<void>
+  onDecline: () => Promise<void>
+}
+
+export function FriendRequestRow({ entry, onAccept, onDecline }: Props) {
+  const [busy, setBusy] = useState<'accept' | 'decline' | null>(null)
+
+  const handleAccept = async () => {
+    if (busy) return
+    setBusy('accept')
+    try {
+      await onAccept()
+    } catch (err) {
+      console.error('FriendRequestRow accept:', err)
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const handleDecline = async () => {
+    if (busy) return
+    setBusy('decline')
+    try {
+      await onDecline()
+    } catch (err) {
+      console.error('FriendRequestRow decline:', err)
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <View style={styles.row}>
+      <UserAvatar
+        displayName={entry.displayName}
+        avatarUrl={entry.avatarUrl}
+        size={40}
+        borderWidth={0}
+      />
+      <View style={styles.info}>
+        <Text style={styles.name}>{entry.displayName}</Text>
+      </View>
+      <TouchableOpacity
+        style={styles.declineButton}
+        onPress={handleDecline}
+        disabled={busy !== null}
+        activeOpacity={0.8}
+      >
+        {busy === 'decline' ? (
+          <ActivityIndicator size="small" color="#666" />
+        ) : (
+          <Text style={styles.declineText}>Decline</Text>
+        )}
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={styles.acceptButton}
+        onPress={handleAccept}
+        disabled={busy !== null}
+        activeOpacity={0.8}
+      >
+        {busy === 'accept' ? (
+          <ActivityIndicator size="small" color="#fff" />
+        ) : (
+          <Text style={styles.acceptText}>Accept</Text>
+        )}
+      </TouchableOpacity>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  info: {
+    flex: 1,
+  },
+  name: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#131313',
+  },
+  declineButton: {
+    borderWidth: 1,
+    borderColor: '#d1d1d1',
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+    borderRadius: 10,
+    minWidth: 68,
+    alignItems: 'center',
+  },
+  declineText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#666',
+  },
+  acceptButton: {
+    backgroundColor: '#131313',
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+    borderRadius: 10,
+    minWidth: 68,
+    alignItems: 'center',
+  },
+  acceptText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#fff',
+  },
+})

--- a/components/friends/FriendRequestRow.tsx
+++ b/components/friends/FriendRequestRow.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react'
-import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { ActivityIndicator, Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { UserAvatar } from '@/components/UserAvatar'
-import { RequestEntry } from '@/hooks/useFriendships'
+import { IncomingRequestEntry } from '@/hooks/useFriendships'
 
 interface Props {
-  entry: RequestEntry
+  entry: IncomingRequestEntry
   onAccept: () => Promise<void>
   onDecline: () => Promise<void>
 }
@@ -19,6 +19,7 @@ export function FriendRequestRow({ entry, onAccept, onDecline }: Props) {
       await onAccept()
     } catch (err) {
       console.error('FriendRequestRow accept:', err)
+      Alert.alert('Error', 'Could not accept request. Try again.')
     } finally {
       setBusy(null)
     }
@@ -31,6 +32,7 @@ export function FriendRequestRow({ entry, onAccept, onDecline }: Props) {
       await onDecline()
     } catch (err) {
       console.error('FriendRequestRow decline:', err)
+      Alert.alert('Error', 'Could not decline request. Try again.')
     } finally {
       setBusy(null)
     }

--- a/components/friends/FriendRow.tsx
+++ b/components/friends/FriendRow.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import {
   ActivityIndicator,
+  Alert,
   Modal,
   Pressable,
   StyleSheet,
@@ -13,7 +14,7 @@ import { FriendEntry } from '@/hooks/useFriendships'
 
 interface Props {
   entry: FriendEntry
-  onUnfriend: () => void
+  onUnfriend: () => Promise<void>
 }
 
 export function FriendRow({ entry, onUnfriend }: Props) {
@@ -23,8 +24,11 @@ export function FriendRow({ entry, onUnfriend }: Props) {
   const handleConfirmUnfriend = async () => {
     setBusy(true)
     try {
-      onUnfriend()
+      await onUnfriend()
       setModalVisible(false)
+    } catch (err) {
+      console.error('FriendRow unfriend:', err)
+      Alert.alert('Error', 'Could not unfriend. Try again.')
     } finally {
       setBusy(false)
     }

--- a/components/friends/FriendRow.tsx
+++ b/components/friends/FriendRow.tsx
@@ -1,0 +1,170 @@
+import { useState } from 'react'
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native'
+import { UserAvatar } from '@/components/UserAvatar'
+import { FriendEntry } from '@/hooks/useFriendships'
+
+interface Props {
+  entry: FriendEntry
+  onUnfriend: () => void
+}
+
+export function FriendRow({ entry, onUnfriend }: Props) {
+  const [modalVisible, setModalVisible] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  const handleConfirmUnfriend = async () => {
+    setBusy(true)
+    try {
+      onUnfriend()
+      setModalVisible(false)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <>
+      <View style={styles.row}>
+        <UserAvatar
+          displayName={entry.displayName}
+          avatarUrl={entry.avatarUrl}
+          size={40}
+          borderWidth={0}
+        />
+        <View style={styles.info}>
+          <Text style={styles.name}>{entry.displayName}</Text>
+        </View>
+        <TouchableOpacity
+          onPress={() => setModalVisible(true)}
+          hitSlop={8}
+          accessibilityLabel="Friend options"
+        >
+          <Text style={styles.menu}>•••</Text>
+        </TouchableOpacity>
+      </View>
+
+      <Modal
+        visible={modalVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => { if (!busy) setModalVisible(false) }}
+      >
+        <Pressable style={styles.backdrop} onPress={() => { if (!busy) setModalVisible(false) }} />
+        <View style={styles.overlay}>
+          <View style={styles.card}>
+            <Text style={styles.title}>Unfriend {entry.displayName}?</Text>
+            <Text style={styles.subtitle}>They won't be notified.</Text>
+
+            <TouchableOpacity
+              style={[styles.button, styles.destructiveButton]}
+              onPress={handleConfirmUnfriend}
+              disabled={busy}
+              activeOpacity={0.85}
+            >
+              {busy ? (
+                <ActivityIndicator color="#fff" size="small" />
+              ) : (
+                <Text style={styles.destructiveText}>Unfriend</Text>
+              )}
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={[styles.button, styles.cancelButton]}
+              onPress={() => setModalVisible(false)}
+              disabled={busy}
+              activeOpacity={0.85}
+            >
+              <Text style={styles.cancelText}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  info: {
+    flex: 1,
+  },
+  name: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#131313',
+  },
+  menu: {
+    fontSize: 16,
+    color: '#666',
+    letterSpacing: 1,
+  },
+  overlay: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+  },
+  card: {
+    width: '80%',
+    backgroundColor: '#FAFAF8',
+    borderRadius: 24,
+    padding: 24,
+    gap: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.15,
+    shadowRadius: 24,
+    elevation: 12,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: '#131313',
+    letterSpacing: -0.3,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#AAAAAA',
+    fontWeight: '400',
+    marginBottom: 4,
+  },
+  button: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 14,
+    paddingVertical: 14,
+  },
+  destructiveButton: {
+    backgroundColor: '#E51E1E',
+  },
+  destructiveText: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#fff',
+  },
+  cancelButton: {
+    backgroundColor: '#F2F2F2',
+  },
+  cancelText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#131313',
+  },
+})

--- a/components/friends/IncomingRequestsSection.tsx
+++ b/components/friends/IncomingRequestsSection.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react'
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { FriendRequestRow } from '@/components/friends/FriendRequestRow'
-import { RequestEntry } from '@/hooks/useFriendships'
+import { IncomingRequestEntry } from '@/hooks/useFriendships'
 
 const INITIAL_VISIBLE = 3
 
 interface Props {
-  requests: RequestEntry[]
+  requests: IncomingRequestEntry[]
   onAccept: (friendshipId: string) => Promise<void>
   onDecline: (friendshipId: string) => Promise<void>
 }

--- a/components/friends/IncomingRequestsSection.tsx
+++ b/components/friends/IncomingRequestsSection.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { FriendRequestRow } from '@/components/friends/FriendRequestRow'
+import { RequestEntry } from '@/hooks/useFriendships'
+
+const INITIAL_VISIBLE = 3
+
+interface Props {
+  requests: RequestEntry[]
+  onAccept: (friendshipId: string) => Promise<void>
+  onDecline: (friendshipId: string) => Promise<void>
+}
+
+export function IncomingRequestsSection({ requests, onAccept, onDecline }: Props) {
+  const [expanded, setExpanded] = useState(false)
+
+  if (requests.length === 0) return null
+
+  const visible = expanded ? requests : requests.slice(0, INITIAL_VISIBLE)
+  const hiddenCount = requests.length - INITIAL_VISIBLE
+
+  return (
+    <View style={styles.section}>
+      {visible.map((entry) => (
+        <FriendRequestRow
+          key={entry.friendshipId}
+          entry={entry}
+          onAccept={() => onAccept(entry.friendshipId)}
+          onDecline={() => onDecline(entry.friendshipId)}
+        />
+      ))}
+      {!expanded && hiddenCount > 0 && (
+        <TouchableOpacity
+          style={styles.showMore}
+          onPress={() => setExpanded(true)}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.showMoreText}>View {hiddenCount} more</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginBottom: 8,
+  },
+  showMore: {
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  showMoreText: {
+    fontSize: 14,
+    color: '#0066FF',
+    fontWeight: '600',
+  },
+})

--- a/components/friends/UserSearchResult.tsx
+++ b/components/friends/UserSearchResult.tsx
@@ -1,15 +1,65 @@
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { useState } from 'react'
+import { ActivityIndicator, Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { UserAvatar } from '@/components/UserAvatar'
 import { SearchUser } from '@/lib/friends'
+import { FriendshipStatus } from '@/lib/friendships'
 
 interface Props {
   user: SearchUser
+  status: FriendshipStatus
+  onSendRequest: () => Promise<void>
+  onCancelRequest: () => Promise<void>
+  onAcceptRequest: () => Promise<void>
 }
 
-export function UserSearchResult({ user }: Props) {
-  const handleAddFriend = () => {
-    console.log('[Friend stub]', user.id, user.display_name)
+export function UserSearchResult({ user, status, onSendRequest, onCancelRequest, onAcceptRequest }: Props) {
+  const [busy, setBusy] = useState(false)
+
+  const handlePress = async () => {
+    if (busy) return
+
+    if (status === 'none') {
+      setBusy(true)
+      try {
+        await onSendRequest()
+      } catch (err) {
+        console.error('UserSearchResult sendRequest:', err)
+      } finally {
+        setBusy(false)
+      }
+      return
+    }
+
+    if (status === 'pending_sent') {
+      Alert.alert('Cancel request?', '', [
+        { text: 'Cancel request', style: 'destructive', onPress: async () => {
+          setBusy(true)
+          try {
+            await onCancelRequest()
+          } catch (err) {
+            console.error('UserSearchResult cancelRequest:', err)
+          } finally {
+            setBusy(false)
+          }
+        }},
+        { text: 'Keep', style: 'cancel' },
+      ])
+      return
+    }
+
+    if (status === 'pending_received') {
+      setBusy(true)
+      try {
+        await onAcceptRequest()
+      } catch (err) {
+        console.error('UserSearchResult acceptRequest:', err)
+      } finally {
+        setBusy(false)
+      }
+    }
   }
+
+  const buttonConfig = getButtonConfig(status)
 
   return (
     <View style={styles.row}>
@@ -22,11 +72,60 @@ export function UserSearchResult({ user }: Props) {
       <View style={styles.info}>
         <Text style={styles.name}>{user.display_name}</Text>
       </View>
-      <TouchableOpacity style={styles.addButton} onPress={handleAddFriend} activeOpacity={0.8}>
-        <Text style={styles.addButtonText}>Add Friend</Text>
+      <TouchableOpacity
+        style={[styles.button, buttonConfig.buttonStyle]}
+        onPress={handlePress}
+        disabled={busy || status === 'accepted'}
+        activeOpacity={0.8}
+      >
+        {busy ? (
+          <ActivityIndicator size="small" color={buttonConfig.spinnerColor} />
+        ) : (
+          <Text style={[styles.buttonText, buttonConfig.textStyle]}>{buttonConfig.label}</Text>
+        )}
       </TouchableOpacity>
     </View>
   )
+}
+
+type ButtonConfig = {
+  label: string
+  buttonStyle: object
+  textStyle: object
+  spinnerColor: string
+}
+
+function getButtonConfig(status: FriendshipStatus): ButtonConfig {
+  switch (status) {
+    case 'none':
+      return {
+        label: 'Add Friend',
+        buttonStyle: styles.buttonDark,
+        textStyle: styles.textLight,
+        spinnerColor: '#fff',
+      }
+    case 'pending_sent':
+      return {
+        label: 'Pending',
+        buttonStyle: styles.buttonGrey,
+        textStyle: styles.textDark,
+        spinnerColor: '#131313',
+      }
+    case 'pending_received':
+      return {
+        label: 'Accept',
+        buttonStyle: styles.buttonBlue,
+        textStyle: styles.textLight,
+        spinnerColor: '#fff',
+      }
+    case 'accepted':
+      return {
+        label: 'Friends',
+        buttonStyle: styles.buttonOutline,
+        textStyle: styles.textMuted,
+        spinnerColor: '#999',
+      }
+  }
 }
 
 const styles = StyleSheet.create({
@@ -45,15 +144,37 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#131313',
   },
-  addButton: {
-    backgroundColor: '#131313',
+  button: {
     paddingHorizontal: 14,
     paddingVertical: 7,
     borderRadius: 10,
+    minWidth: 90,
+    alignItems: 'center',
   },
-  addButtonText: {
-    color: '#ffffff',
+  buttonText: {
     fontSize: 13,
     fontWeight: '600',
+  },
+  buttonDark: {
+    backgroundColor: '#131313',
+  },
+  buttonGrey: {
+    backgroundColor: '#e5e5e5',
+  },
+  buttonBlue: {
+    backgroundColor: '#0066FF',
+  },
+  buttonOutline: {
+    borderWidth: 1,
+    borderColor: '#d1d1d1',
+  },
+  textLight: {
+    color: '#fff',
+  },
+  textDark: {
+    color: '#131313',
+  },
+  textMuted: {
+    color: '#999',
   },
 })

--- a/components/friends/UserSearchResult.tsx
+++ b/components/friends/UserSearchResult.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { ActivityIndicator, Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { ActivityIndicator, Alert, Modal, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { UserAvatar } from '@/components/UserAvatar'
 import { SearchUser } from '@/lib/friends'
 import { FriendshipStatus } from '@/lib/friendships'
@@ -14,6 +14,7 @@ interface Props {
 
 export function UserSearchResult({ user, status, onSendRequest, onCancelRequest, onAcceptRequest }: Props) {
   const [busy, setBusy] = useState(false)
+  const [cancelModalVisible, setCancelModalVisible] = useState(false)
 
   const handlePress = async () => {
     if (busy) return
@@ -24,6 +25,7 @@ export function UserSearchResult({ user, status, onSendRequest, onCancelRequest,
         await onSendRequest()
       } catch (err) {
         console.error('UserSearchResult sendRequest:', err)
+        Alert.alert('Error', 'Could not send friend request. Try again.')
       } finally {
         setBusy(false)
       }
@@ -31,19 +33,7 @@ export function UserSearchResult({ user, status, onSendRequest, onCancelRequest,
     }
 
     if (status === 'pending_sent') {
-      Alert.alert('Cancel request?', '', [
-        { text: 'Cancel request', style: 'destructive', onPress: async () => {
-          setBusy(true)
-          try {
-            await onCancelRequest()
-          } catch (err) {
-            console.error('UserSearchResult cancelRequest:', err)
-          } finally {
-            setBusy(false)
-          }
-        }},
-        { text: 'Keep', style: 'cancel' },
-      ])
+      setCancelModalVisible(true)
       return
     }
 
@@ -53,38 +43,91 @@ export function UserSearchResult({ user, status, onSendRequest, onCancelRequest,
         await onAcceptRequest()
       } catch (err) {
         console.error('UserSearchResult acceptRequest:', err)
+        Alert.alert('Error', 'Could not accept request. Try again.')
       } finally {
         setBusy(false)
       }
     }
   }
 
+  const handleConfirmCancel = async () => {
+    setBusy(true)
+    try {
+      await onCancelRequest()
+      setCancelModalVisible(false)
+    } catch (err) {
+      console.error('UserSearchResult cancelRequest:', err)
+      Alert.alert('Error', 'Could not cancel request. Try again.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const buttonConfig = getButtonConfig(status)
 
   return (
-    <View style={styles.row}>
-      <UserAvatar
-        displayName={user.display_name}
-        avatarUrl={user.avatar_url}
-        size={40}
-        borderWidth={0}
-      />
-      <View style={styles.info}>
-        <Text style={styles.name}>{user.display_name}</Text>
+    <>
+      <View style={styles.row}>
+        <UserAvatar
+          displayName={user.display_name}
+          avatarUrl={user.avatar_url}
+          size={40}
+          borderWidth={0}
+        />
+        <View style={styles.info}>
+          <Text style={styles.name}>{user.display_name}</Text>
+        </View>
+        <TouchableOpacity
+          style={[styles.button, buttonConfig.buttonStyle]}
+          onPress={handlePress}
+          disabled={busy || status === 'accepted'}
+          activeOpacity={0.8}
+        >
+          {busy ? (
+            <ActivityIndicator size="small" color={buttonConfig.spinnerColor} />
+          ) : (
+            <Text style={[styles.buttonText, buttonConfig.textStyle]}>{buttonConfig.label}</Text>
+          )}
+        </TouchableOpacity>
       </View>
-      <TouchableOpacity
-        style={[styles.button, buttonConfig.buttonStyle]}
-        onPress={handlePress}
-        disabled={busy || status === 'accepted'}
-        activeOpacity={0.8}
+
+      <Modal
+        visible={cancelModalVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => { if (!busy) setCancelModalVisible(false) }}
       >
-        {busy ? (
-          <ActivityIndicator size="small" color={buttonConfig.spinnerColor} />
-        ) : (
-          <Text style={[styles.buttonText, buttonConfig.textStyle]}>{buttonConfig.label}</Text>
-        )}
-      </TouchableOpacity>
-    </View>
+        <Pressable style={styles.backdrop} onPress={() => { if (!busy) setCancelModalVisible(false) }} />
+        <View style={styles.overlay}>
+          <View style={styles.card}>
+            <Text style={styles.title}>Cancel request?</Text>
+            <Text style={styles.subtitle}>{user.display_name} won't be notified.</Text>
+
+            <TouchableOpacity
+              style={[styles.modalButton, styles.destructiveButton]}
+              onPress={handleConfirmCancel}
+              disabled={busy}
+              activeOpacity={0.85}
+            >
+              {busy ? (
+                <ActivityIndicator color="#fff" size="small" />
+              ) : (
+                <Text style={styles.destructiveText}>Cancel request</Text>
+              )}
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={[styles.modalButton, styles.cancelButton]}
+              onPress={() => setCancelModalVisible(false)}
+              disabled={busy}
+              activeOpacity={0.85}
+            >
+              <Text style={styles.cancelText}>Keep</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+    </>
   )
 }
 
@@ -129,6 +172,61 @@ function getButtonConfig(status: FriendshipStatus): ButtonConfig {
 }
 
 const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+  },
+  card: {
+    width: '80%',
+    backgroundColor: '#FAFAF8',
+    borderRadius: 24,
+    padding: 24,
+    gap: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.15,
+    shadowRadius: 24,
+    elevation: 12,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: '#131313',
+    letterSpacing: -0.3,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#AAAAAA',
+    fontWeight: '400',
+    marginBottom: 4,
+  },
+  modalButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 14,
+    paddingVertical: 14,
+  },
+  destructiveButton: {
+    backgroundColor: '#E51E1E',
+  },
+  destructiveText: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#fff',
+  },
+  cancelButton: {
+    backgroundColor: '#F2F2F2',
+  },
+  cancelText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#131313',
+  },
   row: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/components/friends/__tests__/FriendRequestRow.test.tsx
+++ b/components/friends/__tests__/FriendRequestRow.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { TouchableOpacity } from 'react-native'
+import { act, create, ReactTestInstance } from 'react-test-renderer'
+import { FriendRequestRow } from '../FriendRequestRow'
+
+const MOCK_ENTRY = {
+  friendshipId: 'fs-req-1',
+  requesterId: 'user-requester',
+  displayName: 'Sam Lee',
+  avatarUrl: null,
+}
+
+function findButtonWithLabel(root: ReturnType<typeof create>, label: string) {
+  const touchables = root.root.findAllByType(TouchableOpacity)
+  return touchables.find((n) => {
+    const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
+    return texts.some((t) => String(t.props.children) === label)
+  })
+}
+
+describe('FriendRequestRow', () => {
+  it('renders the display name', () => {
+    const onAccept = jest.fn().mockResolvedValue(undefined)
+    const onDecline = jest.fn().mockResolvedValue(undefined)
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />) })
+
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+    expect(texts.some((n) => String(n.props.children) === 'Sam Lee')).toBe(true)
+  })
+
+  it('calls onAccept when Accept is pressed', async () => {
+    const onAccept = jest.fn().mockResolvedValue(undefined)
+    const onDecline = jest.fn().mockResolvedValue(undefined)
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />) })
+
+    await act(async () => {
+      findButtonWithLabel(root!, 'Accept')!.props.onPress()
+    })
+
+    expect(onAccept).toHaveBeenCalled()
+    expect(onDecline).not.toHaveBeenCalled()
+  })
+
+  it('calls onDecline when Decline is pressed', async () => {
+    const onAccept = jest.fn().mockResolvedValue(undefined)
+    const onDecline = jest.fn().mockResolvedValue(undefined)
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />) })
+
+    await act(async () => {
+      findButtonWithLabel(root!, 'Decline')!.props.onPress()
+    })
+
+    expect(onDecline).toHaveBeenCalled()
+    expect(onAccept).not.toHaveBeenCalled()
+  })
+
+  it('shows ActivityIndicator while accept is in progress', async () => {
+    let resolveAccept!: () => void
+    const onAccept = jest.fn().mockReturnValue(new Promise<void>((r) => { resolveAccept = r }))
+    const onDecline = jest.fn().mockResolvedValue(undefined)
+
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />) })
+
+    act(() => { findButtonWithLabel(root!, 'Accept')!.props.onPress() })
+
+    const spinners = root!.root.findAll(
+      (n: ReactTestInstance) => (n.type as string) === 'ActivityIndicator'
+    )
+    expect(spinners.length).toBeGreaterThan(0)
+
+    await act(async () => { resolveAccept() })
+  })
+
+  it('shows ActivityIndicator while decline is in progress', async () => {
+    let resolveDecline!: () => void
+    const onAccept = jest.fn().mockResolvedValue(undefined)
+    const onDecline = jest.fn().mockReturnValue(new Promise<void>((r) => { resolveDecline = r }))
+
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />) })
+
+    act(() => { findButtonWithLabel(root!, 'Decline')!.props.onPress() })
+
+    const spinners = root!.root.findAll(
+      (n: ReactTestInstance) => (n.type as string) === 'ActivityIndicator'
+    )
+    expect(spinners.length).toBeGreaterThan(0)
+
+    await act(async () => { resolveDecline() })
+  })
+})

--- a/components/friends/__tests__/FriendRow.test.tsx
+++ b/components/friends/__tests__/FriendRow.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import { TouchableOpacity } from 'react-native'
+import { act, create, ReactTestInstance } from 'react-test-renderer'
+import { FriendRow } from '../FriendRow'
+
+const MOCK_ENTRY = {
+  friendshipId: 'fs-1',
+  userId: 'user-abc',
+  displayName: 'Alex Kim',
+  avatarUrl: null,
+}
+
+describe('FriendRow', () => {
+  it('renders the display name', () => {
+    const onUnfriend = jest.fn()
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
+
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+    expect(texts.some((n) => String(n.props.children) === 'Alex Kim')).toBe(true)
+  })
+
+  it('renders initials avatar fallback', () => {
+    const onUnfriend = jest.fn()
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
+
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+    const initialsNode = texts.find((n) => String(n.props.children) === 'AK')
+    expect(initialsNode).toBeDefined()
+  })
+
+  it('pressing "..." opens the in-app confirmation modal', () => {
+    const onUnfriend = jest.fn()
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
+
+    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const menuBtn = touchables.find((n) => n.props.accessibilityLabel === 'Friend options')
+    act(() => { menuBtn!.props.onPress() })
+
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+    expect(texts.some((n) => String(n.props.children).startsWith('Unfriend'))).toBe(true)
+  })
+
+  it('calls onUnfriend when Unfriend button in modal is pressed', async () => {
+    const onUnfriend = jest.fn()
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
+
+    // Open modal
+    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const menuBtn = touchables.find((n) => n.props.accessibilityLabel === 'Friend options')
+    act(() => { menuBtn!.props.onPress() })
+
+    // Press Unfriend button
+    const allTouchables = root!.root.findAllByType(TouchableOpacity)
+    const unfriendBtn = allTouchables.find((n) => {
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
+      return texts.some((t) => String(t.props.children) === 'Unfriend')
+    })
+
+    await act(async () => { unfriendBtn!.props.onPress() })
+
+    expect(onUnfriend).toHaveBeenCalled()
+  })
+
+  it('Cancel button closes the modal without calling onUnfriend', () => {
+    const onUnfriend = jest.fn()
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
+
+    // Open modal
+    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const menuBtn = touchables.find((n) => n.props.accessibilityLabel === 'Friend options')
+    act(() => { menuBtn!.props.onPress() })
+
+    // Press Cancel
+    const allTouchables = root!.root.findAllByType(TouchableOpacity)
+    const cancelBtn = allTouchables.find((n) => {
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
+      return texts.some((t) => String(t.props.children) === 'Cancel')
+    })
+    act(() => { cancelBtn!.props.onPress() })
+
+    expect(onUnfriend).not.toHaveBeenCalled()
+  })
+})

--- a/components/friends/__tests__/FriendRow.test.tsx
+++ b/components/friends/__tests__/FriendRow.test.tsx
@@ -12,7 +12,7 @@ const MOCK_ENTRY = {
 
 describe('FriendRow', () => {
   it('renders the display name', () => {
-    const onUnfriend = jest.fn()
+    const onUnfriend = jest.fn().mockResolvedValue(undefined)
     let root: ReturnType<typeof create>
     act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
 
@@ -21,7 +21,7 @@ describe('FriendRow', () => {
   })
 
   it('renders initials avatar fallback', () => {
-    const onUnfriend = jest.fn()
+    const onUnfriend = jest.fn().mockResolvedValue(undefined)
     let root: ReturnType<typeof create>
     act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
 
@@ -31,7 +31,7 @@ describe('FriendRow', () => {
   })
 
   it('pressing "..." opens the in-app confirmation modal', () => {
-    const onUnfriend = jest.fn()
+    const onUnfriend = jest.fn().mockResolvedValue(undefined)
     let root: ReturnType<typeof create>
     act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
 
@@ -44,7 +44,7 @@ describe('FriendRow', () => {
   })
 
   it('calls onUnfriend when Unfriend button in modal is pressed', async () => {
-    const onUnfriend = jest.fn()
+    const onUnfriend = jest.fn().mockResolvedValue(undefined)
     let root: ReturnType<typeof create>
     act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
 
@@ -66,7 +66,7 @@ describe('FriendRow', () => {
   })
 
   it('Cancel button closes the modal without calling onUnfriend', () => {
-    const onUnfriend = jest.fn()
+    const onUnfriend = jest.fn().mockResolvedValue(undefined)
     let root: ReturnType<typeof create>
     act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
 

--- a/components/friends/__tests__/IncomingRequestsSection.test.tsx
+++ b/components/friends/__tests__/IncomingRequestsSection.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react'
+import { TouchableOpacity, View } from 'react-native'
+import { act, create, ReactTestInstance } from 'react-test-renderer'
+import { IncomingRequestsSection } from '../IncomingRequestsSection'
+
+jest.mock('../FriendRequestRow', () => {
+  const React = require('react')
+  const { View, Text } = require('react-native')
+  return {
+    FriendRequestRow: ({ entry }: { entry: { displayName: string } }) =>
+      React.createElement(View, { testID: 'request-row' },
+        React.createElement(Text, null, entry.displayName)
+      ),
+  }
+})
+
+function makeRequests(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    friendshipId: `fs-${i}`,
+    requesterId: `user-${i}`,
+    displayName: `User ${i}`,
+    avatarUrl: null,
+  }))
+}
+
+const onAccept = jest.fn().mockResolvedValue(undefined)
+const onDecline = jest.fn().mockResolvedValue(undefined)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+function countRows(root: ReturnType<typeof create>) {
+  // Only count View-type nodes with testID to avoid deep duplicates
+  return root.root.findAll(
+    (n: ReactTestInstance) => n.type === View && n.props.testID === 'request-row'
+  ).length
+}
+
+function getTextContent(root: ReturnType<typeof create>): string[] {
+  return root.root
+    .findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+    .map((n) => {
+      const c = n.props.children
+      return Array.isArray(c) ? c.join('') : String(c)
+    })
+}
+
+describe('IncomingRequestsSection', () => {
+  it('returns null when requests is empty', () => {
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <IncomingRequestsSection requests={[]} onAccept={onAccept} onDecline={onDecline} />
+      )
+    })
+    expect(root!.toJSON()).toBeNull()
+  })
+
+  it('renders all entries when there are 3 or fewer requests', () => {
+    const requests = makeRequests(3)
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <IncomingRequestsSection requests={requests} onAccept={onAccept} onDecline={onDecline} />
+      )
+    })
+
+    expect(countRows(root!)).toBe(3)
+
+    // No "View more" button
+    const touchables = root!.root.findAllByType(TouchableOpacity)
+    expect(touchables).toHaveLength(0)
+  })
+
+  it('shows only first 3 entries when there are more than 3', () => {
+    const requests = makeRequests(5)
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <IncomingRequestsSection requests={requests} onAccept={onAccept} onDecline={onDecline} />
+      )
+    })
+
+    expect(countRows(root!)).toBe(3)
+  })
+
+  it('shows "View N more" button with correct count', () => {
+    const requests = makeRequests(6)
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <IncomingRequestsSection requests={requests} onAccept={onAccept} onDecline={onDecline} />
+      )
+    })
+
+    const texts = getTextContent(root!)
+    expect(texts.some((t) => t === 'View 3 more')).toBe(true)
+  })
+
+  it('pressing "View N more" shows all entries', () => {
+    const requests = makeRequests(5)
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <IncomingRequestsSection requests={requests} onAccept={onAccept} onDecline={onDecline} />
+      )
+    })
+
+    // Initially 3 visible
+    expect(countRows(root!)).toBe(3)
+
+    // Press "View more"
+    const touchable = root!.root.findAllByType(TouchableOpacity)[0]
+    act(() => { touchable.props.onPress() })
+
+    // Now all 5 visible
+    expect(countRows(root!)).toBe(5)
+
+    // "View more" button is gone
+    const touchables = root!.root.findAllByType(TouchableOpacity)
+    expect(touchables).toHaveLength(0)
+  })
+})

--- a/components/friends/__tests__/UserSearchResult.test.tsx
+++ b/components/friends/__tests__/UserSearchResult.test.tsx
@@ -1,57 +1,137 @@
 import React from 'react'
-import { TouchableOpacity } from 'react-native'
+import { TouchableOpacity, Alert } from 'react-native'
 import { act, create, ReactTestInstance } from 'react-test-renderer'
 import { UserSearchResult } from '../UserSearchResult'
 
-const MOCK_USER = {
-  id: 'user-123',
-  display_name: 'Jane Doe',
-  avatar_url: null,
+const MOCK_USER = { id: 'user-123', display_name: 'Jane Doe', avatar_url: null }
+
+const noop = () => Promise.resolve()
+
+function makeProps(status: 'none' | 'pending_sent' | 'pending_received' | 'accepted') {
+  return {
+    user: MOCK_USER,
+    status,
+    onSendRequest: jest.fn().mockResolvedValue(undefined),
+    onCancelRequest: jest.fn().mockResolvedValue(undefined),
+    onAcceptRequest: jest.fn().mockResolvedValue(undefined),
+  }
+}
+
+function findButtonWithLabel(root: ReturnType<typeof create>, label: string) {
+  const touchables = root.root.findAllByType(TouchableOpacity)
+  return touchables.find((n) => {
+    const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
+    return texts.some((t) => String(t.props.children) === label)
+  })
 }
 
 describe('UserSearchResult', () => {
   it('renders the display name', () => {
     let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult user={MOCK_USER} />) })
+    act(() => { root = create(<UserSearchResult {...makeProps('none')} />) })
 
     const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    const nameNode = texts.find((n) => String(n.props.children) === 'Jane Doe')
-    expect(nameNode).toBeDefined()
+    expect(texts.some((n) => String(n.props.children) === 'Jane Doe')).toBe(true)
   })
 
-  it('renders an Add Friend button', () => {
+  it('shows "Add Friend" button when status is none', () => {
     let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult user={MOCK_USER} />) })
+    act(() => { root = create(<UserSearchResult {...makeProps('none')} />) })
 
-    const touchables = root!.root.findAllByType(TouchableOpacity)
-    const addButton = touchables.find((n) => {
-      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
-      return texts.some((t) => String(t.props.children) === 'Add Friend')
-    })
-    expect(addButton).toBeDefined()
+    expect(findButtonWithLabel(root!, 'Add Friend')).toBeDefined()
   })
 
-  it('logs Friend stub to console when Add Friend is pressed', () => {
-    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
-
+  it('calls onSendRequest when Add Friend is pressed', async () => {
+    const props = makeProps('none')
     let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult user={MOCK_USER} />) })
+    act(() => { root = create(<UserSearchResult {...props} />) })
 
-    const touchables = root!.root.findAllByType(TouchableOpacity)
-    const addButton = touchables.find((n) => {
-      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
-      return texts.some((t) => String(t.props.children) === 'Add Friend')
+    await act(async () => {
+      findButtonWithLabel(root!, 'Add Friend')!.props.onPress()
     })
 
-    act(() => { addButton!.props.onPress() })
-
-    expect(consoleSpy).toHaveBeenCalledWith('[Friend stub]', MOCK_USER.id, MOCK_USER.display_name)
-    consoleSpy.mockRestore()
+    expect(props.onSendRequest).toHaveBeenCalled()
   })
 
-  it('renders without avatar (null avatarUrl) using initials fallback', () => {
+  it('shows "Pending" button when status is pending_sent', () => {
     let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult user={MOCK_USER} />) })
+    act(() => { root = create(<UserSearchResult {...makeProps('pending_sent')} />) })
+
+    expect(findButtonWithLabel(root!, 'Pending')).toBeDefined()
+  })
+
+  it('shows Alert with cancel option when Pending is pressed', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {})
+    const props = makeProps('pending_sent')
+
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<UserSearchResult {...props} />) })
+
+    act(() => { findButtonWithLabel(root!, 'Pending')!.props.onPress() })
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Cancel request?',
+      '',
+      expect.arrayContaining([
+        expect.objectContaining({ style: 'destructive' }),
+        expect.objectContaining({ style: 'cancel' }),
+      ])
+    )
+    alertSpy.mockRestore()
+  })
+
+  it('calls onCancelRequest when cancel is confirmed in the Alert', async () => {
+    const props = makeProps('pending_sent')
+    let capturedDestructiveOnPress: (() => void) | undefined
+
+    jest.spyOn(Alert, 'alert').mockImplementation((_title, _msg, buttons) => {
+      const destructive = (buttons as Array<{ style: string; onPress?: () => void }>)
+        .find((b) => b.style === 'destructive')
+      capturedDestructiveOnPress = destructive?.onPress
+    })
+
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<UserSearchResult {...props} />) })
+
+    act(() => { findButtonWithLabel(root!, 'Pending')!.props.onPress() })
+
+    await act(async () => { capturedDestructiveOnPress?.() })
+
+    expect(props.onCancelRequest).toHaveBeenCalled()
+    jest.restoreAllMocks()
+  })
+
+  it('shows "Accept" button when status is pending_received', () => {
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<UserSearchResult {...makeProps('pending_received')} />) })
+
+    expect(findButtonWithLabel(root!, 'Accept')).toBeDefined()
+  })
+
+  it('calls onAcceptRequest when Accept is pressed', async () => {
+    const props = makeProps('pending_received')
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<UserSearchResult {...props} />) })
+
+    await act(async () => {
+      findButtonWithLabel(root!, 'Accept')!.props.onPress()
+    })
+
+    expect(props.onAcceptRequest).toHaveBeenCalled()
+  })
+
+  it('shows "Friends" label when status is accepted and button is disabled', () => {
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<UserSearchResult {...makeProps('accepted')} />) })
+
+    const btn = findButtonWithLabel(root!, 'Friends')
+    expect(btn).toBeDefined()
+    expect(btn!.props.disabled).toBe(true)
+  })
+
+  it('renders initials fallback when avatarUrl is null', () => {
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<UserSearchResult {...makeProps('none')} />) })
 
     const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
     const initialsNode = texts.find((n) => String(n.props.children).match(/^[A-Z]{1,2}$/))

--- a/components/friends/__tests__/UserSearchResult.test.tsx
+++ b/components/friends/__tests__/UserSearchResult.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { TouchableOpacity, Alert } from 'react-native'
+import { TouchableOpacity } from 'react-native'
 import { act, create, ReactTestInstance } from 'react-test-renderer'
 import { UserSearchResult } from '../UserSearchResult'
 
@@ -60,45 +60,38 @@ describe('UserSearchResult', () => {
     expect(findButtonWithLabel(root!, 'Pending')).toBeDefined()
   })
 
-  it('shows Alert with cancel option when Pending is pressed', () => {
-    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {})
+  it('pressing "Pending" opens the in-app cancel confirmation modal', () => {
     const props = makeProps('pending_sent')
-
     let root: ReturnType<typeof create>
     act(() => { root = create(<UserSearchResult {...props} />) })
 
     act(() => { findButtonWithLabel(root!, 'Pending')!.props.onPress() })
 
-    expect(alertSpy).toHaveBeenCalledWith(
-      'Cancel request?',
-      '',
-      expect.arrayContaining([
-        expect.objectContaining({ style: 'destructive' }),
-        expect.objectContaining({ style: 'cancel' }),
-      ])
-    )
-    alertSpy.mockRestore()
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+    expect(texts.some((n) => String(n.props.children) === 'Cancel request?')).toBe(true)
   })
 
-  it('calls onCancelRequest when cancel is confirmed in the Alert', async () => {
+  it('calls onCancelRequest when "Cancel request" button in modal is pressed', async () => {
     const props = makeProps('pending_sent')
-    let capturedDestructiveOnPress: (() => void) | undefined
-
-    jest.spyOn(Alert, 'alert').mockImplementation((_title, _msg, buttons) => {
-      const destructive = (buttons as Array<{ style: string; onPress?: () => void }>)
-        .find((b) => b.style === 'destructive')
-      capturedDestructiveOnPress = destructive?.onPress
-    })
-
     let root: ReturnType<typeof create>
     act(() => { root = create(<UserSearchResult {...props} />) })
 
     act(() => { findButtonWithLabel(root!, 'Pending')!.props.onPress() })
 
-    await act(async () => { capturedDestructiveOnPress?.() })
+    await act(async () => { findButtonWithLabel(root!, 'Cancel request')!.props.onPress() })
 
     expect(props.onCancelRequest).toHaveBeenCalled()
-    jest.restoreAllMocks()
+  })
+
+  it('"Keep" button closes the modal without calling onCancelRequest', () => {
+    const props = makeProps('pending_sent')
+    let root: ReturnType<typeof create>
+    act(() => { root = create(<UserSearchResult {...props} />) })
+
+    act(() => { findButtonWithLabel(root!, 'Pending')!.props.onPress() })
+    act(() => { findButtonWithLabel(root!, 'Keep')!.props.onPress() })
+
+    expect(props.onCancelRequest).not.toHaveBeenCalled()
   })
 
   it('shows "Accept" button when status is pending_received', () => {

--- a/hooks/__tests__/useFriendships.test.ts
+++ b/hooks/__tests__/useFriendships.test.ts
@@ -1,0 +1,295 @@
+import React from 'react'
+import { act, create } from 'react-test-renderer'
+
+const mockUseAuth = jest.fn()
+const mockFetchFriendships = jest.fn()
+const mockLibSendRequest = jest.fn()
+const mockLibCancelRequest = jest.fn()
+const mockLibAcceptRequest = jest.fn()
+const mockLibDeclineRequest = jest.fn()
+const mockLibUnfriend = jest.fn()
+
+const mockChannel = {
+  on: jest.fn().mockReturnThis(),
+  subscribe: jest.fn(),
+}
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    channel: jest.fn(() => mockChannel),
+    removeChannel: jest.fn(),
+  },
+}))
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+jest.mock('@/lib/friendships', () => ({
+  fetchFriendships: (...args: unknown[]) => mockFetchFriendships(...args),
+  sendRequest: (...args: unknown[]) => mockLibSendRequest(...args),
+  cancelRequest: (...args: unknown[]) => mockLibCancelRequest(...args),
+  acceptRequest: (...args: unknown[]) => mockLibAcceptRequest(...args),
+  declineRequest: (...args: unknown[]) => mockLibDeclineRequest(...args),
+  unfriend: (...args: unknown[]) => mockLibUnfriend(...args),
+}))
+
+import { useFriendships } from '../useFriendships'
+
+type HookResult<T> = { current: T }
+
+function renderHook<T>(useHook: () => T): HookResult<T> {
+  const result: HookResult<T> = { current: undefined as unknown as T }
+  function TestComponent() {
+    result.current = useHook()
+    return null
+  }
+  act(() => { create(React.createElement(TestComponent)) })
+  return result
+}
+
+async function flush() {
+  await act(async () => { await Promise.resolve() })
+}
+
+const USER_ID = 'user-me'
+const OTHER_ID = 'user-other'
+const FRIEND_ID = 'user-friend'
+
+const PENDING_SENT_ROW = {
+  id: 'fs-pending-sent',
+  requester_id: USER_ID,
+  addressee_id: OTHER_ID,
+  status: 'pending',
+  created_at: '2026-01-01T00:00:00Z',
+  requester: { id: USER_ID, display_name: 'Me', avatar_url: null },
+  addressee: { id: OTHER_ID, display_name: 'Other', avatar_url: null },
+}
+
+const PENDING_RECEIVED_ROW = {
+  id: 'fs-pending-received',
+  requester_id: OTHER_ID,
+  addressee_id: USER_ID,
+  status: 'pending',
+  created_at: '2026-01-01T00:00:00Z',
+  requester: { id: OTHER_ID, display_name: 'Other', avatar_url: null },
+  addressee: { id: USER_ID, display_name: 'Me', avatar_url: null },
+}
+
+const ACCEPTED_ROW = {
+  id: 'fs-accepted',
+  requester_id: USER_ID,
+  addressee_id: FRIEND_ID,
+  status: 'accepted',
+  created_at: '2026-01-01T00:00:00Z',
+  requester: { id: USER_ID, display_name: 'Me', avatar_url: null },
+  addressee: { id: FRIEND_ID, display_name: 'Friend', avatar_url: null },
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockUseAuth.mockReturnValue({ session: { user: { id: USER_ID } } })
+})
+
+describe('useFriendships', () => {
+  it('returns empty state when no friendships exist', async () => {
+    mockFetchFriendships.mockResolvedValue([])
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    expect(result.current.friends).toEqual([])
+    expect(result.current.incomingRequests).toEqual([])
+    expect(result.current.outgoingRequestMap.size).toBe(0)
+    expect(result.current.pendingCount).toBe(0)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('correctly derives friends from accepted rows', async () => {
+    mockFetchFriendships.mockResolvedValue([ACCEPTED_ROW])
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    expect(result.current.friends).toHaveLength(1)
+    expect(result.current.friends[0].userId).toBe(FRIEND_ID)
+    expect(result.current.friends[0].displayName).toBe('Friend')
+    expect(result.current.friends[0].friendshipId).toBe('fs-accepted')
+  })
+
+  it('correctly derives incomingRequests from pending-received rows', async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    expect(result.current.incomingRequests).toHaveLength(1)
+    expect(result.current.incomingRequests[0].requesterId).toBe(OTHER_ID)
+    expect(result.current.incomingRequests[0].displayName).toBe('Other')
+    expect(result.current.pendingCount).toBe(1)
+  })
+
+  it('correctly populates outgoingRequestMap from pending-sent rows', async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_SENT_ROW])
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(true)
+    expect(result.current.outgoingRequestMap.get(OTHER_ID)).toBe('fs-pending-sent')
+    expect(result.current.incomingRequests).toHaveLength(0)
+  })
+
+  it('sets error state when fetchFriendships throws', async () => {
+    mockFetchFriendships.mockRejectedValue(new Error('network error'))
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    expect(result.current.error).toBe('network error')
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('returns empty state when not authenticated', async () => {
+    mockUseAuth.mockReturnValue({ session: null })
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    expect(result.current.friends).toEqual([])
+    expect(result.current.loading).toBe(false)
+    expect(mockFetchFriendships).not.toHaveBeenCalled()
+  })
+
+  it('sendRequest: optimistically adds to outgoingRequestMap and confirms on success', async () => {
+    mockFetchFriendships.mockResolvedValue([])
+    mockLibSendRequest.mockResolvedValue({ id: 'fs-new', ...PENDING_SENT_ROW })
+
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    await act(async () => { await result.current.sendRequest(OTHER_ID) })
+
+    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(true)
+  })
+
+  it('sendRequest: rolls back optimistic add on error', async () => {
+    mockFetchFriendships.mockResolvedValue([])
+    mockLibSendRequest.mockRejectedValue(new Error('Friend request already exists'))
+
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    await expect(
+      act(async () => { await result.current.sendRequest(OTHER_ID) })
+    ).rejects.toThrow('Friend request already exists')
+
+    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(false)
+  })
+
+  it('cancelRequest: removes from outgoingRequestMap on success', async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_SENT_ROW])
+    mockLibCancelRequest.mockResolvedValue(undefined)
+
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(true)
+
+    await act(async () => { await result.current.cancelRequest('fs-pending-sent') })
+
+    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(false)
+  })
+
+  it('cancelRequest: rolls back on error', async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_SENT_ROW])
+    mockLibCancelRequest.mockRejectedValue(new Error('Request not found or already cancelled'))
+
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    await expect(
+      act(async () => { await result.current.cancelRequest('fs-pending-sent') })
+    ).rejects.toThrow()
+
+    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(true)
+  })
+
+  it('acceptRequest: moves row from incomingRequests to friends', async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
+    mockLibAcceptRequest.mockResolvedValue(undefined)
+
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    expect(result.current.incomingRequests).toHaveLength(1)
+    expect(result.current.friends).toHaveLength(0)
+
+    await act(async () => { await result.current.acceptRequest('fs-pending-received') })
+
+    expect(result.current.incomingRequests).toHaveLength(0)
+    expect(result.current.friends).toHaveLength(1)
+    expect(result.current.pendingCount).toBe(0)
+  })
+
+  it('acceptRequest: rolls back on error', async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
+    mockLibAcceptRequest.mockRejectedValue(new Error('update failed'))
+
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    await expect(
+      act(async () => { await result.current.acceptRequest('fs-pending-received') })
+    ).rejects.toThrow()
+
+    expect(result.current.incomingRequests).toHaveLength(1)
+  })
+
+  it('declineRequest: removes from incomingRequests on success', async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
+    mockLibDeclineRequest.mockResolvedValue(undefined)
+
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    await act(async () => { await result.current.declineRequest('fs-pending-received') })
+
+    expect(result.current.incomingRequests).toHaveLength(0)
+  })
+
+  it('declineRequest: rolls back on error', async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
+    mockLibDeclineRequest.mockRejectedValue(new Error('not found'))
+
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    await expect(
+      act(async () => { await result.current.declineRequest('fs-pending-received') })
+    ).rejects.toThrow()
+
+    expect(result.current.incomingRequests).toHaveLength(1)
+  })
+
+  it('unfriend: removes from friends on success', async () => {
+    mockFetchFriendships.mockResolvedValue([ACCEPTED_ROW])
+    mockLibUnfriend.mockResolvedValue(undefined)
+
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    expect(result.current.friends).toHaveLength(1)
+
+    await act(async () => { await result.current.unfriend('fs-accepted') })
+
+    expect(result.current.friends).toHaveLength(0)
+  })
+
+  it('unfriend: rolls back on error', async () => {
+    mockFetchFriendships.mockResolvedValue([ACCEPTED_ROW])
+    mockLibUnfriend.mockRejectedValue(new Error('Friendship not found'))
+
+    const result = renderHook(() => useFriendships())
+    await flush()
+
+    await expect(
+      act(async () => { await result.current.unfriend('fs-accepted') })
+    ).rejects.toThrow()
+
+    expect(result.current.friends).toHaveLength(1)
+  })
+})

--- a/hooks/__tests__/useFriendships.test.ts
+++ b/hooks/__tests__/useFriendships.test.ts
@@ -156,7 +156,7 @@ describe('useFriendships', () => {
 
   it('sendRequest: optimistically adds to outgoingRequestMap and confirms on success', async () => {
     mockFetchFriendships.mockResolvedValue([])
-    mockLibSendRequest.mockResolvedValue({ id: 'fs-new', ...PENDING_SENT_ROW })
+    mockLibSendRequest.mockResolvedValue({ ...PENDING_SENT_ROW, id: 'fs-new' })
 
     const result = renderHook(() => useFriendships())
     await flush()

--- a/hooks/__tests__/usePendingRequestCount.test.ts
+++ b/hooks/__tests__/usePendingRequestCount.test.ts
@@ -1,0 +1,138 @@
+import React from 'react'
+import { act, create } from 'react-test-renderer'
+
+const mockUseAuth = jest.fn()
+
+const mockSelect = jest.fn()
+const mockChannel = {
+  on: jest.fn().mockReturnThis(),
+  subscribe: jest.fn(),
+}
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(() => ({ select: mockSelect })),
+    channel: jest.fn(() => mockChannel),
+    removeChannel: jest.fn(),
+  },
+}))
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+import { usePendingRequestCount } from '../usePendingRequestCount'
+import { supabase } from '@/lib/supabase'
+
+type HookResult<T> = { current: T }
+
+function renderHook<T>(useHook: () => T): { result: HookResult<T>; unmount: () => void } {
+  const result: HookResult<T> = { current: undefined as unknown as T }
+  let root: ReturnType<typeof create>
+  function TestComponent() {
+    result.current = useHook()
+    return null
+  }
+  act(() => { root = create(React.createElement(TestComponent)) })
+  return { result, unmount: () => act(() => { root.unmount() }) }
+}
+
+async function flush() {
+  await act(async () => { await Promise.resolve() })
+}
+
+const USER_ID = 'user-me'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockUseAuth.mockReturnValue({ session: { user: { id: USER_ID } } })
+  mockChannel.on.mockReturnThis()
+})
+
+describe('usePendingRequestCount', () => {
+  it('returns 0 when unauthenticated', async () => {
+    mockUseAuth.mockReturnValue({ session: null })
+    const { result } = renderHook(() => usePendingRequestCount())
+    await flush()
+
+    expect(result.current).toBe(0)
+  })
+
+  it('returns the correct count from a successful query', async () => {
+    const eq2 = jest.fn().mockResolvedValue({ count: 3, error: null })
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
+    mockSelect.mockReturnValue({ eq: eq1 })
+
+    const { result } = renderHook(() => usePendingRequestCount())
+    await flush()
+
+    expect(result.current).toBe(3)
+    expect(eq1).toHaveBeenCalledWith('addressee_id', USER_ID)
+    expect(eq2).toHaveBeenCalledWith('status', 'pending')
+  })
+
+  it('returns 0 when the query returns null count', async () => {
+    const eq2 = jest.fn().mockResolvedValue({ count: null, error: null })
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
+    mockSelect.mockReturnValue({ eq: eq1 })
+
+    const { result } = renderHook(() => usePendingRequestCount())
+    await flush()
+
+    expect(result.current).toBe(0)
+  })
+
+  it('keeps previous count on query error and logs the error', async () => {
+    const eq2 = jest.fn().mockResolvedValue({ count: null, error: { message: 'RLS denied' } })
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
+    mockSelect.mockReturnValue({ eq: eq1 })
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    const { result } = renderHook(() => usePendingRequestCount())
+    await flush()
+
+    expect(result.current).toBe(0)
+    expect(consoleSpy).toHaveBeenCalledWith('usePendingRequestCount: query error', 'RLS denied')
+    consoleSpy.mockRestore()
+  })
+
+  it('logs error on fetch exception', async () => {
+    const eq2 = jest.fn().mockRejectedValue(new Error('network down'))
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
+    mockSelect.mockReturnValue({ eq: eq1 })
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    const { result } = renderHook(() => usePendingRequestCount())
+    await flush()
+
+    expect(result.current).toBe(0)
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'usePendingRequestCount: failed to fetch count',
+      expect.any(Error)
+    )
+    consoleSpy.mockRestore()
+  })
+
+  it('calls removeChannel on cleanup', async () => {
+    const eq2 = jest.fn().mockResolvedValue({ count: 0, error: null })
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
+    mockSelect.mockReturnValue({ eq: eq1 })
+
+    const { unmount } = renderHook(() => usePendingRequestCount())
+    await flush()
+
+    unmount()
+    expect(supabase.removeChannel).toHaveBeenCalled()
+  })
+
+  it('subscribes with a status callback for Realtime errors', async () => {
+    const eq2 = jest.fn().mockResolvedValue({ count: 0, error: null })
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
+    mockSelect.mockReturnValue({ eq: eq1 })
+
+    renderHook(() => usePendingRequestCount())
+    await flush()
+
+    expect(mockChannel.subscribe).toHaveBeenCalledWith(expect.any(Function))
+  })
+})

--- a/hooks/useFriendships.ts
+++ b/hooks/useFriendships.ts
@@ -1,0 +1,216 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { supabase } from '@/lib/supabase'
+import { useAuth } from '@/hooks/useAuth'
+import {
+  FriendshipWithProfiles,
+  fetchFriendships,
+  sendRequest as libSendRequest,
+  cancelRequest as libCancelRequest,
+  acceptRequest as libAcceptRequest,
+  declineRequest as libDeclineRequest,
+  unfriend as libUnfriend,
+} from '@/lib/friendships'
+
+export type FriendEntry = {
+  friendshipId: string
+  userId: string
+  displayName: string
+  avatarUrl: string | null
+}
+
+export type RequestEntry = {
+  friendshipId: string
+  requesterId: string
+  displayName: string
+  avatarUrl: string | null
+}
+
+function deriveState(rows: FriendshipWithProfiles[], userId: string) {
+  const friends: FriendEntry[] = []
+  const incomingRequests: RequestEntry[] = []
+  // Maps counterparty userId → friendshipId for pending-sent rows
+  const outgoingRequestMap = new Map<string, string>()
+
+  for (const row of rows) {
+    const iAmRequester = row.requester_id === userId
+    const counterparty = iAmRequester ? row.addressee : row.requester
+
+    if (row.status === 'accepted') {
+      friends.push({
+        friendshipId: row.id,
+        userId: counterparty.id,
+        displayName: counterparty.display_name,
+        avatarUrl: counterparty.avatar_url,
+      })
+    } else if (row.status === 'pending') {
+      if (iAmRequester) {
+        outgoingRequestMap.set(counterparty.id, row.id)
+      } else {
+        incomingRequests.push({
+          friendshipId: row.id,
+          requesterId: row.requester.id,
+          displayName: row.requester.display_name,
+          avatarUrl: row.requester.avatar_url,
+        })
+      }
+    }
+  }
+
+  return { friends, incomingRequests, outgoingRequestMap }
+}
+
+export function useFriendships() {
+  const { session } = useAuth()
+  const [rows, setRows] = useState<FriendshipWithProfiles[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const channelId = useRef(`friendships-changes-${Date.now()}-${Math.random()}`)
+
+  useEffect(() => {
+    const userId = session?.user.id
+    if (!userId) {
+      setRows([])
+      setLoading(false)
+      return
+    }
+
+    let active = true
+    setError(null)
+    setLoading(true)
+
+    async function load() {
+      try {
+        const data = await fetchFriendships(supabase)
+        if (!active) return
+        setRows(data)
+      } catch (err) {
+        if (!active) return
+        const message = err instanceof Error ? err.message : 'Unknown error'
+        console.error('useFriendships:', message)
+        setError(message)
+      } finally {
+        if (active) setLoading(false)
+      }
+    }
+
+    load()
+
+    // Subscribe to any change on the friendships table and refetch.
+    // This keeps both parties in sync without a reload — e.g. the recipient
+    // sees an incoming request immediately when the sender taps "Add Friend".
+    const channel = supabase
+      .channel(channelId.current)
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'friendships' }, () => {
+        if (active) load()
+      })
+      .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'friendships' }, () => {
+        if (active) load()
+      })
+      .on('postgres_changes', { event: 'DELETE', schema: 'public', table: 'friendships' }, () => {
+        if (active) load()
+      })
+      .subscribe((status, err) => {
+        if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+          console.error('useFriendships: Realtime error', err ?? '(no details)')
+        }
+      })
+
+    return () => {
+      active = false
+      supabase.removeChannel(channel)
+    }
+  }, [session?.user.id])
+
+  const userId = session?.user.id ?? ''
+  const { friends, incomingRequests, outgoingRequestMap } = deriveState(rows, userId)
+  const pendingCount = incomingRequests.length
+
+  const sendRequest = useCallback(async (addresseeId: string): Promise<void> => {
+    // Optimistic: add a placeholder to outgoingRequestMap via a synthetic row
+    const optimisticRow: FriendshipWithProfiles = {
+      id: `optimistic-${Date.now()}`,
+      requester_id: userId,
+      addressee_id: addresseeId,
+      status: 'pending',
+      created_at: new Date().toISOString(),
+      requester: { id: userId, display_name: '', avatar_url: null },
+      addressee: { id: addresseeId, display_name: '', avatar_url: null },
+    }
+    setRows((prev) => [...prev, optimisticRow])
+    try {
+      const inserted = await libSendRequest(supabase, { addresseeId })
+      // Replace optimistic row with real row (profile data will be fetched next load)
+      setRows((prev) =>
+        prev.map((r) =>
+          r.id === optimisticRow.id
+            ? { ...optimisticRow, id: inserted.id }
+            : r
+        )
+      )
+    } catch (err) {
+      // Roll back
+      setRows((prev) => prev.filter((r) => r.id !== optimisticRow.id))
+      throw err
+    }
+  }, [userId])
+
+  const cancelRequest = useCallback(async (friendshipId: string): Promise<void> => {
+    const prev = rows
+    setRows((r) => r.filter((row) => row.id !== friendshipId))
+    try {
+      await libCancelRequest(supabase, { friendshipId })
+    } catch (err) {
+      setRows(prev)
+      throw err
+    }
+  }, [rows])
+
+  const acceptRequest = useCallback(async (friendshipId: string): Promise<void> => {
+    const prev = rows
+    setRows((r) =>
+      r.map((row) => row.id === friendshipId ? { ...row, status: 'accepted' } : row)
+    )
+    try {
+      await libAcceptRequest(supabase, { friendshipId })
+    } catch (err) {
+      setRows(prev)
+      throw err
+    }
+  }, [rows])
+
+  const declineRequest = useCallback(async (friendshipId: string): Promise<void> => {
+    const prev = rows
+    setRows((r) => r.filter((row) => row.id !== friendshipId))
+    try {
+      await libDeclineRequest(supabase, { friendshipId })
+    } catch (err) {
+      setRows(prev)
+      throw err
+    }
+  }, [rows])
+
+  const unfriend = useCallback(async (friendshipId: string): Promise<void> => {
+    const prev = rows
+    setRows((r) => r.filter((row) => row.id !== friendshipId))
+    try {
+      await libUnfriend(supabase, { friendshipId })
+    } catch (err) {
+      setRows(prev)
+      throw err
+    }
+  }, [rows])
+
+  return {
+    friends,
+    incomingRequests,
+    outgoingRequestMap,
+    pendingCount,
+    loading,
+    error,
+    sendRequest,
+    cancelRequest,
+    acceptRequest,
+    declineRequest,
+    unfriend,
+  }
+}

--- a/hooks/useFriendships.ts
+++ b/hooks/useFriendships.ts
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/hooks/useAuth'
 import {
+  FriendshipStatus,
   FriendshipWithProfiles,
   fetchFriendships,
   sendRequest as libSendRequest,
@@ -18,7 +19,7 @@ export type FriendEntry = {
   avatarUrl: string | null
 }
 
-export type RequestEntry = {
+export type IncomingRequestEntry = {
   friendshipId: string
   requesterId: string
   displayName: string
@@ -27,8 +28,9 @@ export type RequestEntry = {
 
 function deriveState(rows: FriendshipWithProfiles[], userId: string) {
   const friends: FriendEntry[] = []
-  const incomingRequests: RequestEntry[] = []
-  // Maps counterparty userId → friendshipId for pending-sent rows
+  const incomingRequests: IncomingRequestEntry[] = []
+  // Maps counterparty userId → friendshipId for pending-sent rows.
+  // Using a Map enables O(1) status lookups in the search results view.
   const outgoingRequestMap = new Map<string, string>()
 
   for (const row of rows) {
@@ -95,7 +97,8 @@ export function useFriendships() {
 
     load()
 
-    // Subscribe to any change on the friendships table and refetch.
+    // Subscribe to changes on the friendships table and refetch.
+    // RLS ensures only events for the current user's rows are delivered.
     // This keeps both parties in sync without a reload — e.g. the recipient
     // sees an incoming request immediately when the sender taps "Add Friend".
     const channel = supabase
@@ -112,6 +115,7 @@ export function useFriendships() {
       .subscribe((status, err) => {
         if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
           console.error('useFriendships: Realtime error', err ?? '(no details)')
+          if (active) setError('Live updates disconnected. Pull to refresh.')
         }
       })
 
@@ -122,11 +126,32 @@ export function useFriendships() {
   }, [session?.user.id])
 
   const userId = session?.user.id ?? ''
-  const { friends, incomingRequests, outgoingRequestMap } = deriveState(rows, userId)
+
+  const { friends, incomingRequests, outgoingRequestMap } = useMemo(
+    () => deriveState(rows, userId),
+    [rows, userId]
+  )
+
+  const readonlyOutgoingRequestMap: ReadonlyMap<string, string> = outgoingRequestMap
   const pendingCount = incomingRequests.length
 
+  const getStatusForUser = useCallback((targetUserId: string): FriendshipStatus => {
+    if (friends.some((f) => f.userId === targetUserId)) return 'accepted'
+    if (outgoingRequestMap.has(targetUserId)) return 'pending_sent'
+    if (incomingRequests.some((r) => r.requesterId === targetUserId)) return 'pending_received'
+    return 'none'
+  }, [friends, outgoingRequestMap, incomingRequests])
+
+  const getFriendshipId = useCallback((targetUserId: string): string | null => {
+    return outgoingRequestMap.get(targetUserId) ??
+      incomingRequests.find((r) => r.requesterId === targetUserId)?.friendshipId ??
+      friends.find((f) => f.userId === targetUserId)?.friendshipId ??
+      null
+  }, [friends, outgoingRequestMap, incomingRequests])
+
   const sendRequest = useCallback(async (addresseeId: string): Promise<void> => {
-    // Optimistic: add a placeholder to outgoingRequestMap via a synthetic row
+    // Optimistic: insert a synthetic row into raw state so deriveState()
+    // immediately reflects the pending-sent status.
     const optimisticRow: FriendshipWithProfiles = {
       id: `optimistic-${Date.now()}`,
       requester_id: userId,
@@ -139,7 +164,8 @@ export function useFriendships() {
     setRows((prev) => [...prev, optimisticRow])
     try {
       const inserted = await libSendRequest(supabase, { addresseeId })
-      // Replace optimistic row with real row (profile data will be fetched next load)
+      // Replace optimistic row with real row. Profile data is still placeholder —
+      // the Realtime INSERT event will trigger a full refetch with joined profiles.
       setRows((prev) =>
         prev.map((r) =>
           r.id === optimisticRow.id
@@ -148,62 +174,62 @@ export function useFriendships() {
         )
       )
     } catch (err) {
-      // Roll back
       setRows((prev) => prev.filter((r) => r.id !== optimisticRow.id))
       throw err
     }
   }, [userId])
 
   const cancelRequest = useCallback(async (friendshipId: string): Promise<void> => {
-    const prev = rows
-    setRows((r) => r.filter((row) => row.id !== friendshipId))
+    let snapshot: FriendshipWithProfiles[] = []
+    setRows((current) => { snapshot = current; return current.filter((row) => row.id !== friendshipId) })
     try {
       await libCancelRequest(supabase, { friendshipId })
     } catch (err) {
-      setRows(prev)
+      setRows(snapshot)
       throw err
     }
-  }, [rows])
+  }, [])
 
   const acceptRequest = useCallback(async (friendshipId: string): Promise<void> => {
-    const prev = rows
-    setRows((r) =>
-      r.map((row) => row.id === friendshipId ? { ...row, status: 'accepted' } : row)
-    )
+    let snapshot: FriendshipWithProfiles[] = []
+    setRows((current) => {
+      snapshot = current
+      return current.map((row) => row.id === friendshipId ? { ...row, status: 'accepted' as const } : row)
+    })
     try {
       await libAcceptRequest(supabase, { friendshipId })
     } catch (err) {
-      setRows(prev)
+      setRows(snapshot)
       throw err
     }
-  }, [rows])
+  }, [])
 
   const declineRequest = useCallback(async (friendshipId: string): Promise<void> => {
-    const prev = rows
-    setRows((r) => r.filter((row) => row.id !== friendshipId))
+    let snapshot: FriendshipWithProfiles[] = []
+    setRows((current) => { snapshot = current; return current.filter((row) => row.id !== friendshipId) })
     try {
       await libDeclineRequest(supabase, { friendshipId })
     } catch (err) {
-      setRows(prev)
+      setRows(snapshot)
       throw err
     }
-  }, [rows])
+  }, [])
 
   const unfriend = useCallback(async (friendshipId: string): Promise<void> => {
-    const prev = rows
-    setRows((r) => r.filter((row) => row.id !== friendshipId))
+    let snapshot: FriendshipWithProfiles[] = []
+    setRows((current) => { snapshot = current; return current.filter((row) => row.id !== friendshipId) })
     try {
       await libUnfriend(supabase, { friendshipId })
     } catch (err) {
-      setRows(prev)
+      setRows(snapshot)
       throw err
     }
-  }, [rows])
+  }, [])
 
   return {
     friends,
     incomingRequests,
-    outgoingRequestMap,
+    outgoingRequestMap: readonlyOutgoingRequestMap,
     pendingCount,
     loading,
     error,
@@ -212,5 +238,7 @@ export function useFriendships() {
     acceptRequest,
     declineRequest,
     unfriend,
+    getStatusForUser,
+    getFriendshipId,
   }
 }

--- a/hooks/usePendingRequestCount.ts
+++ b/hooks/usePendingRequestCount.ts
@@ -4,6 +4,8 @@ import { useAuth } from '@/hooks/useAuth'
 
 // Lightweight hook used by the tab layout to drive the Friends tab badge.
 // Returns the count of pending incoming friend requests, or 0 on error/no session.
+// NOTE: This hook maintains its own Realtime subscription, independent of
+// useFriendships, because it is mounted in the tab layout which outlives the friends screen.
 export function usePendingRequestCount(): number {
   const { session } = useAuth()
   const [count, setCount] = useState(0)
@@ -27,9 +29,14 @@ export function usePendingRequestCount(): number {
           .eq('status', 'pending')
 
         if (!active) return
-        if (!error) setCount(c ?? 0)
-      } catch {
-        // Non-fatal — badge simply stays at 0
+        if (error) {
+          console.error('usePendingRequestCount: query error', error.message)
+          return
+        }
+        setCount(c ?? 0)
+      } catch (err) {
+        // Non-fatal — badge simply stays at its last value
+        console.error('usePendingRequestCount: failed to fetch count', err)
       }
     }
 
@@ -46,7 +53,11 @@ export function usePendingRequestCount(): number {
       .on('postgres_changes', { event: 'DELETE', schema: 'public', table: 'friendships' }, () => {
         if (active) load()
       })
-      .subscribe()
+      .subscribe((status, err) => {
+        if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+          console.error('usePendingRequestCount: Realtime error', err ?? '(no details)')
+        }
+      })
 
     return () => {
       active = false

--- a/hooks/usePendingRequestCount.ts
+++ b/hooks/usePendingRequestCount.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect, useRef } from 'react'
+import { supabase } from '@/lib/supabase'
+import { useAuth } from '@/hooks/useAuth'
+
+// Lightweight hook used by the tab layout to drive the Friends tab badge.
+// Returns the count of pending incoming friend requests, or 0 on error/no session.
+export function usePendingRequestCount(): number {
+  const { session } = useAuth()
+  const [count, setCount] = useState(0)
+  const channelId = useRef(`pending-count-${Date.now()}-${Math.random()}`)
+
+  useEffect(() => {
+    const userId = session?.user.id
+    if (!userId) {
+      setCount(0)
+      return
+    }
+
+    let active = true
+
+    async function load() {
+      try {
+        const { count: c, error } = await supabase
+          .from('friendships')
+          .select('id', { count: 'exact', head: true })
+          .eq('addressee_id', userId!)
+          .eq('status', 'pending')
+
+        if (!active) return
+        if (!error) setCount(c ?? 0)
+      } catch {
+        // Non-fatal — badge simply stays at 0
+      }
+    }
+
+    load()
+
+    const channel = supabase
+      .channel(channelId.current)
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'friendships' }, () => {
+        if (active) load()
+      })
+      .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'friendships' }, () => {
+        if (active) load()
+      })
+      .on('postgres_changes', { event: 'DELETE', schema: 'public', table: 'friendships' }, () => {
+        if (active) load()
+      })
+      .subscribe()
+
+    return () => {
+      active = false
+      supabase.removeChannel(channel)
+    }
+  }, [session?.user.id])
+
+  return count
+}

--- a/lib/__tests__/friendships.test.ts
+++ b/lib/__tests__/friendships.test.ts
@@ -1,0 +1,266 @@
+import {
+  fetchFriendships,
+  sendRequest,
+  cancelRequest,
+  acceptRequest,
+  declineRequest,
+  unfriend,
+} from '../friendships'
+import { SupabaseClient } from '@supabase/supabase-js'
+import { Database } from '../../types/supabase'
+
+const MOCK_USER_ID = 'user-abc'
+const MOCK_ADDRESSEE_ID = 'user-xyz'
+const MOCK_FRIENDSHIP_ID = 'friendship-123'
+
+const MOCK_ROW = {
+  id: MOCK_FRIENDSHIP_ID,
+  requester_id: MOCK_USER_ID,
+  addressee_id: MOCK_ADDRESSEE_ID,
+  status: 'pending',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+type MockSupabase = { from: jest.Mock; auth: { getUser: jest.Mock } }
+
+function asClient(mock: MockSupabase): SupabaseClient<Database> {
+  return mock as unknown as SupabaseClient<Database>
+}
+
+function authedGetUser(userId = MOCK_USER_ID) {
+  return jest.fn().mockResolvedValue({ data: { user: { id: userId } }, error: null })
+}
+
+// ---------- fetchFriendships ----------
+
+describe('fetchFriendships', () => {
+  it('selects with embedded profile joins', async () => {
+    const select = jest.fn().mockResolvedValue({ data: [MOCK_ROW], error: null })
+    const from = jest.fn().mockReturnValue({ select })
+    const mock: MockSupabase = { from, auth: { getUser: authedGetUser() } }
+
+    const result = await fetchFriendships(asClient(mock))
+    expect(mock.from).toHaveBeenCalledWith('friendships')
+    expect(select).toHaveBeenCalledWith(expect.stringContaining('requester:requester_id'))
+    expect(select).toHaveBeenCalledWith(expect.stringContaining('addressee:addressee_id'))
+    expect(result).toEqual([MOCK_ROW])
+  })
+
+  it('throws when not authenticated', async () => {
+    const from = jest.fn()
+    const mock: MockSupabase = {
+      from,
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: null }) },
+    }
+    await expect(fetchFriendships(asClient(mock))).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws on Supabase error', async () => {
+    const select = jest.fn().mockResolvedValue({ data: null, error: { message: 'db error' } })
+    const from = jest.fn().mockReturnValue({ select })
+    const mock: MockSupabase = { from, auth: { getUser: authedGetUser() } }
+    await expect(fetchFriendships(asClient(mock))).rejects.toThrow('db error')
+  })
+})
+
+// ---------- sendRequest ----------
+
+describe('sendRequest', () => {
+  function makeSendMock(result = { data: MOCK_ROW, error: null }) {
+    const single = jest.fn().mockResolvedValue(result)
+    const select = jest.fn().mockReturnValue({ single })
+    const insert = jest.fn().mockReturnValue({ select })
+    const from = jest.fn().mockReturnValue({ insert })
+    return { from, auth: { getUser: authedGetUser() } }
+  }
+
+  it('inserts with correct fields', async () => {
+    const mock = makeSendMock()
+    await sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })
+
+    expect(mock.from).toHaveBeenCalledWith('friendships')
+    const fromInstance = mock.from.mock.results[0].value
+    expect(fromInstance.insert).toHaveBeenCalledWith({
+      requester_id: MOCK_USER_ID,
+      addressee_id: MOCK_ADDRESSEE_ID,
+      status: 'pending',
+    })
+  })
+
+  it('returns the created friendship row', async () => {
+    const mock = makeSendMock()
+    const result = await sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })
+    expect(result).toEqual(MOCK_ROW)
+  })
+
+  it('throws "Friend request already exists" on unique violation (23505)', async () => {
+    const mock = makeSendMock({ data: null, error: { message: 'duplicate', code: '23505' } as never })
+    await expect(
+      sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })
+    ).rejects.toThrow('Friend request already exists')
+  })
+
+  it('throws Supabase message on other errors', async () => {
+    const mock = makeSendMock({ data: null, error: { message: 'insert failed' } as never })
+    await expect(
+      sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })
+    ).rejects.toThrow('insert failed')
+  })
+
+  it('throws when not authenticated', async () => {
+    const mock = makeSendMock()
+    mock.auth.getUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null })
+    await expect(
+      sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })
+    ).rejects.toThrow('Not authenticated')
+  })
+})
+
+// ---------- cancelRequest ----------
+
+describe('cancelRequest', () => {
+  function makeDeleteMock(result = { count: 1, error: null }) {
+    const eq = jest.fn().mockResolvedValue(result)
+    const del = jest.fn().mockReturnValue({ eq })
+    const from = jest.fn().mockReturnValue({ delete: del })
+    return { from, auth: { getUser: authedGetUser() } }
+  }
+
+  it('deletes by friendshipId', async () => {
+    const mock = makeDeleteMock()
+    await cancelRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+
+    expect(mock.from).toHaveBeenCalledWith('friendships')
+    const del = mock.from.mock.results[0].value.delete
+    expect(del).toHaveBeenCalledWith({ count: 'exact' })
+    const eq = del.mock.results[0].value.eq
+    expect(eq).toHaveBeenCalledWith('id', MOCK_FRIENDSHIP_ID)
+  })
+
+  it('throws "Request not found" when 0 rows deleted', async () => {
+    const mock = makeDeleteMock({ count: 0, error: null })
+    await expect(
+      cancelRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+    ).rejects.toThrow('Request not found or already cancelled')
+  })
+
+  it('throws Supabase error message on DB error', async () => {
+    const mock = makeDeleteMock({ count: null as never, error: { message: 'delete failed' } as never })
+    await expect(
+      cancelRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+    ).rejects.toThrow('delete failed')
+  })
+
+  it('throws when not authenticated', async () => {
+    const mock = makeDeleteMock()
+    mock.auth.getUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null })
+    await expect(
+      cancelRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+    ).rejects.toThrow('Not authenticated')
+  })
+})
+
+// ---------- acceptRequest ----------
+
+describe('acceptRequest', () => {
+  function makeUpdateMock(result = { error: null }) {
+    const eq = jest.fn().mockResolvedValue(result)
+    const update = jest.fn().mockReturnValue({ eq })
+    const from = jest.fn().mockReturnValue({ update })
+    return { from, auth: { getUser: authedGetUser() } }
+  }
+
+  it('updates status to accepted by friendshipId', async () => {
+    const mock = makeUpdateMock()
+    await acceptRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+
+    const upd = mock.from.mock.results[0].value.update
+    expect(upd).toHaveBeenCalledWith({ status: 'accepted' })
+    const eq = upd.mock.results[0].value.eq
+    expect(eq).toHaveBeenCalledWith('id', MOCK_FRIENDSHIP_ID)
+  })
+
+  it('throws Supabase error message on failure', async () => {
+    const mock = makeUpdateMock({ error: { message: 'update failed' } as never })
+    await expect(
+      acceptRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+    ).rejects.toThrow('update failed')
+  })
+
+  it('throws when not authenticated', async () => {
+    const mock = makeUpdateMock()
+    mock.auth.getUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null })
+    await expect(
+      acceptRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+    ).rejects.toThrow('Not authenticated')
+  })
+})
+
+// ---------- declineRequest ----------
+
+describe('declineRequest', () => {
+  function makeDeleteMock(result = { count: 1, error: null }) {
+    const eq = jest.fn().mockResolvedValue(result)
+    const del = jest.fn().mockReturnValue({ eq })
+    const from = jest.fn().mockReturnValue({ delete: del })
+    return { from, auth: { getUser: authedGetUser() } }
+  }
+
+  it('deletes by friendshipId', async () => {
+    const mock = makeDeleteMock()
+    await declineRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+
+    const del = mock.from.mock.results[0].value.delete
+    expect(del).toHaveBeenCalledWith({ count: 'exact' })
+  })
+
+  it('throws "Request not found" when 0 rows deleted', async () => {
+    const mock = makeDeleteMock({ count: 0, error: null })
+    await expect(
+      declineRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+    ).rejects.toThrow('Request not found or already declined')
+  })
+
+  it('throws when not authenticated', async () => {
+    const mock = makeDeleteMock()
+    mock.auth.getUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null })
+    await expect(
+      declineRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+    ).rejects.toThrow('Not authenticated')
+  })
+})
+
+// ---------- unfriend ----------
+
+describe('unfriend', () => {
+  function makeDeleteMock(result = { count: 1, error: null }) {
+    const eq = jest.fn().mockResolvedValue(result)
+    const del = jest.fn().mockReturnValue({ eq })
+    const from = jest.fn().mockReturnValue({ delete: del })
+    return { from, auth: { getUser: authedGetUser() } }
+  }
+
+  it('deletes by friendshipId', async () => {
+    const mock = makeDeleteMock()
+    await unfriend(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+
+    expect(mock.from).toHaveBeenCalledWith('friendships')
+    const del = mock.from.mock.results[0].value.delete
+    const eq = del.mock.results[0].value.eq
+    expect(eq).toHaveBeenCalledWith('id', MOCK_FRIENDSHIP_ID)
+  })
+
+  it('throws "Friendship not found" when 0 rows deleted', async () => {
+    const mock = makeDeleteMock({ count: 0, error: null })
+    await expect(
+      unfriend(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+    ).rejects.toThrow('Friendship not found')
+  })
+
+  it('throws Supabase error message on DB error', async () => {
+    const mock = makeDeleteMock({ count: null as never, error: { message: 'delete failed' } as never })
+    await expect(
+      unfriend(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+    ).rejects.toThrow('delete failed')
+  })
+})

--- a/lib/__tests__/friendships.test.ts
+++ b/lib/__tests__/friendships.test.ts
@@ -34,8 +34,9 @@ function authedGetUser(userId = MOCK_USER_ID) {
 // ---------- fetchFriendships ----------
 
 describe('fetchFriendships', () => {
-  it('selects with embedded profile joins', async () => {
-    const select = jest.fn().mockResolvedValue({ data: [MOCK_ROW], error: null })
+  it('selects with embedded profile joins and user filter', async () => {
+    const or = jest.fn().mockResolvedValue({ data: [MOCK_ROW], error: null })
+    const select = jest.fn().mockReturnValue({ or })
     const from = jest.fn().mockReturnValue({ select })
     const mock: MockSupabase = { from, auth: { getUser: authedGetUser() } }
 
@@ -43,6 +44,8 @@ describe('fetchFriendships', () => {
     expect(mock.from).toHaveBeenCalledWith('friendships')
     expect(select).toHaveBeenCalledWith(expect.stringContaining('requester:requester_id'))
     expect(select).toHaveBeenCalledWith(expect.stringContaining('addressee:addressee_id'))
+    expect(or).toHaveBeenCalledWith(expect.stringContaining(`requester_id.eq.${MOCK_USER_ID}`))
+    expect(or).toHaveBeenCalledWith(expect.stringContaining(`addressee_id.eq.${MOCK_USER_ID}`))
     expect(result).toEqual([MOCK_ROW])
   })
 
@@ -56,7 +59,8 @@ describe('fetchFriendships', () => {
   })
 
   it('throws on Supabase error', async () => {
-    const select = jest.fn().mockResolvedValue({ data: null, error: { message: 'db error' } })
+    const or = jest.fn().mockResolvedValue({ data: null, error: { message: 'db error' } })
+    const select = jest.fn().mockReturnValue({ or })
     const from = jest.fn().mockReturnValue({ select })
     const mock: MockSupabase = { from, auth: { getUser: authedGetUser() } }
     await expect(fetchFriendships(asClient(mock))).rejects.toThrow('db error')
@@ -66,7 +70,7 @@ describe('fetchFriendships', () => {
 // ---------- sendRequest ----------
 
 describe('sendRequest', () => {
-  function makeSendMock(result = { data: MOCK_ROW, error: null }) {
+  function makeSendMock(result: { data: typeof MOCK_ROW | null; error: unknown } = { data: MOCK_ROW, error: null }) {
     const single = jest.fn().mockResolvedValue(result)
     const select = jest.fn().mockReturnValue({ single })
     const insert = jest.fn().mockReturnValue({ select })
@@ -94,14 +98,14 @@ describe('sendRequest', () => {
   })
 
   it('throws "Friend request already exists" on unique violation (23505)', async () => {
-    const mock = makeSendMock({ data: null, error: { message: 'duplicate', code: '23505' } as never })
+    const mock = makeSendMock({ data: null, error: { message: 'duplicate', code: '23505' } })
     await expect(
       sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })
     ).rejects.toThrow('Friend request already exists')
   })
 
   it('throws Supabase message on other errors', async () => {
-    const mock = makeSendMock({ data: null, error: { message: 'insert failed' } as never })
+    const mock = makeSendMock({ data: null, error: { message: 'insert failed' } })
     await expect(
       sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })
     ).rejects.toThrow('insert failed')
@@ -163,25 +167,32 @@ describe('cancelRequest', () => {
 // ---------- acceptRequest ----------
 
 describe('acceptRequest', () => {
-  function makeUpdateMock(result = { error: null }) {
+  function makeUpdateMock(result = { count: 1, error: null }) {
     const eq = jest.fn().mockResolvedValue(result)
     const update = jest.fn().mockReturnValue({ eq })
     const from = jest.fn().mockReturnValue({ update })
     return { from, auth: { getUser: authedGetUser() } }
   }
 
-  it('updates status to accepted by friendshipId', async () => {
+  it('updates status to accepted by friendshipId with count check', async () => {
     const mock = makeUpdateMock()
     await acceptRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
 
     const upd = mock.from.mock.results[0].value.update
-    expect(upd).toHaveBeenCalledWith({ status: 'accepted' })
+    expect(upd).toHaveBeenCalledWith({ status: 'accepted' }, { count: 'exact' })
     const eq = upd.mock.results[0].value.eq
     expect(eq).toHaveBeenCalledWith('id', MOCK_FRIENDSHIP_ID)
   })
 
+  it('throws "Request not found or already handled" when 0 rows updated', async () => {
+    const mock = makeUpdateMock({ count: 0, error: null })
+    await expect(
+      acceptRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+    ).rejects.toThrow('Request not found or already handled')
+  })
+
   it('throws Supabase error message on failure', async () => {
-    const mock = makeUpdateMock({ error: { message: 'update failed' } as never })
+    const mock = makeUpdateMock({ count: null as never, error: { message: 'update failed' } as never })
     await expect(
       acceptRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
     ).rejects.toThrow('update failed')

--- a/lib/friendships.ts
+++ b/lib/friendships.ts
@@ -3,11 +3,13 @@ import { Database, Tables } from '@/types/supabase'
 
 export type FriendshipStatus = 'none' | 'pending_sent' | 'pending_received' | 'accepted'
 
+export type ProfileSummary = Pick<Tables<'profiles'>, 'id' | 'display_name' | 'avatar_url'>
+
 export type FriendshipRow = Tables<'friendships'>
 
 export type FriendshipWithProfiles = FriendshipRow & {
-  requester: { id: string; display_name: string; avatar_url: string | null }
-  addressee: { id: string; display_name: string; avatar_url: string | null }
+  requester: ProfileSummary
+  addressee: ProfileSummary
 }
 
 type Supabase = SupabaseClient<Database>
@@ -23,6 +25,7 @@ export async function fetchFriendships(supabase: Supabase): Promise<FriendshipWi
       requester:requester_id(id, display_name, avatar_url),
       addressee:addressee_id(id, display_name, avatar_url)
     `)
+    .or(`requester_id.eq.${user.id},addressee_id.eq.${user.id}`)
 
   if (error) throw new Error(error.message)
   return (data as unknown as FriendshipWithProfiles[]) ?? []
@@ -42,7 +45,7 @@ export async function sendRequest(
     .single()
 
   if (error) {
-    // Postgres unique violation — pair already exists (either direction)
+    // Postgres unique-constraint violation (23505) — most likely the LEAST/GREATEST pair index
     if (error.code === '23505') throw new Error('Friend request already exists')
     throw new Error(error.message)
   }
@@ -72,12 +75,13 @@ export async function acceptRequest(
   const { data: { user }, error: authError } = await supabase.auth.getUser()
   if (authError || !user) throw new Error('Not authenticated')
 
-  const { error } = await supabase
+  const { count, error } = await supabase
     .from('friendships')
-    .update({ status: 'accepted' })
+    .update({ status: 'accepted' }, { count: 'exact' })
     .eq('id', friendshipId)
 
   if (error) throw new Error(error.message)
+  if (count === 0) throw new Error('Request not found or already handled')
 }
 
 export async function declineRequest(

--- a/lib/friendships.ts
+++ b/lib/friendships.ts
@@ -1,0 +1,113 @@
+import { SupabaseClient } from '@supabase/supabase-js'
+import { Database, Tables } from '@/types/supabase'
+
+export type FriendshipStatus = 'none' | 'pending_sent' | 'pending_received' | 'accepted'
+
+export type FriendshipRow = Tables<'friendships'>
+
+export type FriendshipWithProfiles = FriendshipRow & {
+  requester: { id: string; display_name: string; avatar_url: string | null }
+  addressee: { id: string; display_name: string; avatar_url: string | null }
+}
+
+type Supabase = SupabaseClient<Database>
+
+export async function fetchFriendships(supabase: Supabase): Promise<FriendshipWithProfiles[]> {
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) throw new Error('Not authenticated')
+
+  const { data, error } = await supabase
+    .from('friendships')
+    .select(`
+      *,
+      requester:requester_id(id, display_name, avatar_url),
+      addressee:addressee_id(id, display_name, avatar_url)
+    `)
+
+  if (error) throw new Error(error.message)
+  return (data as unknown as FriendshipWithProfiles[]) ?? []
+}
+
+export async function sendRequest(
+  supabase: Supabase,
+  { addresseeId }: { addresseeId: string }
+): Promise<FriendshipRow> {
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) throw new Error('Not authenticated')
+
+  const { data, error } = await supabase
+    .from('friendships')
+    .insert({ requester_id: user.id, addressee_id: addresseeId, status: 'pending' })
+    .select('*')
+    .single()
+
+  if (error) {
+    // Postgres unique violation — pair already exists (either direction)
+    if (error.code === '23505') throw new Error('Friend request already exists')
+    throw new Error(error.message)
+  }
+  return data
+}
+
+export async function cancelRequest(
+  supabase: Supabase,
+  { friendshipId }: { friendshipId: string }
+): Promise<void> {
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) throw new Error('Not authenticated')
+
+  const { count, error } = await supabase
+    .from('friendships')
+    .delete({ count: 'exact' })
+    .eq('id', friendshipId)
+
+  if (error) throw new Error(error.message)
+  if (count === 0) throw new Error('Request not found or already cancelled')
+}
+
+export async function acceptRequest(
+  supabase: Supabase,
+  { friendshipId }: { friendshipId: string }
+): Promise<void> {
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) throw new Error('Not authenticated')
+
+  const { error } = await supabase
+    .from('friendships')
+    .update({ status: 'accepted' })
+    .eq('id', friendshipId)
+
+  if (error) throw new Error(error.message)
+}
+
+export async function declineRequest(
+  supabase: Supabase,
+  { friendshipId }: { friendshipId: string }
+): Promise<void> {
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) throw new Error('Not authenticated')
+
+  const { count, error } = await supabase
+    .from('friendships')
+    .delete({ count: 'exact' })
+    .eq('id', friendshipId)
+
+  if (error) throw new Error(error.message)
+  if (count === 0) throw new Error('Request not found or already declined')
+}
+
+export async function unfriend(
+  supabase: Supabase,
+  { friendshipId }: { friendshipId: string }
+): Promise<void> {
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) throw new Error('Not authenticated')
+
+  const { count, error } = await supabase
+    .from('friendships')
+    .delete({ count: 'exact' })
+    .eq('id', friendshipId)
+
+  if (error) throw new Error(error.message)
+  if (count === 0) throw new Error('Friendship not found')
+}

--- a/supabase/migrations/017_friendships.sql
+++ b/supabase/migrations/017_friendships.sql
@@ -1,0 +1,48 @@
+-- Migration: 017_friendships
+-- Creates the friendships table for Phase 4 friend requests and friends list.
+-- Covers: send request, accept, decline, cancel, unfriend.
+-- The live_presence friends-only SELECT policy will be updated in a separate
+-- migration once this table is in place (see TODO in 011_live_presence.sql).
+
+CREATE TABLE public.friendships (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  requester_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  addressee_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  status       TEXT NOT NULL CHECK (status IN ('pending', 'accepted')),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT no_self_friendship CHECK (requester_id != addressee_id)
+);
+
+-- Prevent A→B and B→A from coexisting simultaneously.
+-- LEAST/GREATEST normalise the pair so (A,B) and (B,A) map to the same index entry.
+CREATE UNIQUE INDEX friendships_pair_unique
+  ON public.friendships (
+    LEAST(requester_id::text, addressee_id::text),
+    GREATEST(requester_id::text, addressee_id::text)
+  );
+
+CREATE INDEX friendships_requester_idx ON public.friendships(requester_id);
+CREATE INDEX friendships_addressee_idx ON public.friendships(addressee_id);
+
+ALTER TABLE public.friendships ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: each user sees only friendships they are party to.
+CREATE POLICY "Users can view their own friendships"
+  ON public.friendships FOR SELECT
+  USING (requester_id = auth.uid() OR addressee_id = auth.uid());
+
+-- INSERT: only the requester can insert; status must start as 'pending'.
+CREATE POLICY "Users can send friend requests"
+  ON public.friendships FOR INSERT
+  WITH CHECK (requester_id = auth.uid() AND status = 'pending');
+
+-- UPDATE: only the addressee may accept; only pending → accepted is allowed.
+CREATE POLICY "Addressee can accept pending requests"
+  ON public.friendships FOR UPDATE
+  USING (addressee_id = auth.uid() AND status = 'pending')
+  WITH CHECK (status = 'accepted' AND addressee_id = auth.uid());
+
+-- DELETE: either party may remove (cancel sent / decline received / unfriend).
+CREATE POLICY "Either party can remove a friendship"
+  ON public.friendships FOR DELETE
+  USING (requester_id = auth.uid() OR addressee_id = auth.uid());

--- a/supabase/migrations/017_friendships.sql
+++ b/supabase/migrations/017_friendships.sql
@@ -1,8 +1,10 @@
 -- Migration: 017_friendships
 -- Creates the friendships table for Phase 4 friend requests and friends list.
 -- Covers: send request, accept, decline, cancel, unfriend.
--- The live_presence friends-only SELECT policy will be updated in a separate
--- migration once this table is in place (see TODO in 011_live_presence.sql).
+-- NOTE: The live_presence friends-only SELECT policy is NOT updated in this
+-- migration. A follow-up migration is needed to add the friends subquery to
+-- the 011 SELECT policy (see TODO in 011_live_presence.sql and
+-- docs/rls-policy-sketch.md). Tracked in project_status.md Phase 4.
 
 CREATE TABLE public.friendships (
   id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -13,8 +15,7 @@ CREATE TABLE public.friendships (
   CONSTRAINT no_self_friendship CHECK (requester_id != addressee_id)
 );
 
--- Prevent A→B and B→A from coexisting simultaneously.
--- LEAST/GREATEST normalise the pair so (A,B) and (B,A) map to the same index entry.
+-- Prevent duplicate pairs: A→B and B→A map to the same index entry via LEAST/GREATEST normalization.
 CREATE UNIQUE INDEX friendships_pair_unique
   ON public.friendships (
     LEAST(requester_id::text, addressee_id::text),

--- a/supabase/migrations/018_enable_realtime_friendships.sql
+++ b/supabase/migrations/018_enable_realtime_friendships.sql
@@ -1,0 +1,4 @@
+-- Enable Supabase Realtime for the friendships table so both parties
+-- see friend request and acceptance changes without an app reload.
+-- Mirrors the pattern in 012_enable_realtime_live_presence.sql.
+alter publication supabase_realtime add table public.friendships;

--- a/supabase/migrations/019_friendship_status_enum.sql
+++ b/supabase/migrations/019_friendship_status_enum.sql
@@ -1,0 +1,25 @@
+-- Migration: 019_friendship_status_enum
+-- Converts the friendships.status column from a TEXT + CHECK constraint to a
+-- proper Postgres enum. This makes the Supabase type generator emit a union
+-- type ('pending' | 'accepted') instead of plain string, matching the pattern
+-- already used by poi_category and visibility_type.
+
+-- Drop policies that reference the status column (required before ALTER TYPE)
+DROP POLICY "Users can send friend requests" ON public.friendships;
+DROP POLICY "Addressee can accept pending requests" ON public.friendships;
+
+CREATE TYPE public.friendship_status AS ENUM ('pending', 'accepted');
+
+ALTER TABLE public.friendships
+  DROP CONSTRAINT friendships_status_check,
+  ALTER COLUMN status TYPE public.friendship_status USING status::public.friendship_status;
+
+-- Recreate policies using the enum type
+CREATE POLICY "Users can send friend requests"
+  ON public.friendships FOR INSERT
+  WITH CHECK (requester_id = auth.uid() AND status = 'pending');
+
+CREATE POLICY "Addressee can accept pending requests"
+  ON public.friendships FOR UPDATE
+  USING (addressee_id = auth.uid() AND status = 'pending')
+  WITH CHECK (status = 'accepted' AND addressee_id = auth.uid());

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -12,33 +12,47 @@ export type Database = {
   __InternalSupabase: {
     PostgrestVersion: "14.4"
   }
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
   public: {
     Tables: {
+      friendships: {
+        Row: {
+          addressee_id: string
+          created_at: string
+          id: string
+          requester_id: string
+          status: string
+        }
+        Insert: {
+          addressee_id: string
+          created_at?: string
+          id?: string
+          requester_id: string
+          status: string
+        }
+        Update: {
+          addressee_id?: string
+          created_at?: string
+          id?: string
+          requester_id?: string
+          status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "friendships_addressee_id_fkey"
+            columns: ["addressee_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "friendships_requester_id_fkey"
+            columns: ["requester_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       live_presence: {
         Row: {
           created_at: string
@@ -78,45 +92,6 @@ export type Database = {
           {
             foreignKeyName: "live_presence_user_id_fkey"
             columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      presence_joins: {
-        Row: {
-          confirmed: boolean
-          id: string
-          joined_at: string
-          joiner_user_id: string
-          presence_id: string
-        }
-        Insert: {
-          confirmed?: boolean
-          id?: string
-          joined_at?: string
-          joiner_user_id: string
-          presence_id: string
-        }
-        Update: {
-          confirmed?: boolean
-          id?: string
-          joined_at?: string
-          joiner_user_id?: string
-          presence_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "presence_joins_presence_id_fkey"
-            columns: ["presence_id"]
-            isOneToOne: false
-            referencedRelation: "live_presence"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "presence_joins_joiner_user_id_fkey"
-            columns: ["joiner_user_id"]
             isOneToOne: false
             referencedRelation: "profiles"
             referencedColumns: ["id"]
@@ -202,6 +177,45 @@ export type Database = {
             columns: ["created_by"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      presence_joins: {
+        Row: {
+          confirmed: boolean
+          id: string
+          joined_at: string
+          joiner_user_id: string
+          presence_id: string
+        }
+        Insert: {
+          confirmed?: boolean
+          id?: string
+          joined_at?: string
+          joiner_user_id: string
+          presence_id: string
+        }
+        Update: {
+          confirmed?: boolean
+          id?: string
+          joined_at?: string
+          joiner_user_id?: string
+          presence_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "presence_joins_joiner_user_id_fkey"
+            columns: ["joiner_user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "presence_joins_presence_id_fkey"
+            columns: ["presence_id"]
+            isOneToOne: false
+            referencedRelation: "live_presence"
             referencedColumns: ["id"]
           },
         ]
@@ -417,9 +431,6 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
-  graphql_public: {
-    Enums: {},
-  },
   public: {
     Enums: {
       poi_category: [

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -12,6 +12,31 @@ export type Database = {
   __InternalSupabase: {
     PostgrestVersion: "14.4"
   }
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
   public: {
     Tables: {
       friendships: {
@@ -20,21 +45,21 @@ export type Database = {
           created_at: string
           id: string
           requester_id: string
-          status: string
+          status: Database["public"]["Enums"]["friendship_status"]
         }
         Insert: {
           addressee_id: string
           created_at?: string
           id?: string
           requester_id: string
-          status: string
+          status: Database["public"]["Enums"]["friendship_status"]
         }
         Update: {
           addressee_id?: string
           created_at?: string
           id?: string
           requester_id?: string
-          status?: string
+          status?: Database["public"]["Enums"]["friendship_status"]
         }
         Relationships: [
           {
@@ -299,6 +324,7 @@ export type Database = {
       [_ in never]: never
     }
     Enums: {
+      friendship_status: "pending" | "accepted"
       poi_category:
         | "food_drink"
         | "nightlife"
@@ -431,8 +457,12 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {
+      friendship_status: ["pending", "accepted"],
       poi_category: [
         "food_drink",
         "nightlife",


### PR DESCRIPTION
## Summary

- **`friendships` table** — `LEAST/GREATEST` pair uniqueness index prevents both A→B and B→A rows from coexisting; 4 RLS policies (SELECT both parties, INSERT requester only, UPDATE addressee only for pending→accepted, DELETE either party)
- **Full request lifecycle** — send, cancel, accept, decline, unfriend with optimistic updates and full rollback on error
- **Realtime sync** — both `useFriendships` and `usePendingRequestCount` subscribe to Postgres Changes so both users see state changes without an app reload
- **Friends UI** — friends list, incoming requests section (show 3 + inline expand), tab badge, `UserSearchResult` button state machine (Add Friend / Pending / Accept / Friends)
- **Unfriend confirmation** — in-app `Modal` matching app style (replaces native `Alert.alert`)

## Test plan

- [x] Send a friend request → other user's Friends tab shows badge + incoming request row without reload
- [x] Accept request → both users see each other in friends list without reload
- [x] Search for a user you've already requested → button shows "Pending"; tap → confirm → shows "Add Friend"
- [x] "..." → Unfriend → custom modal appears → confirm → removed from list
- [x] Cancel button in unfriend modal closes without action
- [x] Tab badge disappears after accepting/declining all requests
- [x] `npx jest` — 260 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)