### PR TITLE
feat: background geofencing + passive check-in end-to-end (Phase 5)

### DIFF
--- a/app.json
+++ b/app.json
@@ -41,12 +41,16 @@
       [
         "expo-location",
         {
-          "locationAlwaysAndWhenInUsePermission": "Dispatch uses your location to detect when you arrive at spots around Copenhagen and log your check-ins."
+          "locationAlwaysAndWhenInUsePermission": "Dispatch uses your location to detect when you arrive at spots around Copenhagen and log your check-ins.",
+          "isAndroidBackgroundLocationEnabled": true,
+          "isAndroidForegroundServiceEnabled": true
         }
       ],
       "expo-secure-store",
       "@rnmapbox/maps",
-      "expo-font"
+      "expo-font",
+      "expo-task-manager",
+      "expo-notifications"
     ],
     "experiments": {
       "typedRoutes": true

--- a/app/(app)/(tabs)/__tests__/MapScreen.test.tsx
+++ b/app/(app)/(tabs)/__tests__/MapScreen.test.tsx
@@ -37,10 +37,30 @@ jest.mock('@rnmapbox/maps', () => {
 
 jest.mock('expo-location', () => ({
   requestForegroundPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  getBackgroundPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'denied' })),
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
   getCurrentPositionAsync: jest.fn(() =>
     Promise.resolve({ coords: { latitude: 55.6761, longitude: 12.5683 } })
   ),
-  Accuracy: { High: 3 },
+  Accuracy: { High: 3, Low: 2 },
+}))
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+}))
+
+jest.mock('@/lib/backgroundGeofences', () => ({
+  registerGeofences: jest.fn(() => Promise.resolve()),
+}))
+
+jest.mock('@/lib/notifications', () => ({
+  setupNotificationCategories: jest.fn(() => Promise.resolve()),
+  CHECKIN_CATEGORY: 'geofence-checkin',
+}))
+
+jest.mock('@/components/BackgroundPermissionBanner', () => ({
+  BackgroundPermissionBanner: () => null,
 }))
 
 // ---------------------------------------------------------------------------

--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -1,8 +1,9 @@
 import Mapbox from '@rnmapbox/maps'
 import { Ionicons } from '@expo/vector-icons'
 import * as Location from 'expo-location'
+import * as Notifications from 'expo-notifications'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { Platform, Pressable, StyleSheet, Text, View } from 'react-native'
 import { Tables } from '@/types/supabase'
 import { usePois } from '@/hooks/usePois'
 import { useAllPoiRatings } from '@/hooks/useAllPoiRatings'
@@ -16,6 +17,9 @@ import { CategoryFilterBar } from '@/components/map/CategoryFilterBar'
 import { PoiBottomSheet } from '@/components/map/PoiBottomSheet'
 import { PoiListView } from '@/components/map/PoiListView'
 import { POI_CATEGORIES, PoiCategory } from '@/lib/poiCategories'
+import { registerGeofences } from '@/lib/backgroundGeofences'
+import { setupNotificationCategories } from '@/lib/notifications'
+import { BackgroundPermissionBanner } from '@/components/BackgroundPermissionBanner'
 
 type Poi = Tables<'pois'>
 
@@ -35,6 +39,7 @@ export default function MapScreen() {
   const [selectedPoi, setSelectedPoi] = useState<Poi | null>(null)
   const [viewMode, setViewMode] = useState<'map' | 'list'>('map')
   const [locationGranted, setLocationGranted] = useState(false)
+  const [backgroundGranted, setBackgroundGranted] = useState(false)
   const [locationError, setLocationError] = useState<string | null>(null)
   const cameraRef = useRef<Mapbox.Camera>(null)
   const pendingCamera = useRef<Poi | null>(null)
@@ -48,6 +53,51 @@ export default function MapScreen() {
       .catch((err) => { console.error('Location permission request failed:', err) })
     return () => { active = false }
   }, [])
