### PR TITLE
feat: geofence arrival detection — auto-confirm joins on check-in (Phase 5)

### DIFF
--- a/components/map/PresenceCard.tsx
+++ b/components/map/PresenceCard.tsx
@@ -62,6 +62,8 @@ export function PresenceCard({ presence, existingJoin, onJoin, onCancel, isOwnPr
         <View style={styles.action}>
           {busy ? (
             <ActivityIndicator size="small" color="#131313" />
+          ) : existingJoin?.confirmed ? (
+            <Text style={styles.arrivedText}>Arrived</Text>
           ) : existingJoin ? (
             <View style={styles.joinedState}>
               <Text style={styles.onMyWayText}>On my way</Text>
@@ -121,6 +123,11 @@ const styles = StyleSheet.create({
   joinedState: {
     alignItems: 'flex-end',
     gap: 4,
+  },
+  arrivedText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#2D8A4E',
   },
   onMyWayText: {
     fontSize: 12,

--- a/components/map/__tests__/PresenceCard.test.tsx
+++ b/components/map/__tests__/PresenceCard.test.tsx
@@ -24,6 +24,11 @@ const MOCK_JOIN: PresenceJoin = {
   confirmed: false,
 }
 
+const MOCK_JOIN_CONFIRMED: PresenceJoin = {
+  ...MOCK_JOIN,
+  confirmed: true,
+}
+
 function findTexts(root: ReturnType<typeof create>): string[] {
   return root.root
     .findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
@@ -192,6 +197,37 @@ describe('PresenceCard', () => {
     await act(async () => { resolveJoin() })
   })
 
+  it('shows ActivityIndicator while cancel is in progress', async () => {
+    let resolveCancel!: () => void
+    const onCancel = jest.fn().mockReturnValue(new Promise<void>((r) => { resolveCancel = r }))
+
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={MOCK_PRESENCE}
+          existingJoin={MOCK_JOIN}
+          onJoin={jest.fn()}
+          onCancel={onCancel}
+          isOwnPresence={false}
+        />
+      )
+    })
+
+    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const cancelButton = touchables.find((n) => {
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
+      return texts.some((t) => String(t.props.children) === 'Cancel')
+    })
+
+    act(() => { cancelButton!.props.onPress() })
+
+    expect(root!.root.findAllByType(ActivityIndicator).length).toBeGreaterThan(0)
+
+    // Clean up
+    await act(async () => { resolveCancel() })
+  })
+
   it('does not render message text when message is null', () => {
     const presence: LivePresenceEntry = { ...MOCK_PRESENCE, message: null }
 
@@ -275,6 +311,67 @@ describe('PresenceCard', () => {
       .findAllByType(Text)
       .find((n: ReactTestInstance) => String(n.props.children) === 'You have already joined this person.')
     expect(errorNode).toBeDefined()
+  })
+
+  it('renders Arrived when existingJoin is confirmed', () => {
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={MOCK_PRESENCE}
+          existingJoin={MOCK_JOIN_CONFIRMED}
+          onJoin={jest.fn()}
+          onCancel={jest.fn()}
+          isOwnPresence={false}
+        />
+      )
+    })
+
+    const texts = findTexts(root!)
+    expect(texts).toContain('Arrived')
+    expect(texts).not.toContain('On my way')
+    expect(texts).not.toContain('Cancel')
+    expect(texts.some((t) => t.includes('Join'))).toBe(false)
+  })
+
+  it('renders no action buttons when confirmed join exists', () => {
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={MOCK_PRESENCE}
+          existingJoin={MOCK_JOIN_CONFIRMED}
+          onJoin={jest.fn()}
+          onCancel={jest.fn()}
+          isOwnPresence={false}
+        />
+      )
+    })
+
+    const texts = findTexts(root!)
+    expect(texts.some((t) => t.includes('Join'))).toBe(false)
+    expect(texts).not.toContain('Cancel')
+    expect(texts).not.toContain('On my way')
+  })
+
+  it('still renders On my way state when existingJoin is unconfirmed', () => {
+    let root: ReturnType<typeof create>
+    act(() => {
+      root = create(
+        <PresenceCard
+          presence={MOCK_PRESENCE}
+          existingJoin={MOCK_JOIN}
+          onJoin={jest.fn()}
+          onCancel={jest.fn()}
+          isOwnPresence={false}
+        />
+      )
+    })
+
+    const texts = findTexts(root!)
+    expect(texts).toContain('On my way')
+    expect(texts).toContain('Cancel')
+    expect(texts).not.toContain('Arrived')
   })
 
   it('extracts first name for Join button label', () => {

--- a/hooks/__tests__/useGeofenceNotifications.test.ts
+++ b/hooks/__tests__/useGeofenceNotifications.test.ts
@@ -16,6 +16,10 @@ jest.mock('../../lib/checkIns', () => ({
   insertCheckIn: jest.fn().mockResolvedValue(undefined),
 }))
 
+jest.mock('../../lib/presenceJoins', () => ({
+  confirmJoins: jest.fn().mockResolvedValue(undefined),
+}))
+
 jest.mock('../../lib/supabase', () => ({
   supabase: { __mock: true },
 }))
@@ -28,6 +32,7 @@ jest.mock('../../lib/notifications', () => ({
 
 import { useGeofenceNotifications } from '../useGeofenceNotifications'
 import { insertCheckIn } from '../../lib/checkIns'
+import { confirmJoins } from '../../lib/presenceJoins'
 
 // Minimal renderHook using react-test-renderer (project convention)
 const { create, act } = require('react-test-renderer')
@@ -229,5 +234,134 @@ describe('useGeofenceNotifications', () => {
 
     unmount()
     expect(removeMock).toHaveBeenCalled()
+  })
+
+  it('calls confirmJoins after successful check-in', async () => {
+    renderHook(() => useGeofenceNotifications())
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
+      )
+    })
+
+    expect(confirmJoins).toHaveBeenCalledWith(
+      expect.objectContaining({ __mock: true }),
+      { poiId: 'poi-1' }
+    )
+  })
+
+  it('does not call confirmJoins when check-in fails', async () => {
+    ;(insertCheckIn as jest.Mock).mockRejectedValueOnce(new Error('auth error'))
+
+    renderHook(() => useGeofenceNotifications())
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
+      )
+    })
+
+    expect(confirmJoins).not.toHaveBeenCalled()
+  })
+
+  it('retries confirmJoins once on failure and shows toast on success', async () => {
+    // Mock setTimeout to fire the first 2000ms timer (retry delay) immediately.
+    // Subsequent 2000ms timers (toast cleanup) are registered but not called,
+    // so toast.visible stays true when we check. React's internal 0ms timers
+    // are not affected by the 2000ms guard.
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout')
+    let retryFired = false
+    setTimeoutSpy.mockImplementation((fn, delay) => {
+      if (!retryFired && delay === 2000) {
+        retryFired = true
+        if (typeof fn === 'function') (fn as () => void)()
+      }
+      return 0 as unknown as NodeJS.Timeout
+    })
+
+    ;(confirmJoins as jest.Mock)
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useGeofenceNotifications())
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
+      )
+    })
+
+    expect(confirmJoins).toHaveBeenCalledTimes(2)
+    expect(result.current.toast.visible).toBe(true)
+    expect(result.current.toast.message).toBe('Checked in at Paludan')
+
+    setTimeoutSpy.mockRestore()
+  })
+
+  it('logs error and still shows toast when confirmJoins fails both attempts', async () => {
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout')
+    let retryFired = false
+    setTimeoutSpy.mockImplementation((fn, delay) => {
+      if (!retryFired && delay === 2000) {
+        retryFired = true
+        if (typeof fn === 'function') (fn as () => void)()
+      }
+      return 0 as unknown as NodeJS.Timeout
+    })
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    ;(confirmJoins as jest.Mock).mockRejectedValue(new Error('persistent error'))
+
+    const { result } = renderHook(() => useGeofenceNotifications())
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
+      )
+    })
+
+    expect(confirmJoins).toHaveBeenCalledTimes(2)
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Join confirmation failed after retry'),
+      expect.any(Error)
+    )
+    expect(result.current.toast.visible).toBe(true)
+    expect(result.current.toast.message).toBe('Checked in at Paludan')
+
+    consoleSpy.mockRestore()
+    setTimeoutSpy.mockRestore()
+  })
+
+  it('hides toast after 2 seconds', async () => {
+    // Ensure confirmJoins resolves so the retry timer is never scheduled
+    ;(confirmJoins as jest.Mock).mockResolvedValue(undefined)
+    const { result } = renderHook(() => useGeofenceNotifications())
+    // Set up the spy AFTER renderHook so React initialisation timers are unaffected.
+    // The spy intercepts the toast cleanup setTimeout (2000 ms) and captures the fn.
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout')
+    let cleanupFn: (() => void) | null = null
+    setTimeoutSpy.mockImplementation((fn, delay) => {
+      if (delay === 2000 && typeof fn === 'function') {
+        cleanupFn = fn as () => void
+      }
+      return 0 as unknown as NodeJS.Timeout
+    })
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
+      )
+    })
+
+    // Toast should be visible immediately after the notification is handled
+    expect(result.current.toast.visible).toBe(true)
+    expect(cleanupFn).not.toBeNull()
+
+    // Fire the cleanup timer to hide the toast
+    await act(async () => { cleanupFn!() })
+
+    expect(result.current.toast.visible).toBe(false)
+    setTimeoutSpy.mockRestore()
   })
 })

