### PR TITLE
fix: suppress spurious CLOSED log on background/unmount in Realtime hooks

### DIFF
--- a/hooks/__tests__/useFriendships.test.ts
+++ b/hooks/__tests__/useFriendships.test.ts
@@ -37,14 +37,15 @@ import { useFriendships } from '../useFriendships'
 
 type HookResult<T> = { current: T }
 
-function renderHook<T>(useHook: () => T): HookResult<T> {
+function renderHook<T>(useHook: () => T): { result: HookResult<T>; unmount: () => void } {
   const result: HookResult<T> = { current: undefined as unknown as T }
+  let root: ReturnType<typeof create>
   function TestComponent() {
     result.current = useHook()
     return null
   }
-  act(() => { create(React.createElement(TestComponent)) })
-  return result
+  act(() => { root = create(React.createElement(TestComponent)) })
+  return { result, unmount: () => act(() => { root.unmount() }) }
 }
 
 async function flush() {
@@ -93,7 +94,7 @@ beforeEach(() => {
 describe('useFriendships', () => {
   it('returns empty state when no friendships exist', async () => {
     mockFetchFriendships.mockResolvedValue([])
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     expect(result.current.friends).toEqual([])
@@ -105,7 +106,7 @@ describe('useFriendships', () => {
 
   it('correctly derives friends from accepted rows', async () => {
     mockFetchFriendships.mockResolvedValue([ACCEPTED_ROW])
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     expect(result.current.friends).toHaveLength(1)
@@ -116,7 +117,7 @@ describe('useFriendships', () => {
 
   it('correctly derives incomingRequests from pending-received rows', async () => {
     mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     expect(result.current.incomingRequests).toHaveLength(1)
@@ -127,7 +128,7 @@ describe('useFriendships', () => {
 
   it('correctly populates outgoingRequestMap from pending-sent rows', async () => {
     mockFetchFriendships.mockResolvedValue([PENDING_SENT_ROW])
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(true)
@@ -137,7 +138,7 @@ describe('useFriendships', () => {
 
   it('sets error state when fetchFriendships throws', async () => {
     mockFetchFriendships.mockRejectedValue(new Error('network error'))
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     expect(result.current.error).toBe('network error')
@@ -146,7 +147,7 @@ describe('useFriendships', () => {
 
   it('returns empty state when not authenticated', async () => {
     mockUseAuth.mockReturnValue({ session: null })
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     expect(result.current.friends).toEqual([])
@@ -158,7 +159,7 @@ describe('useFriendships', () => {
     mockFetchFriendships.mockResolvedValue([])
     mockLibSendRequest.mockResolvedValue({ ...PENDING_SENT_ROW, id: 'fs-new' })
 
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     await act(async () => { await result.current.sendRequest(OTHER_ID) })
@@ -170,7 +171,7 @@ describe('useFriendships', () => {
     mockFetchFriendships.mockResolvedValue([])
     mockLibSendRequest.mockRejectedValue(new Error('Friend request already exists'))
 
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     await expect(
@@ -184,7 +185,7 @@ describe('useFriendships', () => {
     mockFetchFriendships.mockResolvedValue([PENDING_SENT_ROW])
     mockLibCancelRequest.mockResolvedValue(undefined)
 
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(true)
@@ -198,7 +199,7 @@ describe('useFriendships', () => {
     mockFetchFriendships.mockResolvedValue([PENDING_SENT_ROW])
     mockLibCancelRequest.mockRejectedValue(new Error('Request not found or already cancelled'))
 
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     await expect(
@@ -212,7 +213,7 @@ describe('useFriendships', () => {
     mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
     mockLibAcceptRequest.mockResolvedValue(undefined)
 
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     expect(result.current.incomingRequests).toHaveLength(1)
@@ -229,7 +230,7 @@ describe('useFriendships', () => {
     mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
     mockLibAcceptRequest.mockRejectedValue(new Error('update failed'))
 
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     await expect(
@@ -243,7 +244,7 @@ describe('useFriendships', () => {
     mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
     mockLibDeclineRequest.mockResolvedValue(undefined)
 
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     await act(async () => { await result.current.declineRequest('fs-pending-received') })
@@ -255,7 +256,7 @@ describe('useFriendships', () => {
     mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
     mockLibDeclineRequest.mockRejectedValue(new Error('not found'))
 
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     await expect(
@@ -269,7 +270,7 @@ describe('useFriendships', () => {
     mockFetchFriendships.mockResolvedValue([ACCEPTED_ROW])
     mockLibUnfriend.mockResolvedValue(undefined)
 
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     expect(result.current.friends).toHaveLength(1)
@@ -283,7 +284,7 @@ describe('useFriendships', () => {
     mockFetchFriendships.mockResolvedValue([ACCEPTED_ROW])
     mockLibUnfriend.mockRejectedValue(new Error('Friendship not found'))
 
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     await expect(
@@ -293,10 +294,29 @@ describe('useFriendships', () => {
     expect(result.current.friends).toHaveLength(1)
   })
 
+  it('does not log or set error when CLOSED fires after cleanup (background/unmount)', async () => {
+    mockFetchFriendships.mockResolvedValue([])
+
+    const { result, unmount } = renderHook(() => useFriendships())
+    await flush()
+
+    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (status: string, err?: Error) => void
+    act(() => { statusHandler('SUBSCRIBED') })
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    // Unmount sets active=false; then CLOSED fires (as it does via removeChannel in prod)
+    unmount()
+    act(() => { statusHandler('CLOSED') })
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+    expect(result.current.error).toBeNull()
+    consoleSpy.mockRestore()
+  })
+
   it('refetches and clears error after CHANNEL_ERROR + SUBSCRIBED reconnect', async () => {
     mockFetchFriendships.mockResolvedValue([])
 
-    const result = renderHook(() => useFriendships())
+    const { result } = renderHook(() => useFriendships())
     await flush()
 
     expect(mockFetchFriendships).toHaveBeenCalledTimes(1)

--- a/hooks/__tests__/useFriendships.test.ts
+++ b/hooks/__tests__/useFriendships.test.ts
@@ -294,7 +294,7 @@ describe('useFriendships', () => {
     expect(result.current.friends).toHaveLength(1)
   })
 
-  it('does not log or set error when CLOSED fires after cleanup (background/unmount)', async () => {
+  it('does not log or set error when CLOSED fires after cleanup (unmount)', async () => {
     mockFetchFriendships.mockResolvedValue([])
 
     const { result, unmount } = renderHook(() => useFriendships())
@@ -304,13 +304,33 @@ describe('useFriendships', () => {
     act(() => { statusHandler('SUBSCRIBED') })
 
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-    // Unmount sets active=false; then CLOSED fires (as it does via removeChannel in prod)
     unmount()
     act(() => { statusHandler('CLOSED') })
 
     expect(consoleSpy).not.toHaveBeenCalled()
     expect(result.current.error).toBeNull()
     consoleSpy.mockRestore()
+  })
+
+  it('suppresses error when CHANNEL_ERROR fires while app is backgrounded', async () => {
+    const { AppState } = require('react-native')
+    const original = AppState.currentState
+    mockFetchFriendships.mockResolvedValue([])
+
+    const { result } = renderHook(() => useFriendships())
+    await flush()
+
+    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (status: string, err?: Error) => void
+    act(() => { statusHandler('SUBSCRIBED') })
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    AppState.currentState = 'background'
+    act(() => { statusHandler('CHANNEL_ERROR') })
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+    expect(result.current.error).toBeNull()
+    consoleSpy.mockRestore()
+    AppState.currentState = original
   })
 
   it('refetches and clears error after CHANNEL_ERROR + SUBSCRIBED reconnect', async () => {

--- a/hooks/__tests__/usePendingRequestCount.test.ts
+++ b/hooks/__tests__/usePendingRequestCount.test.ts
@@ -136,6 +136,27 @@ describe('usePendingRequestCount', () => {
     expect(mockChannel.subscribe).toHaveBeenCalledWith(expect.any(Function))
   })
 
+  it('does not log an error when CLOSED fires after cleanup (background/unmount)', async () => {
+    const eq2 = jest.fn().mockResolvedValue({ count: 0, error: null })
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
+    mockSelect.mockReturnValue({ eq: eq1 })
+
+    const { unmount } = renderHook(() => usePendingRequestCount())
+    await flush()
+
+    // Capture handler before unmount
+    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (status: string) => void
+    act(() => { statusHandler('SUBSCRIBED') })
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    // Unmount sets active=false; then CLOSED fires (as it does via removeChannel in prod)
+    unmount()
+    act(() => { statusHandler('CLOSED') })
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+
   it('refetches count after CHANNEL_ERROR + SUBSCRIBED reconnect', async () => {
     const eq2 = jest.fn().mockResolvedValue({ count: 3, error: null })
     const eq1 = jest.fn().mockReturnValue({ eq: eq2 })

--- a/hooks/__tests__/usePendingRequestCount.test.ts
+++ b/hooks/__tests__/usePendingRequestCount.test.ts
@@ -136,7 +136,7 @@ describe('usePendingRequestCount', () => {
     expect(mockChannel.subscribe).toHaveBeenCalledWith(expect.any(Function))
   })
 
-  it('does not log an error when CLOSED fires after cleanup (background/unmount)', async () => {
+  it('does not log an error when CLOSED fires after cleanup (unmount)', async () => {
     const eq2 = jest.fn().mockResolvedValue({ count: 0, error: null })
     const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
     mockSelect.mockReturnValue({ eq: eq1 })
@@ -144,17 +144,37 @@ describe('usePendingRequestCount', () => {
     const { unmount } = renderHook(() => usePendingRequestCount())
     await flush()
 
-    // Capture handler before unmount
     const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (status: string) => void
     act(() => { statusHandler('SUBSCRIBED') })
 
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-    // Unmount sets active=false; then CLOSED fires (as it does via removeChannel in prod)
     unmount()
     act(() => { statusHandler('CLOSED') })
 
     expect(consoleSpy).not.toHaveBeenCalled()
     consoleSpy.mockRestore()
+  })
+
+  it('suppresses error when CHANNEL_ERROR fires while app is backgrounded', async () => {
+    const { AppState } = require('react-native')
+    const original = AppState.currentState
+    const eq2 = jest.fn().mockResolvedValue({ count: 0, error: null })
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
+    mockSelect.mockReturnValue({ eq: eq1 })
+
+    renderHook(() => usePendingRequestCount())
+    await flush()
+
+    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (status: string) => void
+    act(() => { statusHandler('SUBSCRIBED') })
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    AppState.currentState = 'background'
+    act(() => { statusHandler('CHANNEL_ERROR') })
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+    consoleSpy.mockRestore()
+    AppState.currentState = original
   })
 
   it('refetches count after CHANNEL_ERROR + SUBSCRIBED reconnect', async () => {

--- a/hooks/useFriendships.ts
+++ b/hooks/useFriendships.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { AppState } from 'react-native'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/hooks/useAuth'
 import {
@@ -125,15 +126,11 @@ export function useFriendships() {
           } else {
             subscribedOnce = true
           }
-        } else if (status === 'CHANNEL_ERROR') {
-          console.error('useFriendships: Realtime channel error', err ?? '(no details)')
-          if (active) setError('Live updates disconnected — pull to refresh.')
-        } else if (status === 'TIMED_OUT') {
-          console.error('useFriendships: Realtime subscription timed out')
-          if (active) setError('Live updates disconnected — pull to refresh.')
-        } else if (status === 'CLOSED') {
-          console.error('useFriendships: Realtime channel closed unexpectedly')
-          if (active) setError('Live updates disconnected — pull to refresh.')
+        } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
+          // App backgrounding drops the WebSocket — suppress noise, reconnect handles recovery
+          if (AppState.currentState === 'background') return
+          console.error(`useFriendships: Realtime ${status}`, err ?? '(no details)')
+          setError('Live updates disconnected — pull to refresh.')
         }
       })
 

--- a/hooks/useFriendships.ts
+++ b/hooks/useFriendships.ts
@@ -114,6 +114,7 @@ export function useFriendships() {
         if (active) load()
       })
       .subscribe((status, err) => {
+        if (!active) return
         if (status === 'SUBSCRIBED') {
           if (subscribedOnce) {
             // Reconnected after a drop — re-fetch to catch missed events and clear error

--- a/hooks/useLivePresences.ts
+++ b/hooks/useLivePresences.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
+import { AppState } from 'react-native'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/hooks/useAuth'
 
@@ -178,17 +179,11 @@ export function useLivePresences(friendIds: string[]) {
             (friendIds.length === 0 || channelHealth.current.friends)
           if (allHealthy) setError(null)
         }
-      } else if (status === 'TIMED_OUT') {
+      } else if (status === 'TIMED_OUT' || status === 'CHANNEL_ERROR' || status === 'CLOSED') {
         channelHealth.current[channelName] = false
-        console.error(`useLivePresences [${channelName}]: Realtime subscription timed out`)
-        setError('Live updates timed out — pull to refresh.')
-      } else if (status === 'CHANNEL_ERROR') {
-        channelHealth.current[channelName] = false
-        console.error(`useLivePresences [${channelName}]: Realtime channel error`, err?.message ?? '(no details)')
-        setError('Live updates unavailable — pull to refresh.')
-      } else if (status === 'CLOSED') {
-        channelHealth.current[channelName] = false
-        console.error(`useLivePresences [${channelName}]: Realtime channel closed unexpectedly`)
+        // App backgrounding drops the WebSocket — suppress noise, reconnect handles recovery
+        if (AppState.currentState === 'background') return
+        console.error(`useLivePresences [${channelName}]: Realtime ${status}`, err?.message ?? '(no details)')
         setError('Live updates disconnected — pull to refresh.')
       }
     }

--- a/hooks/usePendingRequestCount.ts
+++ b/hooks/usePendingRequestCount.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
+import { AppState } from 'react-native'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/hooks/useAuth'
 
@@ -63,12 +64,9 @@ export function usePendingRequestCount(): number {
           } else {
             subscribedOnce = true
           }
-        } else if (status === 'CHANNEL_ERROR') {
-          console.error('usePendingRequestCount: Realtime channel error', err ?? '(no details)')
-        } else if (status === 'TIMED_OUT') {
-          console.error('usePendingRequestCount: Realtime subscription timed out')
-        } else if (status === 'CLOSED') {
-          console.error('usePendingRequestCount: Realtime channel closed unexpectedly')
+        } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
+          if (AppState.currentState === 'background') return
+          console.error(`usePendingRequestCount: Realtime ${status}`, err ?? '(no details)')
         }
       })
 

--- a/hooks/usePendingRequestCount.ts
+++ b/hooks/usePendingRequestCount.ts
@@ -55,6 +55,7 @@ export function usePendingRequestCount(): number {
         if (active) load()
       })
       .subscribe((status, err) => {
+        if (!active) return
         if (status === 'SUBSCRIBED') {
           if (subscribedOnce) {
             // Reconnected after a drop — re-fetch so the badge count is fresh


### PR DESCRIPTION
## Summary

- `useFriendships` and `usePendingRequestCount` were logging `console.error` when `CLOSED` fired during effect cleanup (triggered by `supabase.removeChannel()` in the return function)
- The `active` flag already guarded `setError`, but not `console.error` — so the log always fired, producing false-alarm errors when backgrounding the app or during React Refresh in dev
- Fix: added `if (!active) return` at the top of both `.subscribe()` callbacks, matching the pattern already in place in `useLivePresences`

## Test plan

- [ ] Two new unit tests verify that firing `CLOSED` after unmount produces no `console.error` and no error state (`useFriendships`, `usePendingRequestCount`)
- [ ] All 343 tests passing
- [ ] Manual: background app → foreground → confirm `useFriendships: Realtime channel closed unexpectedly` and `usePendingRequestCount: Realtime channel closed unexpectedly` no longer appear in Metro logs