+
+  // Check if background location permission has already been granted.
+  useEffect(() => {
+    if (!locationGranted) return
+    Location.getBackgroundPermissionsAsync().then(({ status }) => {
+      setBackgroundGranted(status === 'granted')
+    })
+  }, [locationGranted])
+
+  // Register geofences once background permission + POIs are available.
+  useEffect(() => {
+    if (!backgroundGranted || pois.length === 0) return
+    let cancelled = false
+
+    async function setup() {
+      try {
+        await setupNotificationCategories()
+
+        const { status } = await Notifications.getPermissionsAsync()
+        if (status !== 'granted') {
+          await Notifications.requestPermissionsAsync()
+        }
+
+        let currentLocation: { latitude: number; longitude: number } | undefined
+        try {
+          const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Low })
+          currentLocation = { latitude: loc.coords.latitude, longitude: loc.coords.longitude }
+        } catch {
+          // Fall back to Copenhagen city center (handled inside registerGeofences)
+        }
+
+        if (cancelled) return
+        await registerGeofences(
+          pois.map((p) => ({ id: p.id, name: p.name, lat: p.lat, lng: p.lng })),
+          currentLocation
+        )
+        console.log('[Geofences] registered', pois.length, 'POIs')
+      } catch (err) {
+        console.error('[Geofence registration] failed:', err)
+      }
+    }
+
+    setup()
+    return () => { cancelled = true }
+  }, [pois, backgroundGranted])
 
   const filteredPois = useMemo(
     () => pois.filter((p) => activeCategories[p.category] !== false),
@@ -149,6 +199,10 @@ export default function MapScreen() {
         <Pressable style={styles.locationButton} onPress={handleReturnToLocation} testID="return-to-location">
           <Ionicons name="locate" size={20} color="#fff" />
         </Pressable>
+      )}
+
+      {locationGranted && !backgroundGranted && (
+        <BackgroundPermissionBanner onGranted={() => setBackgroundGranted(true)} />
       )}
 
       {(poisError || ratingsError || presenceError || friendshipsError || joinsError || locationError) && (

--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -3,6 +3,7 @@ import { Ionicons } from '@expo/vector-icons'
 import * as Location from 'expo-location'
 import * as Notifications from 'expo-notifications'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { PoiSlim } from '@/lib/backgroundGeofences'
 import { Platform, Pressable, StyleSheet, Text, View } from 'react-native'
 import { Tables } from '@/types/supabase'
 import { usePois } from '@/hooks/usePois'
@@ -40,6 +41,7 @@ export default function MapScreen() {
   const [viewMode, setViewMode] = useState<'map' | 'list'>('map')
   const [locationGranted, setLocationGranted] = useState(false)
   const [backgroundGranted, setBackgroundGranted] = useState(false)
+  const [bannerDismissed, setBannerDismissed] = useState(false)
   const [locationError, setLocationError] = useState<string | null>(null)
   const cameraRef = useRef<Mapbox.Camera>(null)
   const pendingCamera = useRef<Poi | null>(null)
@@ -57,14 +59,24 @@ export default function MapScreen() {
   // Check if background location permission has already been granted.
   useEffect(() => {
     if (!locationGranted) return
-    Location.getBackgroundPermissionsAsync().then(({ status }) => {
-      setBackgroundGranted(status === 'granted')
-    })
+    Location.getBackgroundPermissionsAsync()
+      .then(({ status }) => { setBackgroundGranted(status === 'granted') })
+      .catch((err) => { console.error('[MapScreen] Failed to check background permissions:', err) })
   }, [locationGranted])
+
+  // Stable key for geofence registration — only re-register when the actual
+  // POI set changes, not on every pois array reference change. Without this,
+  // startGeofencingAsync would re-fire on every render, wiping OS transition
+  // state and potentially causing missed Enter events.
+  const poisSlim = useMemo<PoiSlim[]>(
+    () => pois.map((p) => ({ id: p.id, name: p.name, lat: p.lat, lng: p.lng })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [pois.map((p) => p.id).join(',')]
+  )
 
   // Register geofences once background permission + POIs are available.
   useEffect(() => {
-    if (!backgroundGranted || pois.length === 0) return
+    if (!backgroundGranted || poisSlim.length === 0) return
     let cancelled = false
 
     async function setup() {
@@ -73,7 +85,11 @@ export default function MapScreen() {
 
         const { status } = await Notifications.getPermissionsAsync()
         if (status !== 'granted') {
-          await Notifications.requestPermissionsAsync()
+          const { status: newStatus } = await Notifications.requestPermissionsAsync()
+          if (newStatus !== 'granted') {
+            console.warn('[Geofences] Notification permission denied — skipping geofence registration')
+            return
+          }
         }
 
         let currentLocation: { latitude: number; longitude: number } | undefined
@@ -85,19 +101,20 @@ export default function MapScreen() {
         }
 
         if (cancelled) return
-        await registerGeofences(
-          pois.map((p) => ({ id: p.id, name: p.name, lat: p.lat, lng: p.lng })),
-          currentLocation
-        )
-        console.log('[Geofences] registered', pois.length, 'POIs')
+        await registerGeofences(poisSlim, currentLocation)
+        console.log('[Geofences] registered', poisSlim.length, 'POIs')
       } catch (err) {
         console.error('[Geofence registration] failed:', err)
+        if (!cancelled) {
+          setLocationError('Automatic check-ins could not be started — try restarting the app.')
+          setTimeout(() => setLocationError(null), 5000)
+        }
       }
     }
 
     setup()
     return () => { cancelled = true }
-  }, [pois, backgroundGranted])
+  }, [poisSlim, backgroundGranted])
 
   const filteredPois = useMemo(
     () => pois.filter((p) => activeCategories[p.category] !== false),
@@ -201,8 +218,11 @@ export default function MapScreen() {
         </Pressable>
       )}
 
-      {locationGranted && !backgroundGranted && (
-        <BackgroundPermissionBanner onGranted={() => setBackgroundGranted(true)} />
+      {locationGranted && !backgroundGranted && !bannerDismissed && (
+        <BackgroundPermissionBanner
+          onGranted={() => setBackgroundGranted(true)}
+          onDismiss={() => setBannerDismissed(true)}
+        />
       )}
 
       {(poisError || ratingsError || presenceError || friendshipsError || joinsError || locationError) && (

--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -1,7 +1,11 @@
 import { Stack } from 'expo-router'
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet'
+import { useGeofenceNotifications } from '@/hooks/useGeofenceNotifications'
+import { CheckInToast } from '@/components/CheckInToast'
 
 export default function AppLayout() {
+  const { toast } = useGeofenceNotifications()
+
   return (
     <BottomSheetModalProvider>
       <Stack>
@@ -11,6 +15,7 @@ export default function AppLayout() {
           options={{ presentation: 'modal', title: 'Edit Profile' }}
         />
       </Stack>
+      <CheckInToast visible={toast.visible} message={toast.message} />
     </BottomSheetModalProvider>
   )
 }

--- a/components/BackgroundPermissionBanner.tsx
+++ b/components/BackgroundPermissionBanner.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import * as Location from 'expo-location'
+
+type Props = {
+  onGranted: () => void
+}
+
+export function BackgroundPermissionBanner({ onGranted }: Props) {
+  const [requesting, setRequesting] = useState(false)
+
+  const handlePress = async () => {
+    setRequesting(true)
+    try {
+      const { status } = await Location.requestBackgroundPermissionsAsync()
+      if (status === 'granted') onGranted()
+    } catch (err) {
+      console.error('[BackgroundPermissionBanner] request failed:', err)
+    } finally {
+      setRequesting(false)
+    }
+  }
+
+  return (
+    <View style={styles.banner}>
+      <Text style={styles.text}>
+        Allow background location to get automatic check-ins when you visit places.
+      </Text>
+      <Pressable onPress={handlePress} style={styles.button} disabled={requesting}>
+        <Text style={styles.buttonText}>{requesting ? 'Requesting...' : 'Enable'}</Text>
+      </Pressable>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    position: 'absolute',
+    bottom: 90,
+    left: 16,
+    right: 16,
+    backgroundColor: 'rgba(19, 19, 19, 0.88)',
+    borderRadius: 14,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  text: {
+    flex: 1,
+    color: '#fff',
+    fontSize: 13,
+    fontWeight: '500',
+    lineHeight: 18,
+  },
+  button: {
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+  },
+  buttonText: {
+    color: '#131313',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+})

--- a/components/BackgroundPermissionBanner.tsx
+++ b/components/BackgroundPermissionBanner.tsx
@@ -1,34 +1,64 @@
 import { useState } from 'react'
-import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { Linking, Platform, Pressable, StyleSheet, Text, View } from 'react-native'
 import * as Location from 'expo-location'
 
 type Props = {
   onGranted: () => void
+  onDismiss: () => void
 }
 
-export function BackgroundPermissionBanner({ onGranted }: Props) {
+export function BackgroundPermissionBanner({ onGranted, onDismiss }: Props) {
   const [requesting, setRequesting] = useState(false)
+  const [denied, setDenied] = useState(false)
 
   const handlePress = async () => {
+    if (denied) {
+      // After denial, guide the user to the OS settings screen.
+      Linking.openSettings()
+      return
+    }
+
     setRequesting(true)
     try {
       const { status } = await Location.requestBackgroundPermissionsAsync()
-      if (status === 'granted') onGranted()
+      if (status === 'granted') {
+        onGranted()
+      } else {
+        setDenied(true)
+      }
     } catch (err) {
       console.error('[BackgroundPermissionBanner] request failed:', err)
+      setDenied(true)
     } finally {
       setRequesting(false)
     }
   }
 
+  const message = denied
+    ? Platform.OS === 'ios'
+      ? 'Go to Settings \u2192 Location \u2192 Always to enable automatic check-ins.'
+      : 'Open Settings and allow location access "All the time" for automatic check-ins.'
+    : 'Allow background location to get automatic check-ins when you visit places.'
+
+  const buttonLabel = denied
+    ? 'Open Settings'
+    : requesting
+      ? 'Requesting...'
+      : 'Enable'
+
   return (
     <View style={styles.banner}>
-      <Text style={styles.text}>
-        Allow background location to get automatic check-ins when you visit places.
-      </Text>
-      <Pressable onPress={handlePress} style={styles.button} disabled={requesting}>
-        <Text style={styles.buttonText}>{requesting ? 'Requesting...' : 'Enable'}</Text>
-      </Pressable>
+      <View style={styles.content}>
+        <Text style={styles.text}>{message}</Text>
+        <View style={styles.actions}>
+          <Pressable onPress={handlePress} style={styles.button} disabled={requesting}>
+            <Text style={styles.buttonText}>{buttonLabel}</Text>
+          </Pressable>
+          <Pressable onPress={onDismiss} style={styles.closeButton} hitSlop={8}>
+            <Text style={styles.closeText}>{'\u00D7'}</Text>
+          </Pressable>
+        </View>
+      </View>
     </View>
   )
 }
@@ -43,6 +73,8 @@ const styles = StyleSheet.create({
     borderRadius: 14,
     paddingVertical: 14,
     paddingHorizontal: 16,
+  },
+  content: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 12,
@@ -54,6 +86,11 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     lineHeight: 18,
   },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
   button: {
     backgroundColor: '#fff',
     borderRadius: 8,
@@ -64,5 +101,17 @@ const styles = StyleSheet.create({
     color: '#131313',
     fontSize: 13,
     fontWeight: '700',
+  },
+  closeButton: {
+    width: 28,
+    height: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  closeText: {
+    color: 'rgba(255, 255, 255, 0.6)',
+    fontSize: 20,
+    fontWeight: '600',
+    lineHeight: 22,
   },
 })

--- a/components/CheckInToast.tsx
+++ b/components/CheckInToast.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react'
+import { Animated, StyleSheet, Text } from 'react-native'
+
+type Props = {
+  visible: boolean
+  message: string
+}
+
+export function CheckInToast({ visible, message }: Props) {
+  const opacity = useRef(new Animated.Value(0)).current
+
+  useEffect(() => {
+    Animated.timing(opacity, {
+      toValue: visible ? 1 : 0,
+      duration: 250,
+      useNativeDriver: true,
+    }).start()
+  }, [visible, opacity])
+
+  return (
+    <Animated.View style={[styles.container, { opacity }]} pointerEvents="none">
+      <Text style={styles.text}>{message}</Text>
+    </Animated.View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 100,
+    left: 24,
+    right: 24,
+    backgroundColor: 'rgba(19, 19, 19, 0.92)',
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    alignItems: 'center',
+  },
+  text: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+})

--- a/hooks/__tests__/useGeofenceNotifications.test.ts
+++ b/hooks/__tests__/useGeofenceNotifications.test.ts
@@ -1,0 +1,195 @@
+const React = require('react')
+
+// Track the registered listener so tests can invoke it
+let notificationResponseListener: ((response: unknown) => void) | null = null
+
+jest.mock('expo-notifications', () => ({
+  addNotificationResponseReceivedListener: jest.fn((cb) => {
+    notificationResponseListener = cb
+    return { remove: jest.fn() }
+  }),
+  dismissNotificationAsync: jest.fn().mockResolvedValue(undefined),
+  DEFAULT_ACTION_IDENTIFIER: 'expo.modules.notifications.actions.DEFAULT',
+}))
+
+jest.mock('../../lib/checkIns', () => ({
+  insertCheckIn: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('../../lib/supabase', () => ({
+  supabase: { __mock: true },
+}))
+
+jest.mock('../../lib/notifications', () => ({
+  CHECKIN_CATEGORY: 'geofence-checkin',
+  ACTION_CONFIRM: 'confirm-checkin',
+  ACTION_DISMISS: 'dismiss-checkin',
+}))
+
+import { useGeofenceNotifications } from '../useGeofenceNotifications'
+import { insertCheckIn } from '../../lib/checkIns'
+
+// Minimal renderHook using react-test-renderer (project convention)
+const { create, act } = require('react-test-renderer')
+
+function renderHook<T>(hook: () => T): { result: { current: T }; unmount: () => void } {
+  const result = { current: undefined as T }
+  let renderer: ReturnType<typeof create>
+
+  function TestComponent() {
+    result.current = hook()
+    return null
+  }
+
+  act(() => {
+    renderer = create(React.createElement(TestComponent))
+  })
+
+  return {
+    result,
+    unmount: () => act(() => renderer.unmount()),
+  }
+}
+
+function makeNotificationResponse(actionIdentifier: string, poiId?: string, poiName?: string) {
+  return {
+    actionIdentifier,
+    notification: {
+      request: {
+        identifier: 'notif-123',
+        content: {
+          categoryIdentifier: 'geofence-checkin',
+          data: { poiId, poiName },
+        },
+      },
+    },
+  }
+}
+
+describe('useGeofenceNotifications', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    notificationResponseListener = null
+  })
+
+  it('registers a notification response listener on mount', () => {
+    const Notifications = require('expo-notifications')
+    renderHook(() => useGeofenceNotifications())
+    expect(Notifications.addNotificationResponseReceivedListener).toHaveBeenCalled()
+  })
+
+  it('calls insertCheckIn on confirm action', async () => {
+    renderHook(() => useGeofenceNotifications())
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
+      )
+    })
+
+    expect(insertCheckIn).toHaveBeenCalledWith(
+      expect.objectContaining({ __mock: true }),
+      { poiId: 'poi-1' }
+    )
+  })
+
+  it('calls insertCheckIn on default action (body tap)', async () => {
+    renderHook(() => useGeofenceNotifications())
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse(
+          'expo.modules.notifications.actions.DEFAULT',
+          'poi-2',
+          'Nørrebro'
+        )
+      )
+    })
+
+    expect(insertCheckIn).toHaveBeenCalledWith(
+      expect.anything(),
+      { poiId: 'poi-2' }
+    )
+  })
+
+  it('does not call insertCheckIn on dismiss action', async () => {
+    renderHook(() => useGeofenceNotifications())
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse('dismiss-checkin', 'poi-1', 'Paludan')
+      )
+    })
+
+    expect(insertCheckIn).not.toHaveBeenCalled()
+  })
+
+  it('does not call insertCheckIn for non-geofence notification', async () => {
+    renderHook(() => useGeofenceNotifications())
+
+    await act(async () => {
+      await notificationResponseListener!({
+        actionIdentifier: 'confirm-checkin',
+        notification: {
+          request: {
+            content: {
+              categoryIdentifier: 'some-other-category',
+              data: { poiId: 'poi-1', poiName: 'Paludan' },
+            },
+          },
+        },
+      })
+    })
+
+    expect(insertCheckIn).not.toHaveBeenCalled()
+  })
+
+  it('sets toast visible on successful check-in', async () => {
+    const { result } = renderHook(() => useGeofenceNotifications())
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
+      )
+    })
+
+    expect(result.current.toast.visible).toBe(true)
+    expect(result.current.toast.message).toBe('Checked in at Paludan')
+  })
+
+  it('does not throw when insertCheckIn fails', async () => {
+    ;(insertCheckIn as jest.Mock).mockRejectedValueOnce(new Error('Not authenticated'))
+
+    renderHook(() => useGeofenceNotifications())
+
+    // Should not throw
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
+      )
+    })
+
+    expect(insertCheckIn).toHaveBeenCalled()
+  })
+
+  it('does not call insertCheckIn when poiId is missing', async () => {
+    renderHook(() => useGeofenceNotifications())
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse('confirm-checkin', undefined, 'Paludan')
+      )
+    })
+
+    expect(insertCheckIn).not.toHaveBeenCalled()
+  })
+
+  it('removes listener on unmount', () => {
+    const Notifications = require('expo-notifications')
+    const { unmount } = renderHook(() => useGeofenceNotifications())
+    const removeMock = Notifications.addNotificationResponseReceivedListener.mock.results[0].value.remove
+
+    unmount()
+    expect(removeMock).toHaveBeenCalled()
+  })
+})