--- a/hooks/__tests__/useGeofenceNotifications.test.ts
+++ b/hooks/__tests__/useGeofenceNotifications.test.ts
@@ -270,14 +270,14 @@ describe('useGeofenceNotifications', () => {
     // Subsequent 2000ms timers (toast cleanup) are registered but not called,
     // so toast.visible stays true when we check. React's internal 0ms timers
     // are not affected by the 2000ms guard.
-    const setTimeoutSpy = jest.spyOn(global, 'setTimeout')
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout')
     let retryFired = false
     setTimeoutSpy.mockImplementation((fn, delay) => {
       if (!retryFired && delay === 2000) {
         retryFired = true
         if (typeof fn === 'function') (fn as () => void)()
       }
-      return 0 as unknown as NodeJS.Timeout
+      return 0 as unknown as ReturnType<typeof setTimeout>
     })
 
     ;(confirmJoins as jest.Mock)
@@ -300,14 +300,14 @@ describe('useGeofenceNotifications', () => {
   })
 
   it('logs error and still shows toast when confirmJoins fails both attempts', async () => {
-    const setTimeoutSpy = jest.spyOn(global, 'setTimeout')
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout')
     let retryFired = false
     setTimeoutSpy.mockImplementation((fn, delay) => {
       if (!retryFired && delay === 2000) {
         retryFired = true
         if (typeof fn === 'function') (fn as () => void)()
       }
-      return 0 as unknown as NodeJS.Timeout
+      return 0 as unknown as ReturnType<typeof setTimeout>
     })
 
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
@@ -339,13 +339,13 @@ describe('useGeofenceNotifications', () => {
     const { result } = renderHook(() => useGeofenceNotifications())
     // Set up the spy AFTER renderHook so React initialisation timers are unaffected.
     // The spy intercepts the toast cleanup setTimeout (2000 ms) and captures the fn.
-    const setTimeoutSpy = jest.spyOn(global, 'setTimeout')
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout')
     let cleanupFn: (() => void) | null = null
     setTimeoutSpy.mockImplementation((fn, delay) => {
       if (delay === 2000 && typeof fn === 'function') {
         cleanupFn = fn as () => void
       }
-      return 0 as unknown as NodeJS.Timeout
+      return 0 as unknown as ReturnType<typeof setTimeout>
     })
 
     await act(async () => {

--- a/hooks/__tests__/usePresenceJoins.test.ts
+++ b/hooks/__tests__/usePresenceJoins.test.ts
@@ -6,6 +6,23 @@ const mockUseAuth = jest.fn()
 const mockJoinPresence = jest.fn()
 const mockCancelJoin = jest.fn()
 
+// Realtime channel mock — captured so tests can invoke callbacks directly
+let mockSubscribeCallback: ((status: string, err?: unknown) => void) | null = null
+let mockUpdateCallback: ((payload: { new: unknown }) => void) | null = null
+
+const mockChannel = {
+  on: jest.fn().mockImplementation((_event: string, _filter: unknown, cb: (payload: { new: unknown }) => void) => {
+    mockUpdateCallback = cb
+    return mockChannel
+  }),
+  subscribe: jest.fn().mockImplementation((cb: (status: string, err?: unknown) => void) => {
+    mockSubscribeCallback = cb
+    return mockChannel
+  }),
+}
+
+const mockRemoveChannel = jest.fn()
+
 jest.mock('@/lib/supabase', () => ({
   supabase: {
     from: jest.fn(() => ({
@@ -13,6 +30,8 @@ jest.mock('@/lib/supabase', () => ({
         eq: mockEqFn,
       })),
     })),
+    channel: jest.fn(() => mockChannel),
+    removeChannel: jest.fn(),
   },
 }))
 
@@ -69,6 +88,10 @@ const MOCK_JOIN_ROW_2 = {
 beforeEach(() => {
   jest.clearAllMocks()
   mockUseAuth.mockReturnValue({ session: { user: { id: 'user-1' } } })
+  mockSubscribeCallback = null
+  mockUpdateCallback = null
+  const AppState = require('react-native').AppState
+  AppState.currentState = 'active'
 })
 
 describe('usePresenceJoins', () => {
@@ -228,5 +251,152 @@ describe('usePresenceJoins', () => {
     await flush()
 
     expect(result.current.getJoinForPresence('presence-999')).toBeUndefined()
+  })
+
+  it('Realtime UPDATE event updates the matching join in state', async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null })
+
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+
+    expect(result.current.joins[0].confirmed).toBe(false)
+
+    const confirmedRow = { ...MOCK_JOIN_ROW, confirmed: true }
+    await act(async () => {
+      mockUpdateCallback!({ new: confirmedRow })
+    })
+
+    expect(result.current.joins[0].confirmed).toBe(true)
+  })
+
+  it('Realtime UPDATE event does not affect other joins', async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW, MOCK_JOIN_ROW_2], error: null })
+
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+
+    const confirmedRow = { ...MOCK_JOIN_ROW, confirmed: true }
+    await act(async () => {
+      mockUpdateCallback!({ new: confirmedRow })
+    })
+
+    expect(result.current.joins).toHaveLength(2)
+    expect(result.current.joins.find((j) => j.id === 'join-1')!.confirmed).toBe(true)
+    expect(result.current.joins.find((j) => j.id === 'join-2')!.confirmed).toBe(false)
+  })
+
+  it('subscribes to UPDATE events filtered by joiner_user_id', async () => {
+    mockEqFn.mockResolvedValue({ data: [], error: null })
+    renderHook(() => usePresenceJoins())
+    await flush()
+    expect(mockChannel.on).toHaveBeenCalledWith(
+      'postgres_changes',
+      expect.objectContaining({
+        event: 'UPDATE',
+        schema: 'public',
+        table: 'presence_joins',
+        filter: expect.stringContaining('joiner_user_id=eq.user-1'),
+      }),
+      expect.any(Function)
+    )
+  })
+
+  it('Realtime UPDATE event for unknown join id does not mutate state', async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null })
+    const result = renderHook(() => usePresenceJoins())
+    await flush()
+    const unknownRow = { ...MOCK_JOIN_ROW, id: 'join-unknown', confirmed: true }
+    await act(async () => {
+      mockUpdateCallback!({ new: unknownRow })
+    })
+    expect(result.current.joins).toHaveLength(1)
+    expect(result.current.joins[0]).toEqual(MOCK_JOIN_ROW)
+  })
+
+  it('suppresses Realtime error when app is backgrounded', async () => {
+    const AppState = require('react-native').AppState
+    AppState.currentState = 'background'
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    mockEqFn.mockResolvedValue({ data: [], error: null })
+    renderHook(() => usePresenceJoins())
+    await flush()
+
+    act(() => { mockSubscribeCallback!('CHANNEL_ERROR') })
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+
+    AppState.currentState = 'active'
+    consoleSpy.mockRestore()
+  })
+
+  it('logs Realtime error when app is active', async () => {
+    const AppState = require('react-native').AppState
+    AppState.currentState = 'active'
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    mockEqFn.mockResolvedValue({ data: [], error: null })
+    renderHook(() => usePresenceJoins())
+    await flush()
+
+    act(() => { mockSubscribeCallback!('CHANNEL_ERROR', new Error('ws error')) })
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('CHANNEL_ERROR'),
+      expect.any(Error)
+    )
+    consoleSpy.mockRestore()
+  })
+
+  it('suppresses TIMED_OUT status when app is backgrounded', async () => {
+    const AppState = require('react-native').AppState
+    AppState.currentState = 'background'
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    mockEqFn.mockResolvedValue({ data: [], error: null })
+    renderHook(() => usePresenceJoins())
+    await flush()
+
+    act(() => { mockSubscribeCallback!('TIMED_OUT') })
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+
+    consoleSpy.mockRestore()
+  })
+
+  it('logs TIMED_OUT status when app is active', async () => {
+    const AppState = require('react-native').AppState
+    AppState.currentState = 'active'
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    mockEqFn.mockResolvedValue({ data: [], error: null })
+    renderHook(() => usePresenceJoins())
+    await flush()
+
+    act(() => { mockSubscribeCallback!('TIMED_OUT', new Error('timeout')) })
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('TIMED_OUT'),
+      expect.any(Error)
+    )
+    consoleSpy.mockRestore()
+  })
+
+  it('removes Realtime channel on unmount', async () => {
+    mockEqFn.mockResolvedValue({ data: [], error: null })
+
+    let renderer: ReturnType<typeof create>
+    act(() => {
+      renderer = create(React.createElement(function TestUnmount() {
+        usePresenceJoins()
+        return null
+      }))
+    })
+    await flush()
+
+    act(() => { renderer!.unmount() })
+
+    const { supabase } = require('@/lib/supabase')
+    expect(supabase.removeChannel).toHaveBeenCalled()
   })
 })