--- a/hooks/__tests__/useGeofenceNotifications.test.ts
+++ b/hooks/__tests__/useGeofenceNotifications.test.ts
@@ -124,6 +124,19 @@ describe('useGeofenceNotifications', () => {
     expect(insertCheckIn).not.toHaveBeenCalled()
   })
 
+  it('dismisses notification on dismiss action', async () => {
+    const Notifications = require('expo-notifications')
+    renderHook(() => useGeofenceNotifications())
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse('dismiss-checkin', 'poi-1', 'Paludan')
+      )
+    })
+
+    expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('notif-123')
+  })
+
   it('does not call insertCheckIn for non-geofence notification', async () => {
     renderHook(() => useGeofenceNotifications())
 
@@ -157,19 +170,19 @@ describe('useGeofenceNotifications', () => {
     expect(result.current.toast.message).toBe('Checked in at Paludan')
   })
 
-  it('does not throw when insertCheckIn fails', async () => {
+  it('shows error toast when insertCheckIn fails', async () => {
     ;(insertCheckIn as jest.Mock).mockRejectedValueOnce(new Error('Not authenticated'))
 
-    renderHook(() => useGeofenceNotifications())
+    const { result } = renderHook(() => useGeofenceNotifications())
 
-    // Should not throw
     await act(async () => {
       await notificationResponseListener!(
         makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
       )
     })
 
-    expect(insertCheckIn).toHaveBeenCalled()
+    expect(result.current.toast.visible).toBe(true)
+    expect(result.current.toast.message).toBe('Check-in failed — please try again')
   })
 
   it('does not call insertCheckIn when poiId is missing', async () => {
@@ -182,6 +195,31 @@ describe('useGeofenceNotifications', () => {
     })
 
     expect(insertCheckIn).not.toHaveBeenCalled()
+  })
+
+  it('does not call insertCheckIn when poiName is missing', async () => {
+    renderHook(() => useGeofenceNotifications())
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse('confirm-checkin', 'poi-1', undefined)
+      )
+    })
+
+    expect(insertCheckIn).not.toHaveBeenCalled()
+  })
+
+  it('dismisses notification before attempting check-in', async () => {
+    const Notifications = require('expo-notifications')
+    renderHook(() => useGeofenceNotifications())
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
+      )
+    })
+
+    expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('notif-123')
   })
 
   it('removes listener on unmount', () => {

--- a/hooks/useGeofenceNotifications.ts
+++ b/hooks/useGeofenceNotifications.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useCallback, useState } from 'react'
+import * as Notifications from 'expo-notifications'
+import { supabase } from '@/lib/supabase'
+import { insertCheckIn } from '@/lib/checkIns'
+import { ACTION_CONFIRM, CHECKIN_CATEGORY } from '@/lib/notifications'
+
+export type ToastState = {
+  visible: boolean
+  message: string
+}
+
+export function useGeofenceNotifications() {
+  const [toast, setToast] = useState<ToastState>({ visible: false, message: '' })
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const showToast = useCallback((message: string) => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    setToast({ visible: true, message })
+    timeoutRef.current = setTimeout(() => {
+      setToast({ visible: false, message: '' })
+    }, 2000)
+  }, [])
+
+  useEffect(() => {
+    const subscription = Notifications.addNotificationResponseReceivedListener(
+      async (response) => {
+        const { actionIdentifier, notification } = response
+        const category = notification.request.content.categoryIdentifier
+        if (category !== CHECKIN_CATEGORY) return
+
+        // "No" button — do nothing
+        if (
+          actionIdentifier !== ACTION_CONFIRM &&
+          actionIdentifier !== Notifications.DEFAULT_ACTION_IDENTIFIER
+        ) return
+
+        const data = notification.request.content.data as {
+          poiId?: string
+          poiName?: string
+        }
+
+        if (!data?.poiId || !data?.poiName) {
+          console.error('[Geofence notification] Missing poiId or poiName in data')
+          return
+        }
+
+        // Dismiss immediately so the user can't tap it twice
+        await Notifications.dismissNotificationAsync(
+          notification.request.identifier
+        )
+
+        try {
+          await insertCheckIn(supabase, { poiId: data.poiId })
+          showToast(`Checked in at ${data.poiName}`)
+        } catch (err) {
+          console.error('[Geofence notification] Check-in failed:', err)
+        }
+      }
+    )
+
+    return () => {
+      subscription.remove()
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    }
+  }, [showToast])
+
+  return { toast }
+}

--- a/hooks/useGeofenceNotifications.ts
+++ b/hooks/useGeofenceNotifications.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useCallback, useState } from 'react'
 import * as Notifications from 'expo-notifications'
 import { supabase } from '@/lib/supabase'
 import { insertCheckIn } from '@/lib/checkIns'
-import { ACTION_CONFIRM, CHECKIN_CATEGORY } from '@/lib/notifications'
+import { ACTION_CONFIRM, ACTION_DISMISS, CHECKIN_CATEGORY } from '@/lib/notifications'
 
 export type ToastState = {
   visible: boolean
@@ -28,7 +28,15 @@ export function useGeofenceNotifications() {
         const category = notification.request.content.categoryIdentifier
         if (category !== CHECKIN_CATEGORY) return
 
-        // "No" button — do nothing
+        // Dismiss the notification on any action to prevent stale banners —
+        // on Android, notification actions do not always auto-dismiss.
+        await Notifications.dismissNotificationAsync(
+          notification.request.identifier
+        )
+
+        // Any action other than explicit confirm or default tap (banner tap) is
+        // ignored — e.g. ACTION_DISMISS ("No" button). The notification was
+        // already dismissed above.
         if (
           actionIdentifier !== ACTION_CONFIRM &&
           actionIdentifier !== Notifications.DEFAULT_ACTION_IDENTIFIER
@@ -44,16 +52,12 @@ export function useGeofenceNotifications() {
           return
         }
 
-        // Dismiss immediately so the user can't tap it twice
-        await Notifications.dismissNotificationAsync(
-          notification.request.identifier
-        )
-
         try {
           await insertCheckIn(supabase, { poiId: data.poiId })
           showToast(`Checked in at ${data.poiName}`)
         } catch (err) {
           console.error('[Geofence notification] Check-in failed:', err)
+          showToast('Check-in failed — please try again')
         }
       }
     )

--- a/hooks/useProximity.ts
+++ b/hooks/useProximity.ts
@@ -1,23 +1,8 @@
 import { useState, useEffect } from 'react'
 import * as Location from 'expo-location'
+import { getDistanceMeters } from '@/lib/geo'
 
-// Haversine formula — returns distance in metres between two lat/lng points.
-export function getDistanceMeters(
-  lat1: number, lng1: number,
-  lat2: number, lng2: number
-): number {
-  const R = 6_371_000 // Earth radius in metres
-  const toRad = (deg: number) => (deg * Math.PI) / 180
-
-  const dLat = toRad(lat2 - lat1)
-  const dLng = toRad(lng2 - lng1)
-
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2
-
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
-}
+export { getDistanceMeters }
 
 export function useProximity(
   target: { lat: number; lng: number } | null,

--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+// Custom entry point — task definitions must be registered before the app
+// component tree mounts. In headless JS mode (background geofence events),
+// expo-router never renders components, so side-effect imports inside layout
+// files are never executed. Importing here guarantees defineTask runs in both
+// foreground and headless contexts.
+import './lib/backgroundGeofences';
+import './lib/notifications';
+
+import 'expo-router/entry';

--- a/lib/__tests__/backgroundGeofences.test.ts
+++ b/lib/__tests__/backgroundGeofences.test.ts
@@ -17,6 +17,7 @@ jest.mock('expo-location', () => ({
 }))
 jest.mock('expo-notifications', () => ({
   scheduleNotificationAsync: jest.fn().mockResolvedValue('notif-id'),
+  SchedulableTriggerInputTypes: { TIME_INTERVAL: 'timeInterval' },
 }))
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn().mockResolvedValue(null),
@@ -24,6 +25,19 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 }))
 jest.mock('../notifications', () => ({
   CHECKIN_CATEGORY: 'geofence-checkin',
+}))
+jest.mock('../supabase', () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      select: jest.fn(() => Promise.resolve({
+        data: [
+          { id: 'poi-1', name: 'Alpha', lat: 55.676, lng: 12.568 },
+          { id: 'poi-2', name: 'Bravo', lat: 55.680, lng: 12.570 },
+        ],
+        error: null,
+      })),
+    })),
+  },
 }))
 
 const SAMPLE_POIS: PoiSlim[] = [
@@ -132,6 +146,30 @@ describe('geofence task handler', () => {
     expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled()
   })
 
+  it('does not schedule notification when error is provided', async () => {
+    await handler({
+      data: {
+        eventType: 1,
+        region: { identifier: 'poi-1::Paludan' },
+      },
+      error: { message: 'Location unavailable' },
+    })
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled()
+  })
+
+  it('does not schedule notification when region.identifier is missing', async () => {
+    await handler({
+      data: {
+        eventType: 1,
+        region: { identifier: '' },
+      },
+      error: null,
+    })
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled()
+  })
+
   it('suppresses notification within cooldown window', async () => {
     AsyncStorage.getItem.mockResolvedValue((Date.now() - 1000).toString()) // 1 second ago
 
@@ -179,7 +217,7 @@ describe('geofence task handler', () => {
     )
   })
 
-  it('sets cooldown in AsyncStorage after firing', async () => {
+  it('sets cooldown only after successful notification', async () => {
     await handler({
       data: {
         eventType: 1,
@@ -188,10 +226,159 @@ describe('geofence task handler', () => {
       error: null,
     })
 
+    // Verify setCooldown was called after scheduleNotificationAsync
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled()
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'geofence-cooldown:poi-1',
       expect.any(String)
     )
+  })
+
+  it('does not set cooldown when notification fails', async () => {
+    Notifications.scheduleNotificationAsync.mockRejectedValueOnce(new Error('Channel not found'))
+
+    await handler({
+      data: {
+        eventType: 1,
+        region: { identifier: 'poi-1::Paludan' },
+      },
+      error: null,
+    })
+
+    // setCooldown (setItem for cooldown key) should NOT have been called
+    expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
+      'geofence-cooldown:poi-1',
+      expect.any(String)
+    )
+  })
+
+  it('allows notification when AsyncStorage.getItem fails (cooldown check)', async () => {
+    AsyncStorage.getItem.mockRejectedValueOnce(new Error('Storage full'))
+
+    await handler({
+      data: {
+        eventType: 1,
+        region: { identifier: 'poi-1::Paludan' },
+      },
+      error: null,
+    })
+
+    // Should allow the notification rather than silently blocking
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled()
+  })
+})
+
+describe('SLC task handler', () => {
+  const TaskManager = require('expo-task-manager')
+  const AsyncStorage = require('@react-native-async-storage/async-storage')
+  const Location = require('expo-location')
+  const originalOS = Platform.OS
+
+  const slcCall = TaskManager.defineTask.mock.calls.find(
+    (c: [string, unknown]) => c[0] === 'dispatch-slc-task'
+  )
+  const handler = slcCall![1] as (args: { data: unknown; error: unknown }) => Promise<void>
+
+  beforeEach(() => {
+    AsyncStorage.getItem.mockReset()
+    AsyncStorage.setItem.mockReset()
+    AsyncStorage.getItem.mockResolvedValue(null)
+    AsyncStorage.setItem.mockResolvedValue(undefined)
+    Location.startGeofencingAsync.mockClear()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(Platform, 'OS', { value: originalOS })
+  })
+
+  it('skips re-registration on Android', async () => {
+    Object.defineProperty(Platform, 'OS', { value: 'android' })
+
+    await handler({
+      data: { locations: [{ coords: { latitude: 55.676, longitude: 12.568 } }] },
+      error: null,
+    })
+
+    expect(Location.startGeofencingAsync).not.toHaveBeenCalled()
+  })
+
+  it('skips when locations array is empty', async () => {
+    Object.defineProperty(Platform, 'OS', { value: 'ios' })
+
+    await handler({
+      data: { locations: [] },
+      error: null,
+    })
+
+    expect(Location.startGeofencingAsync).not.toHaveBeenCalled()
+  })
+
+  it('skips when distance moved is below threshold', async () => {
+    Object.defineProperty(Platform, 'OS', { value: 'ios' })
+
+    // Stored location is very close to the new one (< 500m)
+    AsyncStorage.getItem.mockResolvedValue(JSON.stringify({ latitude: 55.676, longitude: 12.568 }))
+
+    await handler({
+      data: { locations: [{ coords: { latitude: 55.6761, longitude: 12.5681 } }] },
+      error: null,
+    })
+
+    expect(Location.startGeofencingAsync).not.toHaveBeenCalled()
+  })
+
+  it('re-registers and updates stored location when distance exceeds threshold', async () => {
+    Object.defineProperty(Platform, 'OS', { value: 'ios' })
+
+    // Stored location is far from the new one (> 500m)
+    AsyncStorage.getItem.mockResolvedValue(JSON.stringify({ latitude: 55.670, longitude: 12.560 }))
+
+    await handler({
+      data: { locations: [{ coords: { latitude: 55.690, longitude: 12.590 } }] },
+      error: null,
+    })
+
+    expect(Location.startGeofencingAsync).toHaveBeenCalled()
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'geofence-slc-last-loc',
+      JSON.stringify({ latitude: 55.690, longitude: 12.590 })
+    )
+  })
+
+  it('does not throw when error parameter is provided', async () => {
+    await handler({
+      data: { locations: [] },
+      error: { message: 'something broke' },
+    })
+
+    expect(Location.startGeofencingAsync).not.toHaveBeenCalled()
+  })
+})
+
+describe('stopGeofences', () => {
+  const Location = require('expo-location')
+
+  beforeEach(() => {
+    Location.stopGeofencingAsync.mockClear()
+    Location.stopLocationUpdatesAsync.mockClear()
+    Location.stopGeofencingAsync.mockResolvedValue(undefined)
+    Location.stopLocationUpdatesAsync.mockResolvedValue(undefined)
+  })
+
+  it('calls both stop functions', async () => {
+    const { stopGeofences } = require('../backgroundGeofences')
+    await stopGeofences()
+
+    expect(Location.stopGeofencingAsync).toHaveBeenCalledWith('dispatch-geofence-task')
+    expect(Location.stopLocationUpdatesAsync).toHaveBeenCalledWith('dispatch-slc-task')
+  })
+
+  it('does not throw when tasks are not registered', async () => {
+    Location.stopGeofencingAsync.mockRejectedValue(new Error('Task not registered'))
+    Location.stopLocationUpdatesAsync.mockRejectedValue(new Error('Task not found'))
+
+    const { stopGeofences } = require('../backgroundGeofences')
+    await expect(stopGeofences()).resolves.toBeUndefined()
   })
 })
 
@@ -213,7 +400,6 @@ describe('registerGeofences', () => {
 
   it('registers all POIs on Android (limit 100 > 63 POIs)', async () => {
     Object.defineProperty(Platform, 'OS', { value: 'android' })
-    // Re-import to pick up the new Platform.OS
     const { registerGeofences } = require('../backgroundGeofences')
 
     // Generate 63 POIs — all fit under Android's 100 limit
@@ -245,5 +431,41 @@ describe('registerGeofences', () => {
 
     const regions = Location.startGeofencingAsync.mock.calls[0][1]
     expect(regions).toHaveLength(20)
+  })
+
+  it('uses Copenhagen center when no currentLocation provided', async () => {
+    Object.defineProperty(Platform, 'OS', { value: 'ios' })
+    const { registerGeofences } = require('../backgroundGeofences')
+
+    const pois: PoiSlim[] = Array.from({ length: 5 }, (_, i) => ({
+      id: `poi-${i}`,
+      name: `Place ${i}`,
+      lat: 55.676 + i * 0.01,
+      lng: 12.568 + i * 0.01,
+    }))
+
+    await registerGeofences(pois) // no second argument
+
+    expect(Location.startGeofencingAsync).toHaveBeenCalled()
+    const regions = Location.startGeofencingAsync.mock.calls[0][1]
+    expect(regions).toHaveLength(5)
+  })
+
+  it('sets notifyOnEnter: true and notifyOnExit: false on each region', async () => {
+    Object.defineProperty(Platform, 'OS', { value: 'ios' })
+    const { registerGeofences } = require('../backgroundGeofences')
+
+    const pois: PoiSlim[] = [
+      { id: 'poi-1', name: 'Test', lat: 55.676, lng: 12.568 },
+    ]
+
+    await registerGeofences(pois, { latitude: 55.676, longitude: 12.568 })
+
+    const regions = Location.startGeofencingAsync.mock.calls[0][1]
+    expect(regions[0]).toEqual(expect.objectContaining({
+      notifyOnEnter: true,
+      notifyOnExit: false,
+      radius: 100,
+    }))
   })
 })

--- a/lib/__tests__/backgroundGeofences.test.ts
+++ b/lib/__tests__/backgroundGeofences.test.ts
@@ -115,9 +115,8 @@ describe('geofence task handler', () => {
         body: 'Are you here? Tap to check in!',
         categoryIdentifier: 'geofence-checkin',
         data: { poiId: 'poi-1', poiName: 'Paludan Bogcafé' },
-        android: { channelId: 'checkin' },
       },
-      trigger: null,
+      trigger: null, // Platform.OS defaults to 'ios' in jest; Android uses TIME_INTERVAL trigger with channelId
     })
   })
 

--- a/lib/__tests__/backgroundGeofences.test.ts
+++ b/lib/__tests__/backgroundGeofences.test.ts
@@ -1,0 +1,250 @@
+import { Platform } from 'react-native'
+import { getNearestPois, getGeofenceLimit, PoiSlim } from '../backgroundGeofences'
+
+// Mock the modules that defineTask calls at import time
+jest.mock('expo-task-manager', () => ({
+  defineTask: jest.fn(),
+  isTaskRegisteredAsync: jest.fn().mockResolvedValue(false),
+}))
+jest.mock('expo-location', () => ({
+  startGeofencingAsync: jest.fn().mockResolvedValue(undefined),
+  startLocationUpdatesAsync: jest.fn().mockResolvedValue(undefined),
+  stopGeofencingAsync: jest.fn().mockResolvedValue(undefined),
+  stopLocationUpdatesAsync: jest.fn().mockResolvedValue(undefined),
+  LocationGeofencingEventType: { Enter: 1, Exit: 2 },
+  Accuracy: { Low: 2, Balanced: 3 },
+  ActivityType: { Other: 3 },
+}))
+jest.mock('expo-notifications', () => ({
+  scheduleNotificationAsync: jest.fn().mockResolvedValue('notif-id'),
+}))
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('../notifications', () => ({
+  CHECKIN_CATEGORY: 'geofence-checkin',
+}))
+
+const SAMPLE_POIS: PoiSlim[] = [
+  { id: 'a', name: 'Alpha', lat: 55.676, lng: 12.568 },
+  { id: 'b', name: 'Bravo', lat: 55.680, lng: 12.570 },
+  { id: 'c', name: 'Charlie', lat: 55.690, lng: 12.580 },
+  { id: 'd', name: 'Delta', lat: 55.700, lng: 12.600 },
+  { id: 'e', name: 'Echo', lat: 55.750, lng: 12.650 },
+]
+
+describe('getNearestPois', () => {
+  it('returns the N nearest POIs sorted by distance', () => {
+    // User is at Alpha's location — Alpha should be first
+    const result = getNearestPois(SAMPLE_POIS, 55.676, 12.568, 3)
+    expect(result).toHaveLength(3)
+    expect(result[0].id).toBe('a') // closest
+    expect(result[1].id).toBe('b') // second closest
+    expect(result[2].id).toBe('c') // third closest
+  })
+
+  it('returns all POIs when limit exceeds array length', () => {
+    const result = getNearestPois(SAMPLE_POIS, 55.676, 12.568, 100)
+    expect(result).toHaveLength(SAMPLE_POIS.length)
+  })
+
+  it('returns empty array for empty input', () => {
+    const result = getNearestPois([], 55.676, 12.568, 5)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not mutate the original array', () => {
+    const original = [...SAMPLE_POIS]
+    getNearestPois(SAMPLE_POIS, 55.750, 12.650, 2)
+    expect(SAMPLE_POIS).toEqual(original)
+  })
+})
+
+describe('getGeofenceLimit', () => {
+  const originalOS = Platform.OS
+
+  afterEach(() => {
+    Object.defineProperty(Platform, 'OS', { value: originalOS })
+  })
+
+  it('returns 20 for iOS', () => {
+    Object.defineProperty(Platform, 'OS', { value: 'ios' })
+    expect(getGeofenceLimit()).toBe(20)
+  })
+
+  it('returns 100 for Android', () => {
+    Object.defineProperty(Platform, 'OS', { value: 'android' })
+    expect(getGeofenceLimit()).toBe(100)
+  })
+})
+
+describe('geofence task handler', () => {
+  const TaskManager = require('expo-task-manager')
+  const Notifications = require('expo-notifications')
+  const AsyncStorage = require('@react-native-async-storage/async-storage')
+
+  // Capture the handler at describe time — before any beforeEach clearAllMocks runs.
+  // defineTask was called at module-load time when backgroundGeofences.ts was imported.
+  const geofenceCall = TaskManager.defineTask.mock.calls.find(
+    (c: [string, unknown]) => c[0] === 'dispatch-geofence-task'
+  )
+  const handler = geofenceCall![1] as (args: { data: unknown; error: unknown }) => Promise<void>
+
+  beforeEach(() => {
+    // Only clear the mocks we use in each test — not defineTask itself
+    Notifications.scheduleNotificationAsync.mockClear()
+    AsyncStorage.getItem.mockReset()
+    AsyncStorage.setItem.mockReset()
+    AsyncStorage.getItem.mockResolvedValue(null)
+    AsyncStorage.setItem.mockResolvedValue(undefined)
+  })
+
+  it('schedules a notification on geofence enter', async () => {
+    await handler({
+      data: {
+        eventType: 1, // Enter
+        region: { identifier: 'poi-1::Paludan Bogcafé' },
+      },
+      error: null,
+    })
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+      content: {
+        title: "You're at Paludan Bogcafé",
+        body: 'Are you here? Tap to check in!',
+        categoryIdentifier: 'geofence-checkin',
+        data: { poiId: 'poi-1', poiName: 'Paludan Bogcafé' },
+        android: { channelId: 'checkin' },
+      },
+      trigger: null,
+    })
+  })
+
+  it('does not schedule notification on exit event', async () => {
+    await handler({
+      data: {
+        eventType: 2, // Exit
+        region: { identifier: 'poi-1::Paludan' },
+      },
+      error: null,
+    })
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled()
+  })
+
+  it('suppresses notification within cooldown window', async () => {
+    AsyncStorage.getItem.mockResolvedValue((Date.now() - 1000).toString()) // 1 second ago
+
+    await handler({
+      data: {
+        eventType: 1,
+        region: { identifier: 'poi-1::Paludan' },
+      },
+      error: null,
+    })
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled()
+  })
+
+  it('fires notification after cooldown expires', async () => {
+    const twoHoursAgo = Date.now() - (2 * 60 * 60 * 1000 + 1000)
+    AsyncStorage.getItem.mockResolvedValue(twoHoursAgo.toString())
+
+    await handler({
+      data: {
+        eventType: 1,
+        region: { identifier: 'poi-1::Paludan' },
+      },
+      error: null,
+    })
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled()
+  })
+
+  it('correctly parses identifier with :: in the POI name', async () => {
+    await handler({
+      data: {
+        eventType: 1,
+        region: { identifier: 'poi-1::Café :: Lounge' },
+      },
+      error: null,
+    })
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({
+          data: { poiId: 'poi-1', poiName: 'Café :: Lounge' },
+        }),
+      })
+    )
+  })
+
+  it('sets cooldown in AsyncStorage after firing', async () => {
+    await handler({
+      data: {
+        eventType: 1,
+        region: { identifier: 'poi-1::Paludan' },
+      },
+      error: null,
+    })
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'geofence-cooldown:poi-1',
+      expect.any(String)
+    )
+  })
+})
+
+describe('registerGeofences', () => {
+  const Location = require('expo-location')
+  const TaskManagerReg = require('expo-task-manager')
+  const originalOS = Platform.OS
+
+  beforeEach(() => {
+    Location.startGeofencingAsync.mockClear()
+    Location.startLocationUpdatesAsync.mockClear()
+    TaskManagerReg.isTaskRegisteredAsync.mockClear()
+    TaskManagerReg.isTaskRegisteredAsync.mockResolvedValue(false)
+  })
+
+  afterEach(() => {
+    Object.defineProperty(Platform, 'OS', { value: originalOS })
+  })
+
+  it('registers all POIs on Android (limit 100 > 63 POIs)', async () => {
+    Object.defineProperty(Platform, 'OS', { value: 'android' })
+    // Re-import to pick up the new Platform.OS
+    const { registerGeofences } = require('../backgroundGeofences')
+
+    // Generate 63 POIs — all fit under Android's 100 limit
+    const pois: PoiSlim[] = Array.from({ length: 63 }, (_, i) => ({
+      id: `poi-${i}`,
+      name: `Place ${i}`,
+      lat: 55.676 + i * 0.001,
+      lng: 12.568 + i * 0.001,
+    }))
+
+    await registerGeofences(pois, { latitude: 55.676, longitude: 12.568 })
+
+    const regions = Location.startGeofencingAsync.mock.calls[0][1]
+    expect(regions).toHaveLength(63)
+  })
+
+  it('registers nearest 20 POIs on iOS', async () => {
+    Object.defineProperty(Platform, 'OS', { value: 'ios' })
+    const { registerGeofences } = require('../backgroundGeofences')
+
+    const pois: PoiSlim[] = Array.from({ length: 63 }, (_, i) => ({
+      id: `poi-${i}`,
+      name: `Place ${i}`,
+      lat: 55.676 + i * 0.001,
+      lng: 12.568 + i * 0.001,
+    }))
+
+    await registerGeofences(pois, { latitude: 55.676, longitude: 12.568 })
+
+    const regions = Location.startGeofencingAsync.mock.calls[0][1]
+    expect(regions).toHaveLength(20)
+  })
+})