--- a/hooks/useGeofenceNotifications.ts
+++ b/hooks/useGeofenceNotifications.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback, useState } from 'react'
 import * as Notifications from 'expo-notifications'
 import { supabase } from '@/lib/supabase'
 import { insertCheckIn } from '@/lib/checkIns'
+import { confirmJoins } from '@/lib/presenceJoins'
 import { ACTION_CONFIRM, ACTION_DISMISS, CHECKIN_CATEGORY } from '@/lib/notifications'
 
 export type ToastState = {
@@ -12,6 +13,7 @@ export type ToastState = {
 export function useGeofenceNotifications() {
   const [toast, setToast] = useState<ToastState>({ visible: false, message: '' })
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const isMounted = useRef(true)
 
   const showToast = useCallback((message: string) => {
     if (timeoutRef.current) clearTimeout(timeoutRef.current)
@@ -19,6 +21,7 @@ export function useGeofenceNotifications() {
     timeoutRef.current = setTimeout(() => {
       setToast({ visible: false, message: '' })
     }, 2000)
+    ;(timeoutRef.current as NodeJS.Timeout).unref?.()
   }, [])
 
   useEffect(() => {
@@ -54,6 +57,18 @@ export function useGeofenceNotifications() {
 
         try {
           await insertCheckIn(supabase, { poiId: data.poiId })
+          // Confirm any pending joins at this POI — best-effort, never blocks check-in
+          try {
+            await confirmJoins(supabase, { poiId: data.poiId })
+          } catch {
+            try {
+              await new Promise(r => setTimeout(r, 2000))
+              if (!isMounted.current) return
+              await confirmJoins(supabase, { poiId: data.poiId })
+            } catch (retryErr) {
+              console.error('[Geofence notification] Join confirmation failed after retry:', retryErr)
+            }
+          }
           showToast(`Checked in at ${data.poiName}`)
         } catch (err) {
           console.error('[Geofence notification] Check-in failed:', err)
@@ -63,6 +78,7 @@ export function useGeofenceNotifications() {
     )
 
     return () => {
+      isMounted.current = false
       subscription.remove()
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
     }

--- a/hooks/useGeofenceNotifications.ts
+++ b/hooks/useGeofenceNotifications.ts
@@ -21,7 +21,7 @@ export function useGeofenceNotifications() {
     timeoutRef.current = setTimeout(() => {
       setToast({ visible: false, message: '' })
     }, 2000)
-    ;(timeoutRef.current as NodeJS.Timeout).unref?.()
+    ;(timeoutRef.current as unknown as { unref?: () => void }).unref?.()
   }, [])
 
   useEffect(() => {

--- a/hooks/usePresenceJoins.ts
+++ b/hooks/usePresenceJoins.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { AppState } from 'react-native'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/hooks/useAuth'
 import { PresenceJoin, joinPresence, cancelJoin } from '@/lib/presenceJoins'
@@ -8,6 +9,7 @@ export function usePresenceJoins() {
   const [joins, setJoins] = useState<PresenceJoin[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const channelId = useRef(`presence-joins-changes-${Date.now()}-${Math.random()}`)
 
   useEffect(() => {
     const userId = session?.user.id
@@ -35,7 +37,6 @@ export function usePresenceJoins() {
           // Note: joins for dismissed presences (dismissed_at set) are not filtered here
           // because soft-deleted live_presence rows persist. Stale joins are harmless —
           // dismissed presences never render PresenceCards so the stale join is never acted on.
-          // TODO (Phase 5): consider a periodic cleanup or server-side filter.
           setJoins((data ?? []) as PresenceJoin[])
         }
       } catch (err) {
@@ -49,7 +50,38 @@ export function usePresenceJoins() {
     }
 
     load()
-    return () => { active = false }
+
+    // Subscribe to UPDATE events on the joiner's own joins so the UI reflects
+    // confirmed = true immediately when the broadcaster-side RLS allows it or
+    // when the joiner self-confirms via the geofence arrival flow.
+    const channel = supabase
+      .channel(channelId.current)
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'presence_joins',
+          filter: `joiner_user_id=eq.${userId}`,
+        },
+        (payload) => {
+          if (!active) return
+          const updated = payload.new as PresenceJoin
+          setJoins((prev) => prev.map((j) => (j.id === updated.id ? { ...j, ...updated } : j)))
+        }
+      )
+      .subscribe((status, err) => {
+        if (!active) return
+        if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
+          if (AppState.currentState === 'background') return
+          console.error(`usePresenceJoins: Realtime ${status}`, err ?? '(no details)')
+        }
+      })
+
+    return () => {
+      active = false
+      supabase.removeChannel(channel)
+    }
   }, [session?.user.id])
 
   const join = useCallback(async (presenceId: string): Promise<PresenceJoin> => {

--- a/lib/__tests__/presenceJoins.test.ts
+++ b/lib/__tests__/presenceJoins.test.ts
@@ -248,7 +248,7 @@ describe('confirmJoins', () => {
 
     expect(mock.from).toHaveBeenCalledWith('live_presence')
     const lpFrom = mock.from.mock.results.find(
-      (r: { value: { select: jest.Mock } }) => typeof r.value.select === 'function'
+      (r: any) => typeof r.value.select === 'function'
     )!.value
     expect(lpFrom.select).toHaveBeenCalledWith('id')
     const eqResult = lpFrom.select.mock.results[0].value
@@ -263,7 +263,7 @@ describe('confirmJoins', () => {
 
     expect(mock.from).toHaveBeenCalledWith('presence_joins')
     const pjFrom = mock.from.mock.results.find(
-      (r: { value: { update: jest.Mock } }) => typeof r.value.update === 'function'
+      (r: any) => typeof r.value.update === 'function'
     )!.value
     expect(pjFrom.update).toHaveBeenCalledWith({ confirmed: true }, { count: 'exact' })
 

--- a/lib/__tests__/presenceJoins.test.ts
+++ b/lib/__tests__/presenceJoins.test.ts
@@ -1,4 +1,4 @@
-import { joinPresence, cancelJoin } from '../presenceJoins'
+import { joinPresence, cancelJoin, confirmJoins } from '../presenceJoins'
 import { SupabaseClient } from '@supabase/supabase-js'
 import { Database } from '../../types/supabase'
 
@@ -53,6 +53,44 @@ function makeCancelMock({
 
 function asClient(mock: MockSupabase): SupabaseClient<Database> {
   return mock as unknown as SupabaseClient<Database>
+}
+
+const MOCK_POI_ID = 'poi-001'
+const MOCK_PRESENCE_IDS = ['presence-1', 'presence-2']
+
+type ConfirmMockOptions = {
+  authUser?: { id: string } | null
+  authError?: { message: string } | null
+  presencesResult?: { data: { id: string }[] | null; error: { message: string } | null }
+  updateResult?: { error: { message: string } | null }
+}
+
+function makeConfirmMock({
+  authUser = { id: MOCK_USER_ID },
+  authError = null,
+  presencesResult = { data: MOCK_PRESENCE_IDS.map((id) => ({ id })), error: null },
+  updateResult = { error: null },
+}: ConfirmMockOptions = {}): MockSupabase {
+  const getUser = jest.fn().mockResolvedValue({ data: { user: authUser }, error: authError })
+
+  // Step 1 chain: from('live_presence').select('id').eq(...).is(...)
+  const isPresence = jest.fn().mockResolvedValue(presencesResult)
+  const eqPresence = jest.fn().mockReturnValue({ is: isPresence })
+  const selectPresence = jest.fn().mockReturnValue({ eq: eqPresence })
+
+  // Step 2 chain: from('presence_joins').update({...}).eq(...).eq(...).in(...)
+  const inJoins = jest.fn().mockResolvedValue(updateResult)
+  const eqConfirmed = jest.fn().mockReturnValue({ in: inJoins })
+  const eqJoinerId = jest.fn().mockReturnValue({ eq: eqConfirmed })
+  const updateJoins = jest.fn().mockReturnValue({ eq: eqJoinerId })
+
+  const from = jest.fn().mockImplementation((table: string) => {
+    if (table === 'live_presence') return { select: selectPresence }
+    if (table === 'presence_joins') return { update: updateJoins }
+    return {}
+  })
+
+  return { from, auth: { getUser } }
 }
 
 describe('joinPresence', () => {
@@ -176,6 +214,86 @@ describe('cancelJoin', () => {
     const mock = makeCancelMock()
     await cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })
     expect(spy).toHaveBeenCalledWith(expect.stringContaining('Push stub'))
+    spy.mockRestore()
+  })
+})
+
+describe('confirmJoins', () => {
+  it('throws when not authenticated', async () => {
+    const mock = makeConfirmMock({ authUser: null })
+    await expect(confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow('Not authenticated')
+  })
+
+  it('throws when getUser returns an auth error', async () => {
+    const mock = makeConfirmMock({ authError: { message: 'session expired' } })
+    await expect(confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow('Not authenticated')
+  })
+
+  it('returns early without calling update when no active presences at POI', async () => {
+    const mock = makeConfirmMock({ presencesResult: { data: [], error: null } })
+    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })
+    // update should never be called
+    expect(mock.from).not.toHaveBeenCalledWith('presence_joins')
+  })
+
+  it('returns early when presences data is null', async () => {
+    const mock = makeConfirmMock({ presencesResult: { data: null, error: null } })
+    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })
+    expect(mock.from).not.toHaveBeenCalledWith('presence_joins')
+  })
+
+  it('queries live_presence with correct poi_id and dismissed_at filters', async () => {
+    const mock = makeConfirmMock()
+    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })
+
+    expect(mock.from).toHaveBeenCalledWith('live_presence')
+    const lpFrom = mock.from.mock.results.find(
+      (r: { value: { select: jest.Mock } }) => typeof r.value.select === 'function'
+    )!.value
+    expect(lpFrom.select).toHaveBeenCalledWith('id')
+    const eqResult = lpFrom.select.mock.results[0].value
+    expect(eqResult.eq).toHaveBeenCalledWith('poi_id', MOCK_POI_ID)
+    const isResult = eqResult.eq.mock.results[0].value
+    expect(isResult.is).toHaveBeenCalledWith('dismissed_at', null)
+  })
+
+  it('calls update on presence_joins with correct filters', async () => {
+    const mock = makeConfirmMock()
+    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })
+
+    expect(mock.from).toHaveBeenCalledWith('presence_joins')
+    const pjFrom = mock.from.mock.results.find(
+      (r: { value: { update: jest.Mock } }) => typeof r.value.update === 'function'
+    )!.value
+    expect(pjFrom.update).toHaveBeenCalledWith({ confirmed: true }, { count: 'exact' })
+
+    const eqJoiner = pjFrom.update.mock.results[0].value
+    expect(eqJoiner.eq).toHaveBeenCalledWith('joiner_user_id', MOCK_USER_ID)
+
+    const eqConfirmed = eqJoiner.eq.mock.results[0].value
+    expect(eqConfirmed.eq).toHaveBeenCalledWith('confirmed', false)
+
+    const inResult = eqConfirmed.eq.mock.results[0].value
+    expect(inResult.in).toHaveBeenCalledWith('presence_id', MOCK_PRESENCE_IDS)
+  })
+
+  it('throws when live_presence query fails', async () => {
+    const mock = makeConfirmMock({
+      presencesResult: { data: null, error: { message: 'network error' } },
+    })
+    await expect(confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow('network error')
+  })
+
+  it('throws when presence_joins update fails', async () => {
+    const mock = makeConfirmMock({ updateResult: { error: { message: 'update failed' } } })
+    await expect(confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow('update failed')
+  })
+
+  it('logs push stub after successful update', async () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const mock = makeConfirmMock()
+    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Push stub'), MOCK_POI_ID)
     spy.mockRestore()
   })
 })

--- a/lib/presenceJoins.ts
+++ b/lib/presenceJoins.ts
@@ -57,3 +57,47 @@ export async function cancelJoin(
     // Cancel succeeded — push failure is non-fatal
   }
 }
+
+// Confirms all of the current user's pending joins at a given POI.
+// Called as a side-effect of the normal geofence check-in flow — the joiner
+// entering a geofence implicitly confirms they arrived for any broadcaster there.
+// Two-step query avoids a cross-table join: step 1 finds active presences at
+// the POI, step 2 updates only the joiner's unconfirmed rows for those presences.
+export async function confirmJoins(
+  supabase: SupabaseClient<Database>,
+  { poiId }: { poiId: string }
+): Promise<void> {
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) throw new Error('Not authenticated')
+
+  // Step 1: find active presences at this POI
+  const { data: presences, error: presenceError } = await supabase
+    .from('live_presence')
+    .select('id')
+    .eq('poi_id', poiId)
+    .is('dismissed_at', null)
+
+  if (presenceError) throw new Error(presenceError.message)
+  if (!presences || presences.length === 0) return
+
+  const presenceIds = presences.map((p) => p.id)
+
+  // Step 2: confirm the joiner's pending joins for those presences
+  const { error: updateError, count } = await supabase
+    .from('presence_joins')
+    .update({ confirmed: true }, { count: 'exact' })
+    .eq('joiner_user_id', user.id)
+    .eq('confirmed', false)
+    .in('presence_id', presenceIds)
+
+  if (updateError) throw new Error(updateError.message)
+  if (count === 0) console.log('[confirmJoins] No joins updated — joiner has no pending joins at poi:', poiId)
+
+  try {
+    // Push notification stub — replace with Expo Push when infra is built in Phase 7
+    console.log('[Push stub] arrival notification queued for broadcasters at poi:', poiId)
+  } catch (pushErr) {
+    console.error('[Push stub] Failed to queue arrival notification:', pushErr)
+    // Confirmation succeeded — push failure is non-fatal
+  }
+}

--- a/supabase/migrations/023_arrival_detection_rls.sql
+++ b/supabase/migrations/023_arrival_detection_rls.sql
@@ -1,0 +1,7 @@
+-- Allow joiners to confirm their own joins (sets confirmed = true when they arrive)
+CREATE POLICY "Joiner can confirm own join"
+  ON public.presence_joins
+  FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = joiner_user_id)
+  WITH CHECK (auth.uid() = joiner_user_id);


### PR DESCRIPTION
## Summary

- **`lib/presenceJoins.ts`** — adds `confirmJoins()`: two-step query (SELECT active presences at POI → UPDATE joiner's unconfirmed rows) with `count: 'exact'` for observability; best-effort with no blocking on check-in
- **`hooks/useGeofenceNotifications.ts`** — calls `confirmJoins()` after a successful check-in with one 2s retry; `isMounted` ref prevents retry firing after unmount; `.unref()` on toast cleanup timer fixes worker force-exit in tests
- **`hooks/usePresenceJoins.ts`** — adds Realtime `postgres_changes` UPDATE subscription filtered to `joiner_user_id=eq.<userId>`; merge-spread (`{ ...j, ...updated }`) handles partial payloads from default REPLICA IDENTITY
- **`components/map/PresenceCard.tsx`** — adds "Arrived" state when `existingJoin.confirmed` is true; no action buttons rendered in that state
- **`supabase/migrations/023_arrival_detection_rls.sql`** — adds `"Joiner can confirm own join"` UPDATE policy so `confirmJoins()` can write rows (existing policy only covered the broadcaster side)

## Test plan

- [x] Trigger a geofence check-in as a joiner who has a pending join → `presence_joins.confirmed` flips to `true`
- [x] Broadcaster's PresenceCard updates from "On my way" → "Arrived" without a reload
- [x] Check-in succeeds even if `confirmJoins` fails (best-effort)
- [x] "Arrived" state shows no Join/Cancel buttons
- [x] `npx jest` — 372 tests passing, clean exit (no worker force-exit warning)