--- a/lib/__tests__/checkIns.test.ts
+++ b/lib/__tests__/checkIns.test.ts
@@ -1,0 +1,115 @@
+import { insertCheckIn } from '../checkIns'
+import { SupabaseClient } from '@supabase/supabase-js'
+import { Database } from '../../types/supabase'
+
+const MOCK_USER_ID = 'user-123'
+const MOCK_POI_ID = 'poi-456'
+const MOCK_SEMESTER_ID = 'sem-789'
+
+type MockSupabase = {
+  from: jest.Mock
+  auth: { getUser: jest.Mock }
+}
+
+function makeMockSupabase({
+  profileResult = { data: { semester_id: MOCK_SEMESTER_ID }, error: null },
+  insertResult = { error: null },
+}: {
+  profileResult?: { data: { semester_id: string | null } | null; error: { message: string } | null }
+  insertResult?: { error: { message: string } | null }
+} = {}): MockSupabase {
+  const single = jest.fn().mockResolvedValue(profileResult)
+  const eqProfile = jest.fn().mockReturnValue({ single })
+  const selectProfile = jest.fn().mockReturnValue({ eq: eqProfile })
+
+  const insert = jest.fn().mockResolvedValue(insertResult)
+
+  const from = jest.fn().mockImplementation((table: string) => {
+    if (table === 'profiles') return { select: selectProfile }
+    if (table === 'check_ins') return { insert }
+    return {}
+  })
+
+  const getUser = jest.fn().mockResolvedValue({
+    data: { user: { id: MOCK_USER_ID } },
+    error: null,
+  })
+
+  return { from, auth: { getUser } }
+}
+
+function asClient(mock: MockSupabase): SupabaseClient<Database> {
+  return mock as unknown as SupabaseClient<Database>
+}
+
+describe('insertCheckIn', () => {
+  it('inserts a check-in with correct user_id, poi_id, and semester_id', async () => {
+    const mock = makeMockSupabase()
+    await insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })
+
+    expect(mock.from).toHaveBeenCalledWith('check_ins')
+    const checkInsFrom = mock.from.mock.results.find(
+      (_r: { value: unknown }, i: number) => mock.from.mock.calls[i][0] === 'check_ins'
+    )!.value
+    expect(checkInsFrom.insert).toHaveBeenCalledWith({
+      user_id: MOCK_USER_ID,
+      poi_id: MOCK_POI_ID,
+      semester_id: MOCK_SEMESTER_ID,
+    })
+  })
+
+  it('handles null semester_id from profile', async () => {
+    const mock = makeMockSupabase({
+      profileResult: { data: { semester_id: null }, error: null },
+    })
+    await insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })
+
+    const checkInsFrom = mock.from.mock.results.find(
+      (_r: { value: unknown }, i: number) => mock.from.mock.calls[i][0] === 'check_ins'
+    )!.value
+    expect(checkInsFrom.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ semester_id: null })
+    )
+  })
+
+  it('throws when user is not authenticated', async () => {
+    const mock = makeMockSupabase()
+    mock.auth.getUser.mockResolvedValue({ data: { user: null }, error: null })
+
+    await expect(
+      insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws when auth returns an error', async () => {
+    const mock = makeMockSupabase()
+    mock.auth.getUser.mockResolvedValue({
+      data: { user: null },
+      error: { message: 'auth error' },
+    })
+
+    await expect(
+      insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })
+    ).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws when profile fetch fails', async () => {
+    const mock = makeMockSupabase({
+      profileResult: { data: null, error: { message: 'profile not found' } },
+    })
+
+    await expect(
+      insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })
+    ).rejects.toThrow('profile not found')
+  })
+
+  it('throws when check-in insert fails', async () => {
+    const mock = makeMockSupabase({
+      insertResult: { error: { message: 'insert failed' } },
+    })
+
+    await expect(
+      insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })
+    ).rejects.toThrow('insert failed')
+  })
+})

--- a/lib/backgroundGeofences.ts
+++ b/lib/backgroundGeofences.ts
@@ -13,13 +13,15 @@ import { CHECKIN_CATEGORY } from '@/lib/notifications'
 export const GEOFENCE_TASK = 'dispatch-geofence-task'
 export const SLC_TASK = 'dispatch-slc-task'
 
-const COOLDOWN_MS = 2 * 60 * 60 * 1000 // 2 hours
-const GEOFENCE_RADIUS = 100 // metres
+const COOLDOWN_MS = 2 * 60 * 60 * 1000
+const GEOFENCE_RADIUS = 100
 const COPENHAGEN_CENTER = { latitude: 55.6761, longitude: 12.5683 }
-const SLC_REREGISTER_THRESHOLD = 500 // metres — only re-register geofences when user moves 500m+
+const SLC_REREGISTER_THRESHOLD = 500
 const SLC_LAST_LOC_KEY = 'geofence-slc-last-loc'
 
-// iOS hard cap is 20 regions. Android cap is 100; all 64 V1 POIs fit.
+// iOS CLLocationManager hard cap: 20 regions. Google Play Services cap: 100.
+// If POI count exceeds ANDROID_GEOFENCE_LIMIT, the Android early-return in the
+// background location task must be removed to enable re-registration on Android.
 const IOS_GEOFENCE_LIMIT = 20
 const ANDROID_GEOFENCE_LIMIT = 100
 
@@ -55,13 +57,22 @@ export function getNearestPois(
 // ---------------------------------------------------------------------------
 
 async function isCoolingDown(poiId: string): Promise<boolean> {
-  const stored = await AsyncStorage.getItem(`geofence-cooldown:${poiId}`)
-  if (!stored) return false
-  return Date.now() - parseInt(stored, 10) < COOLDOWN_MS
+  try {
+    const stored = await AsyncStorage.getItem(`geofence-cooldown:${poiId}`)
+    if (!stored) return false
+    return Date.now() - parseInt(stored, 10) < COOLDOWN_MS
+  } catch {
+    // If AsyncStorage fails, allow the notification rather than silently blocking.
+    return false
+  }
 }
 
 async function setCooldown(poiId: string): Promise<void> {
-  await AsyncStorage.setItem(`geofence-cooldown:${poiId}`, Date.now().toString())
+  try {
+    await AsyncStorage.setItem(`geofence-cooldown:${poiId}`, Date.now().toString())
+  } catch (err) {
+    console.error('[Geofence] failed to set cooldown:', err)
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -84,9 +95,15 @@ export async function registerGeofences(
   pois: PoiSlim[],
   currentLocation?: { latitude: number; longitude: number }
 ): Promise<void> {
-  // Stop any stale SLC task from a previous session to prevent
-  // re-registration from wiping the geofence transition state.
-  try { await Location.stopLocationUpdatesAsync(SLC_TASK) } catch { /* not registered */ }
+  // Stop any stale location-update task from a previous session. A leftover
+  // task could trigger re-registration (via the SLC_TASK callback) while we
+  // are in the middle of setting up fresh geofence regions, overwriting them.
+  try { await Location.stopLocationUpdatesAsync(SLC_TASK) } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (!msg.includes('not registered') && !msg.includes('not found')) {
+      console.error('[registerGeofences] unexpected error stopping stale SLC task:', err)
+    }
+  }
 
   const loc = currentLocation ?? COPENHAGEN_CENTER
   const limit = getGeofenceLimit()
@@ -98,6 +115,8 @@ export async function registerGeofences(
   // Start background location monitoring. On Android, the foreground service
   // keeps the process alive so geofence PendingIntents are delivered in the
   // background. On iOS, this also drives nearest-20 re-registration.
+  // deferredUpdatesInterval: 0 means updates are delivered as soon as the
+  // distance threshold is reached, not on a timer.
   await Location.startLocationUpdatesAsync(SLC_TASK, {
     accuracy: Location.Accuracy.Low,
     activityType: Location.ActivityType.Other,
@@ -114,8 +133,18 @@ export async function registerGeofences(
 }
 
 export async function stopGeofences(): Promise<void> {
-  try { await Location.stopGeofencingAsync(GEOFENCE_TASK) } catch { /* not registered */ }
-  try { await Location.stopLocationUpdatesAsync(SLC_TASK) } catch { /* not registered */ }
+  try { await Location.stopGeofencingAsync(GEOFENCE_TASK) } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (!msg.includes('not registered') && !msg.includes('not found')) {
+      console.error('[stopGeofences] unexpected error stopping geofence task:', err)
+    }
+  }
+  try { await Location.stopLocationUpdatesAsync(SLC_TASK) } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (!msg.includes('not registered') && !msg.includes('not found')) {
+      console.error('[stopGeofences] unexpected error stopping SLC task:', err)
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -140,7 +169,6 @@ TaskManager.defineTask(GEOFENCE_TASK, async ({ data, error }) => {
   const poiName = nameParts.join('::')
 
   if (await isCoolingDown(poiId)) return
-  await setCooldown(poiId)
 
   try {
     await Notifications.scheduleNotificationAsync({
@@ -154,13 +182,18 @@ TaskManager.defineTask(GEOFENCE_TASK, async ({ data, error }) => {
         ? { type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL, seconds: 1, channelId: 'checkin' }
         : null,
     })
+    // Set cooldown only after successful notification — a transient failure
+    // should not burn the 2h window and silently block future prompts.
+    await setCooldown(poiId)
   } catch (err) {
     console.error('[Geofence task] failed to schedule notification:', err)
   }
 })
 
 // ---------------------------------------------------------------------------
-// Background task: significant location change → re-register nearest N
+// Background task: low-accuracy location updates → re-register nearest N
+// Uses startLocationUpdatesAsync with deferredUpdatesDistance to approximate
+// significant-location-change behavior. Not the iOS CLLocationManager SLC API.
 // ---------------------------------------------------------------------------
 
 TaskManager.defineTask(SLC_TASK, async ({ data, error }) => {
@@ -169,10 +202,11 @@ TaskManager.defineTask(SLC_TASK, async ({ data, error }) => {
     return
   }
 
-  // On Android, all 64 V1 POIs fit within the 100-region limit.
-  // The SLC task only exists to keep the foreground service alive —
-  // no re-registration needed. On iOS (20-region limit), re-register
-  // the nearest 20 when the user moves 500m+.
+  // On Android, the 100-region limit accommodates all V1 POIs. The background
+  // location task only exists to keep the foreground service alive — no
+  // re-registration needed. If POI count exceeds ANDROID_GEOFENCE_LIMIT, this
+  // early-return must be removed to enable re-registration on Android as well.
+  // On iOS (20-region limit), re-register the nearest 20 when the user moves 500m+.
   if (Platform.OS === 'android') return
 
   const { locations } = data as { locations: Location.LocationObject[] }
@@ -192,9 +226,14 @@ TaskManager.defineTask(SLC_TASK, async ({ data, error }) => {
     }
 
     const { supabase } = require('@/lib/supabase')
-    const { data: pois } = await supabase
+    const { data: pois, error: poisError } = await supabase
       .from('pois')
       .select('id, name, lat, lng')
+
+    if (poisError) {
+      console.error('[SLC task] failed to fetch POIs:', poisError.message)
+      return
+    }
 
     if (!pois || pois.length === 0) return
 

--- a/lib/backgroundGeofences.ts
+++ b/lib/backgroundGeofences.ts
@@ -1,0 +1,215 @@
+import { Platform } from 'react-native'
+import * as TaskManager from 'expo-task-manager'
+import * as Location from 'expo-location'
+import * as Notifications from 'expo-notifications'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { getDistanceMeters } from '@/lib/geo'
+import { CHECKIN_CATEGORY } from '@/lib/notifications'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const GEOFENCE_TASK = 'dispatch-geofence-task'
+export const SLC_TASK = 'dispatch-slc-task'
+
+const COOLDOWN_MS = 2 * 60 * 60 * 1000 // 2 hours
+const GEOFENCE_RADIUS = 100 // metres
+const COPENHAGEN_CENTER = { latitude: 55.6761, longitude: 12.5683 }
+const SLC_REREGISTER_THRESHOLD = 500 // metres — only re-register geofences when user moves 500m+
+const SLC_LAST_LOC_KEY = 'geofence-slc-last-loc'
+
+// iOS hard cap is 20 regions. Android cap is 100; all 64 V1 POIs fit.
+const IOS_GEOFENCE_LIMIT = 20
+const ANDROID_GEOFENCE_LIMIT = 100
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PoiSlim = { id: string; name: string; lat: number; lng: number }
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+export function getGeofenceLimit(): number {
+  return Platform.OS === 'ios' ? IOS_GEOFENCE_LIMIT : ANDROID_GEOFENCE_LIMIT
+}
+
+export function getNearestPois(
+  pois: PoiSlim[],
+  latitude: number,
+  longitude: number,
+  limit: number
+): PoiSlim[] {
+  return [...pois]
+    .map((p) => ({ poi: p, dist: getDistanceMeters(latitude, longitude, p.lat, p.lng) }))
+    .sort((a, b) => a.dist - b.dist)
+    .slice(0, limit)
+    .map((entry) => entry.poi)
+}
+
+// ---------------------------------------------------------------------------
+// Cooldown helpers (AsyncStorage)
+// ---------------------------------------------------------------------------
+
+async function isCoolingDown(poiId: string): Promise<boolean> {
+  const stored = await AsyncStorage.getItem(`geofence-cooldown:${poiId}`)
+  if (!stored) return false
+  return Date.now() - parseInt(stored, 10) < COOLDOWN_MS
+}
+
+async function setCooldown(poiId: string): Promise<void> {
+  await AsyncStorage.setItem(`geofence-cooldown:${poiId}`, Date.now().toString())
+}
+
+// ---------------------------------------------------------------------------
+// Geofence registration
+// ---------------------------------------------------------------------------
+
+export async function registerGeofenceRegions(pois: PoiSlim[]): Promise<void> {
+  const regions: Location.LocationRegion[] = pois.map((p) => ({
+    identifier: `${p.id}::${p.name}`,
+    latitude: p.lat,
+    longitude: p.lng,
+    radius: GEOFENCE_RADIUS,
+    notifyOnEnter: true,
+    notifyOnExit: false,
+  }))
+  await Location.startGeofencingAsync(GEOFENCE_TASK, regions)
+}
+
+export async function registerGeofences(
+  pois: PoiSlim[],
+  currentLocation?: { latitude: number; longitude: number }
+): Promise<void> {
+  // Stop any stale SLC task from a previous session to prevent
+  // re-registration from wiping the geofence transition state.
+  try { await Location.stopLocationUpdatesAsync(SLC_TASK) } catch { /* not registered */ }
+
+  const loc = currentLocation ?? COPENHAGEN_CENTER
+  const limit = getGeofenceLimit()
+  const nearest = getNearestPois(pois, loc.latitude, loc.longitude, limit)
+  await registerGeofenceRegions(nearest)
+
+  await AsyncStorage.setItem(SLC_LAST_LOC_KEY, JSON.stringify(loc))
+
+  // Start background location monitoring. On Android, the foreground service
+  // keeps the process alive so geofence PendingIntents are delivered in the
+  // background. On iOS, this also drives nearest-20 re-registration.
+  await Location.startLocationUpdatesAsync(SLC_TASK, {
+    accuracy: Location.Accuracy.Low,
+    activityType: Location.ActivityType.Other,
+    deferredUpdatesDistance: SLC_REREGISTER_THRESHOLD,
+    deferredUpdatesInterval: 0,
+    ...(Platform.OS === 'android' && {
+      foregroundService: {
+        notificationTitle: 'Dispatch is running',
+        notificationBody: 'Monitoring nearby places for check-ins',
+        notificationColor: '#1a73e8',
+      },
+    }),
+  })
+}
+
+export async function stopGeofences(): Promise<void> {
+  try { await Location.stopGeofencingAsync(GEOFENCE_TASK) } catch { /* not registered */ }
+  try { await Location.stopLocationUpdatesAsync(SLC_TASK) } catch { /* not registered */ }
+}
+
+// ---------------------------------------------------------------------------
+// Background task: geofence event handler
+// ---------------------------------------------------------------------------
+
+TaskManager.defineTask(GEOFENCE_TASK, async ({ data, error }) => {
+  if (error) {
+    console.error('[Geofence task] error:', error.message)
+    return
+  }
+
+  const { eventType, region } = data as {
+    eventType: Location.LocationGeofencingEventType
+    region: Location.LocationRegion
+  }
+
+  if (eventType !== Location.LocationGeofencingEventType.Enter) return
+  if (!region.identifier) return
+
+  const [poiId, ...nameParts] = region.identifier.split('::')
+  const poiName = nameParts.join('::')
+
+  if (await isCoolingDown(poiId)) return
+  await setCooldown(poiId)
+
+  try {
+    await Notifications.scheduleNotificationAsync({
+      content: {
+        title: `You're at ${poiName}`,
+        body: 'Are you here? Tap to check in!',
+        categoryIdentifier: CHECKIN_CATEGORY,
+        data: { poiId, poiName },
+        android: { channelId: 'checkin' },
+      },
+      trigger: null,
+    })
+  } catch (err) {
+    console.error('[Geofence task] failed to schedule notification:', err)
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Background task: significant location change → re-register nearest N
+// ---------------------------------------------------------------------------
+
+TaskManager.defineTask(SLC_TASK, async ({ data, error }) => {
+  if (error) {
+    console.error('[SLC task] error:', error.message)
+    return
+  }
+
+  // On Android, all 64 V1 POIs fit within the 100-region limit.
+  // The SLC task only exists to keep the foreground service alive —
+  // no re-registration needed. On iOS (20-region limit), re-register
+  // the nearest 20 when the user moves 500m+.
+  if (Platform.OS === 'android') return
+
+  const { locations } = data as { locations: Location.LocationObject[] }
+  if (!locations || locations.length === 0) return
+
+  const current = locations[locations.length - 1]
+
+  try {
+    const stored = await AsyncStorage.getItem(SLC_LAST_LOC_KEY)
+    if (stored) {
+      const last = JSON.parse(stored) as { latitude: number; longitude: number }
+      const dist = getDistanceMeters(
+        last.latitude, last.longitude,
+        current.coords.latitude, current.coords.longitude
+      )
+      if (dist < SLC_REREGISTER_THRESHOLD) return
+    }
+
+    const { supabase } = require('@/lib/supabase')
+    const { data: pois } = await supabase
+      .from('pois')
+      .select('id, name, lat, lng')
+
+    if (!pois || pois.length === 0) return
+
+    const limit = getGeofenceLimit()
+    const nearest = getNearestPois(
+      pois as PoiSlim[],
+      current.coords.latitude,
+      current.coords.longitude,
+      limit
+    )
+    await registerGeofenceRegions(nearest)
+    await AsyncStorage.setItem(
+      SLC_LAST_LOC_KEY,
+      JSON.stringify({ latitude: current.coords.latitude, longitude: current.coords.longitude })
+    )
+  } catch (err) {
+    console.error('[SLC task] failed to re-register geofences:', err)
+  }
+})

--- a/lib/backgroundGeofences.ts
+++ b/lib/backgroundGeofences.ts
@@ -149,9 +149,10 @@ TaskManager.defineTask(GEOFENCE_TASK, async ({ data, error }) => {
         body: 'Are you here? Tap to check in!',
         categoryIdentifier: CHECKIN_CATEGORY,
         data: { poiId, poiName },
-        android: { channelId: 'checkin' },
       },
-      trigger: null,
+      trigger: Platform.OS === 'android'
+        ? { type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL, seconds: 1, channelId: 'checkin' }
+        : null,
     })
   } catch (err) {
     console.error('[Geofence task] failed to schedule notification:', err)

--- a/lib/checkIns.ts
+++ b/lib/checkIns.ts
@@ -1,0 +1,26 @@
+import { SupabaseClient } from '@supabase/supabase-js'
+import { Database } from '@/types/supabase'
+
+export async function insertCheckIn(
+  supabase: SupabaseClient<Database>,
+  { poiId }: { poiId: string }
+): Promise<void> {
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) throw new Error('Not authenticated')
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('semester_id')
+    .eq('id', user.id)
+    .single()
+  if (profileError) throw new Error(profileError.message)
+
+  const { error } = await supabase
+    .from('check_ins')
+    .insert({
+      user_id: user.id,
+      poi_id: poiId,
+      semester_id: profile.semester_id,
+    })
+  if (error) throw new Error(error.message)
+}

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -1,0 +1,17 @@
+// Haversine formula — returns distance in metres between two lat/lng points.
+export function getDistanceMeters(
+  lat1: number, lng1: number,
+  lat2: number, lng2: number
+): number {
+  const R = 6_371_000 // Earth radius in metres
+  const toRad = (deg: number) => (deg * Math.PI) / 180
+
+  const dLat = toRad(lat2 - lat1)
+  const dLng = toRad(lng2 - lng1)
+
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2
+
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -29,7 +29,11 @@ export async function setupNotificationCategories(): Promise<void> {
   ])
 }
 
-// Ensure notifications display when the app is in the foreground.
+// Module-level side effect (intentional): setNotificationHandler must be
+// registered early, before any notification arrives. Imported via index.js to
+// ensure registration in both foreground and headless contexts. Currently
+// applies to all categories — scope to categoryIdentifier if additional
+// notification types are added in Phase 7.
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
     shouldShowAlert: true,

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,0 +1,41 @@
+import { Platform } from 'react-native'
+import * as Notifications from 'expo-notifications'
+
+export const CHECKIN_CATEGORY = 'geofence-checkin'
+export const ACTION_CONFIRM = 'confirm-checkin'
+export const ACTION_DISMISS = 'dismiss-checkin'
+
+export async function setupNotificationCategories(): Promise<void> {
+  if (Platform.OS === 'android') {
+    await Notifications.setNotificationChannelAsync('checkin', {
+      name: 'Check-in notifications',
+      importance: Notifications.AndroidImportance.HIGH,
+      vibrationPattern: [0, 250, 250, 250],
+      enableVibrate: true,
+    })
+  }
+
+  await Notifications.setNotificationCategoryAsync(CHECKIN_CATEGORY, [
+    {
+      identifier: ACTION_CONFIRM,
+      buttonTitle: "Yes, I'm here",
+      options: { opensAppToForeground: true },
+    },
+    {
+      identifier: ACTION_DISMISS,
+      buttonTitle: 'No',
+      options: { opensAppToForeground: false },
+    },
+  ])
+}
+
+// Ensure notifications display when the app is in the foreground.
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldShowBanner: true,
+    shouldShowList: true,
+    shouldPlaySound: false,
+    shouldSetBadge: false,
+  }),
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,11 @@
         "expo-image-picker": "~55.0.14",
         "expo-linking": "~55.0.9",
         "expo-location": "~55.1.4",
+        "expo-notifications": "~55.0.18",
         "expo-router": "~55.0.8",
         "expo-secure-store": "~55.0.9",
         "expo-status-bar": "~55.0.4",
+        "expo-task-manager": "~55.0.14",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-native": "0.83.2",
@@ -1515,32 +1517,31 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "55.0.11",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.11.tgz",
-      "integrity": "sha512-14AkSmR1gOIUhCsPJ0cAo5ZduMNsPQsmFV9jBNZn1xC5Zb3D8x5eqvUie5QzWaUwdcyrq79uYJ2bTCiC6+nD0Q==",
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.14.tgz",
+      "integrity": "sha512-CCIe6Suuy0DjC58PI6jBpK8Y3pW0BimXGP8tZrVKPqS5ECqVTei0Xp78nbC/fbO+79r6ak5Su6Os71U459j4dw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~55.0.7",
+        "@expo/config-plugins": "~55.0.8",
         "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "^10.0.12",
-        "@expo/require-utils": "^55.0.3",
+        "@expo/json-file": "^10.0.13",
+        "@expo/require-utils": "^55.0.4",
         "deepmerge": "^4.3.1",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
-        "resolve-from": "^5.0.0",
         "resolve-workspace-root": "^2.0.0",
         "semver": "^7.6.0",
         "slugify": "^1.3.4"
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "55.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.7.tgz",
-      "integrity": "sha512-XZUoDWrsHEkH3yasnDSJABM/UxP5a1ixzRwU/M+BToyn/f0nTrSJJe/Ay/FpxkI4JSNz2n0e06I23b2bleXKVA==",
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.8.tgz",
+      "integrity": "sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "~10.0.12",
+        "@expo/json-file": "~10.0.13",
         "@expo/plist": "^0.5.2",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
@@ -1648,24 +1649,24 @@
       }
     },
     "node_modules/@expo/image-utils": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.12.tgz",
-      "integrity": "sha512-3KguH7kyKqq7pNwLb9j6BBdD/bjmNwXZG/HPWT6GWIXbwrvAJt2JNyYTP5agWJ8jbbuys1yuCzmkX+TU6rmI7A==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.13.tgz",
+      "integrity": "sha512-1I//yBQeTY6p0u1ihqGNDAr35EbSG8uFEupFrIF0jd++h9EWH33521yZJU1yE+mwGlzCb61g3ehu78siMhXBlA==",
       "license": "MIT",
       "dependencies": {
+        "@expo/require-utils": "^55.0.4",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "getenv": "^2.0.0",
         "jimp-compact": "0.16.1",
         "parse-png": "^2.1.0",
-        "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "10.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.12.tgz",
-      "integrity": "sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==",
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.13.tgz",
+      "integrity": "sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -1783,9 +1784,9 @@
       }
     },
     "node_modules/@expo/require-utils": {
-      "version": "55.0.3",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.3.tgz",
-      "integrity": "sha512-TS1m5tW45q4zoaTlt6DwmdYHxvFTIxoLrTHKOFrIirHIqIXnHCzpceg8wumiBi+ZXSaGY2gobTbfv+WVhJY6Fw==",
+      "version": "55.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.4.tgz",
+      "integrity": "sha512-JAANvXqV7MOysWeVWgaiDzikoyDjJWOV/ulOW60Zb3kXJfrx2oZOtGtDXDFKD1mXuahQgoM5QOjuZhF7gFRNjA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -4202,6 +4203,12 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -5448,13 +5455,22 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-55.0.14.tgz",
+      "integrity": "sha512-NgqDIt3eCf4aVLp1L6AcEanCYoyJeuBsGrgGSzOIvxAsOvp5X3SYKW3ROgpKUnLQEKMWlzwETpjsUGszcqkk8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-constants": {
-      "version": "55.0.9",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.9.tgz",
-      "integrity": "sha512-iBiXjZeuU5S/8docQeNzsVvtDy4w0zlmXBpFEi1ypwugceEpdQQab65TVRbusXAcwpNVxCPMpNlDssYp0Pli2g==",
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.13.tgz",
+      "integrity": "sha512-imSsHm94KWsJbBLvjsUNgubcPQ3H6dXaAm0IZj2Y6+XEdJmjWo2JreriYmeSu/azmpiYUd3Y7K+/Hq9WXQ2Elg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~55.0.10",
+        "@expo/config": "~55.0.14",
         "@expo/env": "~2.1.1"
       },
       "peerDependencies": {
@@ -5652,6 +5668,24 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-notifications": {
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-55.0.18.tgz",
+      "integrity": "sha512-NxA9zdADnsQ5g66cznpu3m+bFMyoi7XKN+GkKZCRQ0RJAi4NXwB+1mljzdCAt5TGlcnAwwVBw+3zC1B9qORfcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.13",
+        "abort-controller": "^3.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~55.0.14",
+        "expo-constants": "~55.0.13"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-router": {
       "version": "55.0.8",
       "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-55.0.8.tgz",
@@ -5813,6 +5847,19 @@
         "expo": "*",
         "expo-font": "*",
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-task-manager": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-task-manager/-/expo-task-manager-55.0.14.tgz",
+      "integrity": "sha512-KWee8OhusVJYkhCfFtZ1AqsjkbnTqErgcV595CY0mUQZK7Phhe1qJsv9xiIpxTI0nbOS/248nvm/FcVOrZPaPw==",
+      "license": "MIT",
+      "dependencies": {
+        "unimodules-app-loader": "~55.0.4"
+      },
+      "peerDependencies": {
+        "expo": "*",
         "react-native": "*"
       }
     },
@@ -11592,6 +11639,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/unimodules-app-loader": {
+      "version": "55.0.4",
+      "resolved": "https://registry.npmjs.org/unimodules-app-loader/-/unimodules-app-loader-55.0.4.tgz",
+      "integrity": "sha512-l3vMWR/lYLTj3JE4rhIX5vDVMDY9nGS550XaB90HENqUQnBEMdhhOpI8tOA37QJOUZE6pCQGeQX6mIdEu3uqzg==",
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dispatch",
   "version": "1.0.0",
-  "main": "expo-router/entry",
+  "main": "index.js",
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",
@@ -26,9 +26,11 @@
     "expo-image-picker": "~55.0.14",
     "expo-linking": "~55.0.9",
     "expo-location": "~55.1.4",
+    "expo-notifications": "~55.0.18",
     "expo-router": "~55.0.8",
     "expo-secure-store": "~55.0.9",
     "expo-status-bar": "~55.0.4",
+    "expo-task-manager": "~55.0.14",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.2",

--- a/supabase/migrations/021_check_ins.sql
+++ b/supabase/migrations/021_check_ins.sql
@@ -1,0 +1,20 @@
+-- Check-ins — immutable append-only log of passive geofence check-ins.
+-- No UPDATE or DELETE policies: Postgres denies them by default when RLS is enabled.
+
+create table public.check_ins (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  poi_id uuid not null references public.pois(id),
+  checked_in_at timestamptz default now(),
+  semester_id uuid references public.semesters(id)
+);
+
+alter table public.check_ins enable row level security;
+
+create policy "Users can view own check-ins"
+  on check_ins for select to authenticated
+  using (auth.uid() = user_id);
+
+create policy "Users can insert own check-ins"
+  on check_ins for insert to authenticated
+  with check (auth.uid() = user_id);

--- a/supabase/migrations/021_check_ins.sql
+++ b/supabase/migrations/021_check_ins.sql
@@ -1,5 +1,6 @@
 -- Check-ins — immutable append-only log of passive geofence check-ins.
--- No UPDATE or DELETE policies: Postgres denies them by default when RLS is enabled.
+-- No UPDATE or DELETE policies defined — RLS implicitly denies these operations
+-- for authenticated client requests. The service_role key bypasses RLS.
 
 create table public.check_ins (
   id uuid primary key default gen_random_uuid(),

--- a/supabase/migrations/022_check_ins_not_null_timestamp.sql
+++ b/supabase/migrations/022_check_ins_not_null_timestamp.sql
@@ -1,0 +1,5 @@
+-- Ensure every check-in has a timestamp. The column already defaults to now(),
+-- but without NOT NULL a crafted insert could omit it. Backfill any NULLs first.
+
+update public.check_ins set checked_in_at = now() where checked_in_at is null;
+alter table public.check_ins alter column checked_in_at set not null;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -39,6 +39,45 @@ export type Database = {
   }
   public: {
     Tables: {
+      check_ins: {
+        Row: {
+          checked_in_at: string | null
+          id: string
+          poi_id: string
+          semester_id: string | null
+          user_id: string
+        }
+        Insert: {
+          checked_in_at?: string | null
+          id?: string
+          poi_id: string
+          semester_id?: string | null
+          user_id: string
+        }
+        Update: {
+          checked_in_at?: string | null
+          id?: string
+          poi_id?: string
+          semester_id?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "check_ins_poi_id_fkey"
+            columns: ["poi_id"]
+            isOneToOne: false
+            referencedRelation: "pois"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "check_ins_semester_id_fkey"
+            columns: ["semester_id"]
+            isOneToOne: false
+            referencedRelation: "semesters"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       friendships: {
         Row: {
           addressee_id: string

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -41,21 +41,21 @@ export type Database = {
     Tables: {
       check_ins: {
         Row: {
-          checked_in_at: string | null
+          checked_in_at: string
           id: string
           poi_id: string
           semester_id: string | null
           user_id: string
         }
         Insert: {
-          checked_in_at?: string | null
+          checked_in_at?: string
           id?: string
           poi_id: string
           semester_id?: string | null
           user_id: string
         }
         Update: {
-          checked_in_at?: string | null
+          checked_in_at?: string
           id?: string
           poi_id?: string
           semester_id?: string | null


### PR DESCRIPTION
## Summary

- **End-to-end passive check-in pipeline**: OS geofence entry → background task → local notification → confirm tap → `check_ins` row inserted → toast shown
- **Custom entry point `index.js`**: ensures `TaskManager.defineTask` runs in headless JS context (Expo Router lazy-loads routes, so `app/_layout.tsx` never executes without a React tree)
- **Android all-POIs / iOS nearest-20**: Android's 100-region limit fits all 63 POIs; iOS uses SLC task to re-register nearest 20 on 500m+ movement

## New files

| File | Purpose |
|------|---------|
| `index.js` | Custom entry point — registers background tasks before `expo-router/entry` |
| `supabase/migrations/021_check_ins.sql` | `check_ins` table — immutable append-only, RLS on own rows |
| `lib/geo.ts` | `getDistanceMeters` haversine extracted from `useProximity` |
| `lib/checkIns.ts` | `insertCheckIn` — auth + semester_id lookup + insert |
| `lib/notifications.ts` | Notification categories, Android `checkin` channel (IMPORTANCE_HIGH), foreground handler |
| `lib/backgroundGeofences.ts` | `GEOFENCE_TASK` + `SLC_TASK` handlers, `registerGeofences`, 2h cooldown |
| `hooks/useGeofenceNotifications.ts` | Notification response listener — confirm/dismiss → insert + toast |
| `components/CheckInToast.tsx` | Animated fade-in/out bottom toast |
| `components/BackgroundPermissionBanner.tsx` | Inline banner when foreground granted but background denied |

## Modified files

- `app.json` — added `expo-task-manager`, `expo-notifications` plugins; `expo-location` updated with Android background + foreground service flags
- `package.json` — `main` → `index.js`; added `expo-notifications`, `expo-task-manager` deps
- `app/(app)/_layout.tsx` — wires `useGeofenceNotifications` + renders `CheckInToast`
- `app/(app)/(tabs)/index.tsx` — background permission check, geofence registration effect, `BackgroundPermissionBanner`
- `hooks/useProximity.ts` — re-exports `getDistanceMeters` from `lib/geo.ts`
- `types/supabase.ts` — manually added `check_ins` table type (pending `supabase gen types` regeneration)

## Test plan

- [x] Install dev build APK via `eas build --platform android --profile development`
- [x] Enable background location permission in Android Settings → Dispatch → Location → "Allow all the time"
- [x] Use Fake GPS Location app to simulate entering a POI geofence (~100m radius)
- [x] Verify heads-up notification appears with "Yes, I'm here" / "No" buttons
- [x] Tap "Yes, I'm here" → confirm `check_ins` row appears in Supabase dashboard
- [x] Verify notification is dismissed after tap (no duplicate on second tap)
- [x] Verify in-app toast shows "Checked in at [Place]"
- [x] Simulate second entry within 2h — confirm no notification (cooldown)
- [x] Deny background permission — verify `BackgroundPermissionBanner` appears
- [x] 325 unit tests passing (`npx jest`)

## What's not in this PR (remaining Phase 5)

- Geofence arrival detection ("Did [Name] arrive?" broadcaster prompt)
- Broadcast auto-dismiss on geofence exit
- iOS SLC re-registration untested on physical device

🤖 Generated with [Claude Code](https://claude.com/claude-code)