### PR TITLE
chore: add prettier + PostToolUse format hook

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/app/(app)/(tabs)/__tests__/FriendsScreen.test.tsx
+++ b/app/(app)/(tabs)/__tests__/FriendsScreen.test.tsx
@@ -1,47 +1,47 @@
-import React from 'react'
-import { act, create, ReactTestInstance } from 'react-test-renderer'
+import React from "react";
+import { act, create, ReactTestInstance } from "react-test-renderer";
 
-const mockUseUserSearch = jest.fn()
-const mockUseFriendships = jest.fn()
+const mockUseUserSearch = jest.fn();
+const mockUseFriendships = jest.fn();
 
-jest.mock('@/hooks/useUserSearch', () => ({
+jest.mock("@/hooks/useUserSearch", () => ({
   useUserSearch: (...args: unknown[]) => mockUseUserSearch(...args),
-}))
+}));
 
-jest.mock('@/hooks/useFriendships', () => ({
+jest.mock("@/hooks/useFriendships", () => ({
   useFriendships: () => mockUseFriendships(),
-}))
+}));
 
-jest.mock('@/components/friends/UserSearchResult', () => {
-  const React = require('react')
-  const { Text } = require('react-native')
+jest.mock("@/components/friends/UserSearchResult", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
   return {
     UserSearchResult: ({ user }: { user: { display_name: string } }) =>
       React.createElement(Text, null, user.display_name),
-  }
-})
+  };
+});
 
-jest.mock('@/components/friends/FriendRow', () => {
-  const React = require('react')
-  const { Text } = require('react-native')
+jest.mock("@/components/friends/FriendRow", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
   return {
     FriendRow: ({ entry }: { entry: { displayName: string } }) =>
       React.createElement(Text, null, entry.displayName),
-  }
-})
+  };
+});
 
-jest.mock('@/components/friends/IncomingRequestsSection', () => {
-  const React = require('react')
-  const { Text } = require('react-native')
+jest.mock("@/components/friends/IncomingRequestsSection", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
   return {
     IncomingRequestsSection: ({ requests }: { requests: { displayName: string }[] }) =>
       requests.length > 0
         ? React.createElement(Text, null, `${requests.length} incoming request(s)`)
         : null,
-  }
-})
+  };
+});
 
-import FriendsScreen from '../friends'
+import FriendsScreen from "../friends";
 
 const EMPTY_FRIENDSHIPS = {
   friends: [],
@@ -55,123 +55,149 @@ const EMPTY_FRIENDSHIPS = {
   acceptRequest: jest.fn(),
   declineRequest: jest.fn(),
   unfriend: jest.fn(),
-  getStatusForUser: jest.fn().mockReturnValue('none'),
+  getStatusForUser: jest.fn().mockReturnValue("none"),
   getFriendshipId: jest.fn().mockReturnValue(null),
-}
+};
 
-const IDLE_SEARCH = { results: [], state: 'idle' as const, error: null }
+const IDLE_SEARCH = { results: [], state: "idle" as const, error: null };
 
 beforeEach(() => {
-  jest.clearAllMocks()
-  mockUseFriendships.mockReturnValue(EMPTY_FRIENDSHIPS)
-  mockUseUserSearch.mockReturnValue(IDLE_SEARCH)
-})
+  jest.clearAllMocks();
+  mockUseFriendships.mockReturnValue(EMPTY_FRIENDSHIPS);
+  mockUseUserSearch.mockReturnValue(IDLE_SEARCH);
+});
 
-describe('FriendsScreen', () => {
-  it('renders a search input', () => {
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendsScreen />) })
+describe("FriendsScreen", () => {
+  it("renders a search input", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendsScreen />);
+    });
 
-    const inputs = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'TextInput')
-    expect(inputs.length).toBeGreaterThan(0)
-  })
+    const inputs = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "TextInput");
+    expect(inputs.length).toBeGreaterThan(0);
+  });
 
   it('shows "Search for friends by name" hint when idle with no friends', () => {
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendsScreen />) })
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendsScreen />);
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'Search for friends by name')).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(texts.some((n) => String(n.props.children) === "Search for friends by name")).toBe(true);
+  });
 
-  it('renders friends list entries when friends exist', () => {
+  it("renders friends list entries when friends exist", () => {
     mockUseFriendships.mockReturnValue({
       ...EMPTY_FRIENDSHIPS,
-      friends: [{ friendshipId: 'fs-1', userId: 'u1', displayName: 'Alice', avatarUrl: null }],
-    })
+      friends: [{ friendshipId: "fs-1", userId: "u1", displayName: "Alice", avatarUrl: null }],
+    });
 
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendsScreen />) })
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendsScreen />);
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'Alice')).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(texts.some((n) => String(n.props.children) === "Alice")).toBe(true);
+  });
 
-  it('shows IncomingRequestsSection when incoming requests exist', () => {
+  it("shows IncomingRequestsSection when incoming requests exist", () => {
     mockUseFriendships.mockReturnValue({
       ...EMPTY_FRIENDSHIPS,
       incomingRequests: [
-        { friendshipId: 'fs-req-1', requesterId: 'u2', displayName: 'Bob', avatarUrl: null },
+        { friendshipId: "fs-req-1", requesterId: "u2", displayName: "Bob", avatarUrl: null },
       ],
       pendingCount: 1,
-    })
+    });
 
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendsScreen />) })
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendsScreen />);
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === '1 incoming request(s)')).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(texts.some((n) => String(n.props.children) === "1 incoming request(s)")).toBe(true);
+  });
 
-  it('hides IncomingRequestsSection when no incoming requests', () => {
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendsScreen />) })
+  it("hides IncomingRequestsSection when no incoming requests", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendsScreen />);
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children).includes('incoming request'))).toBe(false)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(texts.some((n) => String(n.props.children).includes("incoming request"))).toBe(false);
+  });
 
-  it('shows ActivityIndicator while friendships are loading', () => {
-    mockUseFriendships.mockReturnValue({ ...EMPTY_FRIENDSHIPS, loading: true })
+  it("shows ActivityIndicator while friendships are loading", () => {
+    mockUseFriendships.mockReturnValue({ ...EMPTY_FRIENDSHIPS, loading: true });
 
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendsScreen />) })
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendsScreen />);
+    });
 
-    const spinners = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'ActivityIndicator')
-    expect(spinners.length).toBeGreaterThan(0)
-  })
+    const spinners = root!.root.findAll(
+      (n: ReactTestInstance) => (n.type as string) === "ActivityIndicator",
+    );
+    expect(spinners.length).toBeGreaterThan(0);
+  });
 
-  it('shows search results when query is non-empty', () => {
+  it("shows search results when query is non-empty", () => {
     mockUseUserSearch.mockReturnValue({
-      state: 'results',
-      results: [{ id: 'u-1', display_name: 'Jane Doe', avatar_url: null }],
+      state: "results",
+      results: [{ id: "u-1", display_name: "Jane Doe", avatar_url: null }],
       error: null,
-    })
+    });
 
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendsScreen />) })
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendsScreen />);
+    });
 
     // Simulate typing in the search bar
-    const inputs = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'TextInput')
-    act(() => { inputs[0].props.onChangeText('jane') })
+    const inputs = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "TextInput");
+    act(() => {
+      inputs[0].props.onChangeText("jane");
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'Jane Doe')).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(texts.some((n) => String(n.props.children) === "Jane Doe")).toBe(true);
+  });
 
   it('shows "No users found" when search returns empty results', () => {
-    mockUseUserSearch.mockReturnValue({ state: 'results', results: [], error: null })
+    mockUseUserSearch.mockReturnValue({ state: "results", results: [], error: null });
 
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendsScreen />) })
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendsScreen />);
+    });
 
-    const inputs = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'TextInput')
-    act(() => { inputs[0].props.onChangeText('xyz') })
+    const inputs = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "TextInput");
+    act(() => {
+      inputs[0].props.onChangeText("xyz");
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'No users found')).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(texts.some((n) => String(n.props.children) === "No users found")).toBe(true);
+  });
 
-  it('shows error text when search state is error', () => {
-    mockUseUserSearch.mockReturnValue({ state: 'error', results: [], error: 'network failure' })
+  it("shows error text when search state is error", () => {
+    mockUseUserSearch.mockReturnValue({ state: "error", results: [], error: "network failure" });
 
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendsScreen />) })
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendsScreen />);
+    });
 
-    const inputs = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'TextInput')
-    act(() => { inputs[0].props.onChangeText('a') })
+    const inputs = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "TextInput");
+    act(() => {
+      inputs[0].props.onChangeText("a");
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'network failure')).toBe(true)
-  })
-})
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(texts.some((n) => String(n.props.children) === "network failure")).toBe(true);
+  });
+});

--- a/app/(app)/(tabs)/__tests__/MapScreen.test.tsx
+++ b/app/(app)/(tabs)/__tests__/MapScreen.test.tsx
@@ -5,111 +5,124 @@
  * Uses react-test-renderer + React.act (no @testing-library/react-native needed).
  */
 
-import React from 'react'
-import { Text } from 'react-native'
-import { act, create, ReactTestInstance } from 'react-test-renderer'
+import React from "react";
+import { Text } from "react-native";
+import { act, create, ReactTestInstance } from "react-test-renderer";
 
 // ---------------------------------------------------------------------------
 // Mapbox mock — Camera wires setCamera to a stable spy via useImperativeHandle.
 // mockSetCamera is prefixed with "mock" so Jest hoisting allows it in the factory.
 // ---------------------------------------------------------------------------
-const mockSetCamera = jest.fn()
+const mockSetCamera = jest.fn();
 
-jest.mock('@rnmapbox/maps', () => {
-  const React = require('react')
+jest.mock("@rnmapbox/maps", () => {
+  const React = require("react");
   return {
     __esModule: true,
     default: {
       MapView: function MockMapView({ children }: { children: React.ReactNode }) {
-        return React.createElement(React.Fragment, null, children)
+        return React.createElement(React.Fragment, null, children);
       },
       Camera: React.forwardRef(function MockCamera(_: any, ref: any) {
-        React.useImperativeHandle(ref, () => ({ setCamera: mockSetCamera }))
-        return null
+        React.useImperativeHandle(ref, () => ({ setCamera: mockSetCamera }));
+        return null;
       }),
-      LocationPuck: function MockLocationPuck() { return null },
+      LocationPuck: function MockLocationPuck() {
+        return null;
+      },
       StyleURL: {
-        Light: 'mapbox://styles/mapbox/light-v10',
+        Light: "mapbox://styles/mapbox/light-v10",
       },
     },
-  }
-})
+  };
+});
 
-jest.mock('expo-location', () => ({
-  requestForegroundPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
-  getBackgroundPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'denied' })),
-  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+jest.mock("expo-location", () => ({
+  requestForegroundPermissionsAsync: jest.fn(() => Promise.resolve({ status: "granted" })),
+  getBackgroundPermissionsAsync: jest.fn(() => Promise.resolve({ status: "denied" })),
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: "granted" })),
   getCurrentPositionAsync: jest.fn(() =>
-    Promise.resolve({ coords: { latitude: 55.6761, longitude: 12.5683 } })
+    Promise.resolve({ coords: { latitude: 55.6761, longitude: 12.5683 } }),
   ),
   Accuracy: { High: 3, Low: 2 },
-}))
+}));
 
-jest.mock('expo-notifications', () => ({
-  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
-  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
-}))
+jest.mock("expo-notifications", () => ({
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: "granted" })),
+  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: "granted" })),
+}));
 
-jest.mock('@/lib/backgroundGeofences', () => ({
+jest.mock("@/lib/backgroundGeofences", () => ({
   registerGeofences: jest.fn(() => Promise.resolve()),
-}))
+}));
 
-jest.mock('@/lib/notifications', () => ({
+jest.mock("@/lib/notifications", () => ({
   setupNotificationCategories: jest.fn(() => Promise.resolve()),
-  CHECKIN_CATEGORY: 'geofence-checkin',
-}))
+  CHECKIN_CATEGORY: "geofence-checkin",
+}));
 
-jest.mock('@/components/BackgroundPermissionBanner', () => ({
+jest.mock("@/components/BackgroundPermissionBanner", () => ({
   BackgroundPermissionBanner: () => null,
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Hook mocks
 // ---------------------------------------------------------------------------
-const mockRefetchRatings = jest.fn()
+const mockRefetchRatings = jest.fn();
 
-jest.mock('@/hooks/usePois', () => ({
+jest.mock("@/hooks/usePois", () => ({
   usePois: jest.fn(() => ({ pois: [], error: null })),
-}))
+}));
 
-jest.mock('@/hooks/useAllPoiRatings', () => ({
+jest.mock("@/hooks/useAllPoiRatings", () => ({
   useAllPoiRatings: jest.fn(() => ({
     avgRatings: {},
     loading: false,
     error: null,
     refetch: mockRefetchRatings,
   })),
-}))
+}));
 
 // Fix 5: use real useState so setBroadcast/clearBroadcast actually update activePresence
-jest.mock('@/hooks/useActivePresence', () => {
-  const { useState } = require('react')
+jest.mock("@/hooks/useActivePresence", () => {
+  const { useState } = require("react");
   return {
     useActivePresence: () => {
-      const [activePresence, setActivePresence] = useState(null)
+      const [activePresence, setActivePresence] = useState(null);
       return {
         activePresence,
         loading: false,
         error: null,
         setBroadcast: setActivePresence,
         clearBroadcast: () => setActivePresence(null),
-      }
+      };
     },
-  }
-})
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Child component mocks — render null so only MapScreen's own nodes are visible
 // ---------------------------------------------------------------------------
-jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }))
-jest.mock('@/hooks/useFriendships', () => ({
-  useFriendships: jest.fn(() => ({ friends: [], incomingRequests: [], outgoingRequestMap: new Map(), sendRequest: jest.fn(), acceptRequest: jest.fn(), declineRequest: jest.fn(), cancelRequest: jest.fn(), unfriend: jest.fn(), getStatusForUser: jest.fn(() => 'none'), getFriendshipId: jest.fn(() => null) })),
-}))
-jest.mock('@/hooks/useLivePresences', () => ({
+jest.mock("@expo/vector-icons", () => ({ Ionicons: () => null }));
+jest.mock("@/hooks/useFriendships", () => ({
+  useFriendships: jest.fn(() => ({
+    friends: [],
+    incomingRequests: [],
+    outgoingRequestMap: new Map(),
+    sendRequest: jest.fn(),
+    acceptRequest: jest.fn(),
+    declineRequest: jest.fn(),
+    cancelRequest: jest.fn(),
+    unfriend: jest.fn(),
+    getStatusForUser: jest.fn(() => "none"),
+    getFriendshipId: jest.fn(() => null),
+  })),
+}));
+jest.mock("@/hooks/useLivePresences", () => ({
   useLivePresences: jest.fn(() => ({ presences: [], loading: false, error: null })),
-}))
+}));
 
-jest.mock('@/hooks/usePresenceJoins', () => ({
+jest.mock("@/hooks/usePresenceJoins", () => ({
   usePresenceJoins: jest.fn(() => ({
     joins: [],
     loading: false,
@@ -118,283 +131,60 @@ jest.mock('@/hooks/usePresenceJoins', () => ({
     cancel: jest.fn(),
     getJoinForPresence: jest.fn(() => undefined),
   })),
-}))
-jest.mock('@/components/map/PoiLayer', () => ({ PoiLayer: (props: any) => null }))
-jest.mock('@/components/map/PresenceLayer', () => ({ PresenceLayer: (props: any) => null }))
-jest.mock('@/components/map/CategoryFilterBar', () => ({ CategoryFilterBar: () => null }))
-jest.mock('@/components/map/PoiBottomSheet', () => ({ PoiBottomSheet: (props: any) => null }))
-jest.mock('@/components/map/PoiListView', () => ({ PoiListView: (props: any) => null }))
+}));
+jest.mock("@/components/map/PoiLayer", () => ({ PoiLayer: (props: any) => null }));
+jest.mock("@/components/map/PresenceLayer", () => ({ PresenceLayer: (props: any) => null }));
+jest.mock("@/components/map/CategoryFilterBar", () => ({ CategoryFilterBar: () => null }));
+jest.mock("@/components/map/PoiBottomSheet", () => ({ PoiBottomSheet: (props: any) => null }));
+jest.mock("@/components/map/PoiListView", () => ({ PoiListView: (props: any) => null }));
 
 // ---------------------------------------------------------------------------
 // Imports resolve to mocked versions — used with findByType
 // ---------------------------------------------------------------------------
-import Mapbox from '@rnmapbox/maps'
-import { usePois } from '@/hooks/usePois'
-import { useAllPoiRatings } from '@/hooks/useAllPoiRatings'
-import { useFriendships } from '@/hooks/useFriendships'
-import { useLivePresences } from '@/hooks/useLivePresences'
-import { usePresenceJoins } from '@/hooks/usePresenceJoins'
-import { PoiLayer } from '@/components/map/PoiLayer'
-import { PresenceLayer } from '@/components/map/PresenceLayer'
-import { PoiBottomSheet } from '@/components/map/PoiBottomSheet'
-import { PoiListView } from '@/components/map/PoiListView'
-import { Tables } from '@/types/supabase'
-import MapScreen from '../index'
+import Mapbox from "@rnmapbox/maps";
+import { usePois } from "@/hooks/usePois";
+import { useAllPoiRatings } from "@/hooks/useAllPoiRatings";
+import { useFriendships } from "@/hooks/useFriendships";
+import { useLivePresences } from "@/hooks/useLivePresences";
+import { usePresenceJoins } from "@/hooks/usePresenceJoins";
+import { PoiLayer } from "@/components/map/PoiLayer";
+import { PresenceLayer } from "@/components/map/PresenceLayer";
+import { PoiBottomSheet } from "@/components/map/PoiBottomSheet";
+import { PoiListView } from "@/components/map/PoiListView";
+import { Tables } from "@/types/supabase";
+import MapScreen from "../index";
 
-type Poi = Tables<'pois'>
+type Poi = Tables<"pois">;
 
 function makePoi(overrides: Partial<Poi> = {}): Poi {
   return {
-    id: 'poi-1',
-    name: 'Test Cafe',
-    category: 'food_drink',
+    id: "poi-1",
+    name: "Test Cafe",
+    category: "food_drink",
     lat: 55.6761,
     lng: 12.5683,
     description: null,
-    created_by: 'user-1',
-    created_at: '2025-01-01T00:00:00Z',
+    created_by: "user-1",
+    created_at: "2025-01-01T00:00:00Z",
     ...overrides,
-  } as Poi
+  } as Poi;
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('MapScreen', () => {
+describe("MapScreen", () => {
   beforeEach(() => {
-    jest.clearAllMocks()
-    ;(usePois as jest.Mock).mockReturnValue({ pois: [], error: null })
-    ;(useAllPoiRatings as jest.Mock).mockReturnValue({
+    jest.clearAllMocks();
+    (usePois as jest.Mock).mockReturnValue({ pois: [], error: null });
+    (useAllPoiRatings as jest.Mock).mockReturnValue({
       avgRatings: {},
       loading: false,
       error: null,
       refetch: mockRefetchRatings,
-    })
-    ;(useFriendships as jest.Mock).mockReturnValue({ friends: [], incomingRequests: [], outgoingRequestMap: new Map(), sendRequest: jest.fn(), acceptRequest: jest.fn(), declineRequest: jest.fn(), cancelRequest: jest.fn(), unfriend: jest.fn(), getStatusForUser: jest.fn(() => 'none'), getFriendshipId: jest.fn(() => null), error: null })
-    ;(useLivePresences as jest.Mock).mockReturnValue({ presences: [], loading: false, error: null })
-  })
-
-  it('Camera initializes centered on Copenhagen at zoom 13', async () => {
-    let root: ReturnType<typeof create>
-
-    await act(async () => { root = create(<MapScreen />) })
-
-    const camera = root!.root.findByType(Mapbox.Camera)
-    expect(camera.props.defaultSettings.centerCoordinate).toEqual([12.5683, 55.6761])
-    expect(camera.props.defaultSettings.zoomLevel).toBe(13)
-  })
-
-  it('handleSheetClose clears selected POI and calls refetchRatings', async () => {
-    const poi = makePoi()
-    let root: ReturnType<typeof create>
-
-    await act(async () => { root = create(<MapScreen />) })
-
-    // Open bottom sheet by tapping a map POI
-    act(() => { root!.root.findByType(PoiLayer).props.onPoiPress(poi) })
-    expect(root!.root.findByType(PoiBottomSheet).props.poi).toEqual(poi)
-
-    // Close the sheet
-    act(() => { root!.root.findByType(PoiBottomSheet).props.onClose() })
-
-    expect(root!.root.findByType(PoiBottomSheet).props.poi).toBeNull()
-    expect(mockRefetchRatings).toHaveBeenCalledTimes(1)
-  })
-
-  it('handleListRowPress switches to map, opens bottom sheet, and flies camera to POI', async () => {
-    const poi = makePoi({ id: 'poi-fly', lat: 55.7, lng: 12.6 })
-    let root: ReturnType<typeof create>
-
-    await act(async () => { root = create(<MapScreen />) })
-
-    // Switch to list mode via the toggle button
-    const toggle = root!.root.findAll(
-      (n: ReactTestInstance) => n.props.testID === 'view-mode-toggle' && typeof n.props.onPress === 'function'
-    )[0]
-    act(() => { toggle.props.onPress() })
-    expect(root!.root.findAllByType(PoiListView).length).toBeGreaterThan(0)
-
-    // Press a list row
-    act(() => { root!.root.findByType(PoiListView).props.onPoiPress(poi) })
-
-    // Map mode restored — list view is gone
-    expect(root!.root.findAllByType(PoiListView).length).toBe(0)
-    // Bottom sheet receives the pressed POI
-    expect(root!.root.findByType(PoiBottomSheet).props.poi).toEqual(poi)
-    // Camera flies to the POI's coordinates
-    expect(mockSetCamera).toHaveBeenCalledWith({
-      centerCoordinate: [poi.lng, poi.lat],
-      zoomLevel: 15,
-      animationDuration: 800,
-    })
-  })
-
-  it('error banner shows POI connection message when usePois errors', async () => {
-    ;(usePois as jest.Mock).mockReturnValue({ pois: [], error: 'network error' })
-    let root: ReturnType<typeof create>
-
-    await act(async () => { root = create(<MapScreen />) })
-
-    const hasMessage = root!.root
-      .findAllByType(Text)
-      .some((n: ReactTestInstance) =>
-        String(n.props.children).includes("Couldn't load places")
-      )
-    expect(hasMessage).toBe(true)
-  })
-
-  it('error banner shows join status message when only usePresenceJoins errors', async () => {
-    ;(usePresenceJoins as jest.Mock).mockReturnValue({
-      joins: [],
-      loading: false,
-      error: 'joins error',
-      join: jest.fn(),
-      cancel: jest.fn(),
-      getJoinForPresence: jest.fn(() => undefined),
-    })
-    let root: ReturnType<typeof create>
-
-    await act(async () => { root = create(<MapScreen />) })
-
-    const hasMessage = root!.root
-      .findAllByType(Text)
-      .some((n: ReactTestInstance) =>
-        String(n.props.children).includes('Could not load join status')
-      )
-    expect(hasMessage).toBe(true)
-  })
-
-  it('passes join, cancel, and getJoinForPresence from usePresenceJoins to PoiBottomSheet', async () => {
-    const mockJoin = jest.fn()
-    const mockCancel = jest.fn()
-    const mockGetJoin = jest.fn(() => undefined)
-    ;(usePresenceJoins as jest.Mock).mockReturnValue({
-      joins: [],
-      loading: false,
-      error: null,
-      join: mockJoin,
-      cancel: mockCancel,
-      getJoinForPresence: mockGetJoin,
-    })
-
-    let root: ReturnType<typeof create>
-    await act(async () => { root = create(<MapScreen />) })
-
-    const sheet = root!.root.findByType(PoiBottomSheet)
-    expect(sheet.props.onJoinPresence).toBe(mockJoin)
-    expect(sheet.props.onCancelJoin).toBe(mockCancel)
-    expect(sheet.props.getJoinForPresence).toBe(mockGetJoin)
-  })
-
-  it('error banner shows ratings message when only useAllPoiRatings errors', async () => {
-    ;(useAllPoiRatings as jest.Mock).mockReturnValue({
-      avgRatings: {},
-      loading: false,
-      error: 'ratings error',
-      refetch: mockRefetchRatings,
-    })
-    let root: ReturnType<typeof create>
-
-    await act(async () => { root = create(<MapScreen />) })
-
-    const hasMessage = root!.root
-      .findAllByType(Text)
-      .some((n: ReactTestInstance) =>
-        String(n.props.children).includes('Ratings unavailable')
-      )
-    expect(hasMessage).toBe(true)
-  })
-
-  it('return-to-location button calls setCamera with user coordinates', async () => {
-    // render with async act so locationGranted flushes to true
-    let root: ReturnType<typeof create>
-    await act(async () => { root = create(<MapScreen />) })
-
-    const btn = root!.root.findAll(
-      (n: ReactTestInstance) => n.props.testID === 'return-to-location' && typeof n.props.onPress === 'function'
-    )[0]
-    expect(btn).toBeDefined()
-
-    await act(async () => { btn.props.onPress() })
-
-    expect(mockSetCamera).toHaveBeenCalledWith({
-      centerCoordinate: [12.5683, 55.6761],
-      zoomLevel: 15,
-      animationDuration: 800,
-    })
-  })
-
-  it('hides LocationPuck and return-to-location button when permission is denied', async () => {
-    const Location = require('expo-location')
-    Location.requestForegroundPermissionsAsync.mockResolvedValueOnce({ status: 'denied' })
-
-    let root: ReturnType<typeof create>
-    await act(async () => { root = create(<MapScreen />) })
-
-    expect(root!.root.findAllByType(Mapbox.LocationPuck).length).toBe(0)
-    const btns = root!.root.findAll(
-      (n: ReactTestInstance) => n.props.testID === 'return-to-location'
-    )
-    expect(btns.length).toBe(0)
-  })
-
-  it('hides return-to-location button in list mode', async () => {
-    let root: ReturnType<typeof create>
-    await act(async () => { root = create(<MapScreen />) })
-
-    // switch to list mode
-    const toggle = root!.root.findAll(
-      (n: ReactTestInstance) => n.props.testID === 'view-mode-toggle' && typeof n.props.onPress === 'function'
-    )[0]
-    act(() => { toggle.props.onPress() })
-
-    const btns = root!.root.findAll(
-      (n: ReactTestInstance) => n.props.testID === 'return-to-location'
-    )
-    expect(btns.length).toBe(0)
-  })
-
-  it('renders LocationPuck when location permission is granted', async () => {
-    let root: ReturnType<typeof create>
-    await act(async () => { root = create(<MapScreen />) })
-
-    expect(root!.root.findAllByType(Mapbox.LocationPuck).length).toBe(1)
-  })
-
-  it('passes unfiltered pois and presences from useLivePresences to PresenceLayer', async () => {
-    const allPois = [
-      makePoi({ id: 'poi-1', category: 'food_drink' }),
-      makePoi({ id: 'poi-2', category: 'nightlife' }),
-    ]
-    const mockPresences = [{ id: 'p-1', userId: 'u-2', poiId: 'poi-1', displayName: 'Jane', avatarUrl: null, message: null }]
-    ;(usePois as jest.Mock).mockReturnValue({ pois: allPois, error: null })
-    ;(useLivePresences as jest.Mock).mockReturnValue({ presences: mockPresences, loading: false, error: null })
-
-    let root: ReturnType<typeof create>
-    await act(async () => { root = create(<MapScreen />) })
-
-    const layer = root!.root.findByType(PresenceLayer)
-    // receives ALL pois, not filtered subset
-    expect(layer.props.pois).toEqual(allPois)
-    expect(layer.props.presences).toEqual(mockPresences)
-  })
-
-  it('passes handlePoiPress to PresenceLayer as onPoiPress and it opens the bottom sheet', async () => {
-    const poi = makePoi()
-    ;(usePois as jest.Mock).mockReturnValue({ pois: [poi], error: null })
-
-    let root: ReturnType<typeof create>
-    await act(async () => { root = create(<MapScreen />) })
-
-    act(() => { root!.root.findByType(PresenceLayer).props.onPoiPress(poi) })
-
-    expect(root!.root.findByType(PoiBottomSheet).props.poi).toEqual(poi)
-  })
-
-  // Fix 5: verify setBroadcast/clearBroadcast wiring through PoiBottomSheet props
-  it('error banner shows friend list message when useFriendships errors', async () => {
-    ;(useFriendships as jest.Mock).mockReturnValue({
+    });
+    (useFriendships as jest.Mock).mockReturnValue({
       friends: [],
       incomingRequests: [],
       outgoingRequestMap: new Map(),
@@ -403,45 +193,338 @@ describe('MapScreen', () => {
       declineRequest: jest.fn(),
       cancelRequest: jest.fn(),
       unfriend: jest.fn(),
-      getStatusForUser: jest.fn(() => 'none'),
+      getStatusForUser: jest.fn(() => "none"),
       getFriendshipId: jest.fn(() => null),
-      error: 'network error',
-    })
-    let root: ReturnType<typeof create>
+      error: null,
+    });
+    (useLivePresences as jest.Mock).mockReturnValue({ presences: [], loading: false, error: null });
+  });
 
-    await act(async () => { root = create(<MapScreen />) })
+  it("Camera initializes centered on Copenhagen at zoom 13", async () => {
+    let root: ReturnType<typeof create>;
+
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
+
+    const camera = root!.root.findByType(Mapbox.Camera);
+    expect(camera.props.defaultSettings.centerCoordinate).toEqual([12.5683, 55.6761]);
+    expect(camera.props.defaultSettings.zoomLevel).toBe(13);
+  });
+
+  it("handleSheetClose clears selected POI and calls refetchRatings", async () => {
+    const poi = makePoi();
+    let root: ReturnType<typeof create>;
+
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
+
+    // Open bottom sheet by tapping a map POI
+    act(() => {
+      root!.root.findByType(PoiLayer).props.onPoiPress(poi);
+    });
+    expect(root!.root.findByType(PoiBottomSheet).props.poi).toEqual(poi);
+
+    // Close the sheet
+    act(() => {
+      root!.root.findByType(PoiBottomSheet).props.onClose();
+    });
+
+    expect(root!.root.findByType(PoiBottomSheet).props.poi).toBeNull();
+    expect(mockRefetchRatings).toHaveBeenCalledTimes(1);
+  });
+
+  it("handleListRowPress switches to map, opens bottom sheet, and flies camera to POI", async () => {
+    const poi = makePoi({ id: "poi-fly", lat: 55.7, lng: 12.6 });
+    let root: ReturnType<typeof create>;
+
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
+
+    // Switch to list mode via the toggle button
+    const toggle = root!.root.findAll(
+      (n: ReactTestInstance) =>
+        n.props.testID === "view-mode-toggle" && typeof n.props.onPress === "function",
+    )[0];
+    act(() => {
+      toggle.props.onPress();
+    });
+    expect(root!.root.findAllByType(PoiListView).length).toBeGreaterThan(0);
+
+    // Press a list row
+    act(() => {
+      root!.root.findByType(PoiListView).props.onPoiPress(poi);
+    });
+
+    // Map mode restored — list view is gone
+    expect(root!.root.findAllByType(PoiListView).length).toBe(0);
+    // Bottom sheet receives the pressed POI
+    expect(root!.root.findByType(PoiBottomSheet).props.poi).toEqual(poi);
+    // Camera flies to the POI's coordinates
+    expect(mockSetCamera).toHaveBeenCalledWith({
+      centerCoordinate: [poi.lng, poi.lat],
+      zoomLevel: 15,
+      animationDuration: 800,
+    });
+  });
+
+  it("error banner shows POI connection message when usePois errors", async () => {
+    (usePois as jest.Mock).mockReturnValue({ pois: [], error: "network error" });
+    let root: ReturnType<typeof create>;
+
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
+
+    const hasMessage = root!.root
+      .findAllByType(Text)
+      .some((n: ReactTestInstance) => String(n.props.children).includes("Couldn't load places"));
+    expect(hasMessage).toBe(true);
+  });
+
+  it("error banner shows join status message when only usePresenceJoins errors", async () => {
+    (usePresenceJoins as jest.Mock).mockReturnValue({
+      joins: [],
+      loading: false,
+      error: "joins error",
+      join: jest.fn(),
+      cancel: jest.fn(),
+      getJoinForPresence: jest.fn(() => undefined),
+    });
+    let root: ReturnType<typeof create>;
+
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
 
     const hasMessage = root!.root
       .findAllByType(Text)
       .some((n: ReactTestInstance) =>
-        String(n.props.children).includes('Friend list unavailable')
-      )
-    expect(hasMessage).toBe(true)
-  })
+        String(n.props.children).includes("Could not load join status"),
+      );
+    expect(hasMessage).toBe(true);
+  });
 
-  it('passes setBroadcast and clearBroadcast to PoiBottomSheet and they update activePresence', async () => {
+  it("passes join, cancel, and getJoinForPresence from usePresenceJoins to PoiBottomSheet", async () => {
+    const mockJoin = jest.fn();
+    const mockCancel = jest.fn();
+    const mockGetJoin = jest.fn(() => undefined);
+    (usePresenceJoins as jest.Mock).mockReturnValue({
+      joins: [],
+      loading: false,
+      error: null,
+      join: mockJoin,
+      cancel: mockCancel,
+      getJoinForPresence: mockGetJoin,
+    });
+
+    let root: ReturnType<typeof create>;
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
+
+    const sheet = root!.root.findByType(PoiBottomSheet);
+    expect(sheet.props.onJoinPresence).toBe(mockJoin);
+    expect(sheet.props.onCancelJoin).toBe(mockCancel);
+    expect(sheet.props.getJoinForPresence).toBe(mockGetJoin);
+  });
+
+  it("error banner shows ratings message when only useAllPoiRatings errors", async () => {
+    (useAllPoiRatings as jest.Mock).mockReturnValue({
+      avgRatings: {},
+      loading: false,
+      error: "ratings error",
+      refetch: mockRefetchRatings,
+    });
+    let root: ReturnType<typeof create>;
+
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
+
+    const hasMessage = root!.root
+      .findAllByType(Text)
+      .some((n: ReactTestInstance) => String(n.props.children).includes("Ratings unavailable"));
+    expect(hasMessage).toBe(true);
+  });
+
+  it("return-to-location button calls setCamera with user coordinates", async () => {
+    // render with async act so locationGranted flushes to true
+    let root: ReturnType<typeof create>;
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
+
+    const btn = root!.root.findAll(
+      (n: ReactTestInstance) =>
+        n.props.testID === "return-to-location" && typeof n.props.onPress === "function",
+    )[0];
+    expect(btn).toBeDefined();
+
+    await act(async () => {
+      btn.props.onPress();
+    });
+
+    expect(mockSetCamera).toHaveBeenCalledWith({
+      centerCoordinate: [12.5683, 55.6761],
+      zoomLevel: 15,
+      animationDuration: 800,
+    });
+  });
+
+  it("hides LocationPuck and return-to-location button when permission is denied", async () => {
+    const Location = require("expo-location");
+    Location.requestForegroundPermissionsAsync.mockResolvedValueOnce({ status: "denied" });
+
+    let root: ReturnType<typeof create>;
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
+
+    expect(root!.root.findAllByType(Mapbox.LocationPuck).length).toBe(0);
+    const btns = root!.root.findAll(
+      (n: ReactTestInstance) => n.props.testID === "return-to-location",
+    );
+    expect(btns.length).toBe(0);
+  });
+
+  it("hides return-to-location button in list mode", async () => {
+    let root: ReturnType<typeof create>;
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
+
+    // switch to list mode
+    const toggle = root!.root.findAll(
+      (n: ReactTestInstance) =>
+        n.props.testID === "view-mode-toggle" && typeof n.props.onPress === "function",
+    )[0];
+    act(() => {
+      toggle.props.onPress();
+    });
+
+    const btns = root!.root.findAll(
+      (n: ReactTestInstance) => n.props.testID === "return-to-location",
+    );
+    expect(btns.length).toBe(0);
+  });
+
+  it("renders LocationPuck when location permission is granted", async () => {
+    let root: ReturnType<typeof create>;
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
+
+    expect(root!.root.findAllByType(Mapbox.LocationPuck).length).toBe(1);
+  });
+
+  it("passes unfiltered pois and presences from useLivePresences to PresenceLayer", async () => {
+    const allPois = [
+      makePoi({ id: "poi-1", category: "food_drink" }),
+      makePoi({ id: "poi-2", category: "nightlife" }),
+    ];
+    const mockPresences = [
+      {
+        id: "p-1",
+        userId: "u-2",
+        poiId: "poi-1",
+        displayName: "Jane",
+        avatarUrl: null,
+        message: null,
+      },
+    ];
+    (usePois as jest.Mock).mockReturnValue({ pois: allPois, error: null });
+    (useLivePresences as jest.Mock).mockReturnValue({
+      presences: mockPresences,
+      loading: false,
+      error: null,
+    });
+
+    let root: ReturnType<typeof create>;
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
+
+    const layer = root!.root.findByType(PresenceLayer);
+    // receives ALL pois, not filtered subset
+    expect(layer.props.pois).toEqual(allPois);
+    expect(layer.props.presences).toEqual(mockPresences);
+  });
+
+  it("passes handlePoiPress to PresenceLayer as onPoiPress and it opens the bottom sheet", async () => {
+    const poi = makePoi();
+    (usePois as jest.Mock).mockReturnValue({ pois: [poi], error: null });
+
+    let root: ReturnType<typeof create>;
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
+
+    act(() => {
+      root!.root.findByType(PresenceLayer).props.onPoiPress(poi);
+    });
+
+    expect(root!.root.findByType(PoiBottomSheet).props.poi).toEqual(poi);
+  });
+
+  // Fix 5: verify setBroadcast/clearBroadcast wiring through PoiBottomSheet props
+  it("error banner shows friend list message when useFriendships errors", async () => {
+    (useFriendships as jest.Mock).mockReturnValue({
+      friends: [],
+      incomingRequests: [],
+      outgoingRequestMap: new Map(),
+      sendRequest: jest.fn(),
+      acceptRequest: jest.fn(),
+      declineRequest: jest.fn(),
+      cancelRequest: jest.fn(),
+      unfriend: jest.fn(),
+      getStatusForUser: jest.fn(() => "none"),
+      getFriendshipId: jest.fn(() => null),
+      error: "network error",
+    });
+    let root: ReturnType<typeof create>;
+
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
+
+    const hasMessage = root!.root
+      .findAllByType(Text)
+      .some((n: ReactTestInstance) => String(n.props.children).includes("Friend list unavailable"));
+    expect(hasMessage).toBe(true);
+  });
+
+  it("passes setBroadcast and clearBroadcast to PoiBottomSheet and they update activePresence", async () => {
     const mockPresence = {
-      id: 'presence-1',
-      poi_id: 'poi-1',
-      message: 'here now',
-      visible_to: 'friends' as const,
-    }
+      id: "presence-1",
+      poi_id: "poi-1",
+      message: "here now",
+      visible_to: "friends" as const,
+    };
 
-    let root: ReturnType<typeof create>
-    await act(async () => { root = create(<MapScreen />) })
+    let root: ReturnType<typeof create>;
+    await act(async () => {
+      root = create(<MapScreen />);
+    });
 
-    const sheet = root!.root.findByType(PoiBottomSheet)
+    const sheet = root!.root.findByType(PoiBottomSheet);
 
     // onBroadcast and onDismissBroadcast props must be functions
-    expect(typeof sheet.props.onBroadcast).toBe('function')
-    expect(typeof sheet.props.onDismissBroadcast).toBe('function')
+    expect(typeof sheet.props.onBroadcast).toBe("function");
+    expect(typeof sheet.props.onDismissBroadcast).toBe("function");
 
     // Calling onBroadcast sets activePresence on the sheet
-    act(() => { sheet.props.onBroadcast(mockPresence) })
-    expect(root!.root.findByType(PoiBottomSheet).props.activePresence).toEqual(mockPresence)
+    act(() => {
+      sheet.props.onBroadcast(mockPresence);
+    });
+    expect(root!.root.findByType(PoiBottomSheet).props.activePresence).toEqual(mockPresence);
 
     // Calling onDismissBroadcast clears it
-    act(() => { sheet.props.onDismissBroadcast() })
-    expect(root!.root.findByType(PoiBottomSheet).props.activePresence).toBeNull()
-  })
-})
+    act(() => {
+      sheet.props.onDismissBroadcast();
+    });
+    expect(root!.root.findByType(PoiBottomSheet).props.activePresence).toBeNull();
+  });
+});

--- a/app/(app)/(tabs)/_layout.tsx
+++ b/app/(app)/(tabs)/_layout.tsx
@@ -1,16 +1,16 @@
-import { Tabs } from 'expo-router'
-import { Ionicons } from '@expo/vector-icons'
-import { usePendingRequestCount } from '@/hooks/usePendingRequestCount'
+import { Tabs } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import { usePendingRequestCount } from "@/hooks/usePendingRequestCount";
 
 export default function TabLayout() {
-  const pendingCount = usePendingRequestCount()
+  const pendingCount = usePendingRequestCount();
 
   return (
-    <Tabs screenOptions={{ tabBarActiveTintColor: '#0066FF' }}>
+    <Tabs screenOptions={{ tabBarActiveTintColor: "#0066FF" }}>
       <Tabs.Screen
         name="index"
         options={{
-          title: 'Map',
+          title: "Map",
           headerShown: false,
           tabBarIcon: ({ color }) => <Ionicons name="map" size={24} color={color} />,
         }}
@@ -18,18 +18,18 @@ export default function TabLayout() {
       <Tabs.Screen
         name="passport"
         options={{
-          title: 'Passport',
+          title: "Passport",
           tabBarIcon: ({ color }) => <Ionicons name="id-card" size={24} color={color} />,
         }}
       />
       <Tabs.Screen
         name="friends"
         options={{
-          title: 'Friends',
+          title: "Friends",
           tabBarBadge: pendingCount > 0 ? pendingCount : undefined,
           tabBarIcon: ({ color }) => <Ionicons name="people" size={24} color={color} />,
         }}
       />
     </Tabs>
-  )
+  );
 }

--- a/app/(app)/(tabs)/friends.tsx
+++ b/app/(app)/(tabs)/friends.tsx
@@ -1,17 +1,17 @@
-import { useState } from 'react'
-import { ActivityIndicator, FlatList, StyleSheet, Text, TextInput, View } from 'react-native'
-import { useUserSearch } from '@/hooks/useUserSearch'
-import { useFriendships } from '@/hooks/useFriendships'
-import { UserSearchResult } from '@/components/friends/UserSearchResult'
-import { FriendRow } from '@/components/friends/FriendRow'
-import { IncomingRequestsSection } from '@/components/friends/IncomingRequestsSection'
+import { useState } from "react";
+import { ActivityIndicator, FlatList, StyleSheet, Text, TextInput, View } from "react-native";
+import { useUserSearch } from "@/hooks/useUserSearch";
+import { useFriendships } from "@/hooks/useFriendships";
+import { UserSearchResult } from "@/components/friends/UserSearchResult";
+import { FriendRow } from "@/components/friends/FriendRow";
+import { IncomingRequestsSection } from "@/components/friends/IncomingRequestsSection";
 
 export default function FriendsScreen() {
-  const [query, setQuery] = useState('')
-  const search = useUserSearch(query)
-  const friendships = useFriendships()
+  const [query, setQuery] = useState("");
+  const search = useUserSearch(query);
+  const friendships = useFriendships();
 
-  const isSearching = query.trim().length > 0
+  const isSearching = query.trim().length > 0;
 
   return (
     <View style={styles.container}>
@@ -74,46 +74,46 @@ export default function FriendsScreen() {
       {/* Search results */}
       {isSearching && (
         <>
-          {search.state === 'searching' && (
+          {search.state === "searching" && (
             <View style={styles.center}>
               <ActivityIndicator size="small" color="#131313" />
             </View>
           )}
 
-          {search.state === 'results' && search.results.length === 0 && (
+          {search.state === "results" && search.results.length === 0 && (
             <View style={styles.center}>
               <Text style={styles.hint}>No users found</Text>
             </View>
           )}
 
-          {search.state === 'results' && search.results.length > 0 && (
+          {search.state === "results" && search.results.length > 0 && (
             <FlatList
               data={search.results}
               keyExtractor={(item) => item.id}
               renderItem={({ item }) => {
-                const status = friendships.getStatusForUser(item.id)
-                const friendshipId = friendships.getFriendshipId(item.id)
+                const status = friendships.getStatusForUser(item.id);
+                const friendshipId = friendships.getFriendshipId(item.id);
                 return (
                   <UserSearchResult
                     user={item}
                     status={status}
                     onSendRequest={() => friendships.sendRequest(item.id)}
                     onCancelRequest={() => {
-                      if (!friendshipId) return Promise.resolve()
-                      return friendships.cancelRequest(friendshipId)
+                      if (!friendshipId) return Promise.resolve();
+                      return friendships.cancelRequest(friendshipId);
                     }}
                     onAcceptRequest={() => {
-                      if (!friendshipId) return Promise.resolve()
-                      return friendships.acceptRequest(friendshipId)
+                      if (!friendshipId) return Promise.resolve();
+                      return friendships.acceptRequest(friendshipId);
                     }}
                   />
-                )
+                );
               }}
               contentContainerStyle={styles.list}
             />
           )}
 
-          {search.state === 'error' && (
+          {search.state === "error" && (
             <View style={styles.center}>
               <Text style={styles.errorText}>{search.error}</Text>
             </View>
@@ -121,13 +121,13 @@ export default function FriendsScreen() {
         </>
       )}
     </View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
+    backgroundColor: "#fff",
   },
   searchBarWrapper: {
     paddingHorizontal: 16,
@@ -136,26 +136,26 @@ const styles = StyleSheet.create({
   },
   searchBar: {
     height: 44,
-    backgroundColor: '#f2f2f2',
+    backgroundColor: "#f2f2f2",
     borderRadius: 12,
     paddingHorizontal: 14,
     fontSize: 15,
-    color: '#131313',
+    color: "#131313",
   },
   center: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
   },
   hint: {
     fontSize: 14,
-    color: '#999',
+    color: "#999",
   },
   errorText: {
     fontSize: 14,
-    color: '#e53e3e',
+    color: "#e53e3e",
   },
   list: {
     paddingTop: 4,
   },
-})
+});

--- a/app/(app)/(tabs)/index.tsx
+++ b/app/(app)/(tabs)/index.tsx
@@ -1,67 +1,77 @@
-import Mapbox from '@rnmapbox/maps'
-import { Ionicons } from '@expo/vector-icons'
-import * as Location from 'expo-location'
-import * as Notifications from 'expo-notifications'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { PoiSlim } from '@/lib/backgroundGeofences'
-import { Platform, Pressable, StyleSheet, Text, View } from 'react-native'
-import { Tables } from '@/types/supabase'
-import { usePois } from '@/hooks/usePois'
-import { useAllPoiRatings } from '@/hooks/useAllPoiRatings'
-import { useActivePresence } from '@/hooks/useActivePresence'
-import { useFriendships } from '@/hooks/useFriendships'
-import { useLivePresences } from '@/hooks/useLivePresences'
-import { usePresenceJoins } from '@/hooks/usePresenceJoins'
-import { PoiLayer } from '@/components/map/PoiLayer'
-import { PresenceLayer } from '@/components/map/PresenceLayer'
-import { CategoryFilterBar } from '@/components/map/CategoryFilterBar'
-import { PoiBottomSheet } from '@/components/map/PoiBottomSheet'
-import { PoiListView } from '@/components/map/PoiListView'
-import { POI_CATEGORIES, PoiCategory } from '@/lib/poiCategories'
-import { registerGeofences } from '@/lib/backgroundGeofences'
-import { BackgroundPermissionBanner } from '@/components/BackgroundPermissionBanner'
+import Mapbox from "@rnmapbox/maps";
+import { Ionicons } from "@expo/vector-icons";
+import * as Location from "expo-location";
+import * as Notifications from "expo-notifications";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { PoiSlim } from "@/lib/backgroundGeofences";
+import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
+import { Tables } from "@/types/supabase";
+import { usePois } from "@/hooks/usePois";
+import { useAllPoiRatings } from "@/hooks/useAllPoiRatings";
+import { useActivePresence } from "@/hooks/useActivePresence";
+import { useFriendships } from "@/hooks/useFriendships";
+import { useLivePresences } from "@/hooks/useLivePresences";
+import { usePresenceJoins } from "@/hooks/usePresenceJoins";
+import { PoiLayer } from "@/components/map/PoiLayer";
+import { PresenceLayer } from "@/components/map/PresenceLayer";
+import { CategoryFilterBar } from "@/components/map/CategoryFilterBar";
+import { PoiBottomSheet } from "@/components/map/PoiBottomSheet";
+import { PoiListView } from "@/components/map/PoiListView";
+import { POI_CATEGORIES, PoiCategory } from "@/lib/poiCategories";
+import { registerGeofences } from "@/lib/backgroundGeofences";
+import { BackgroundPermissionBanner } from "@/components/BackgroundPermissionBanner";
 
-type Poi = Tables<'pois'>
+type Poi = Tables<"pois">;
 
-const ALL_ACTIVE = Object.fromEntries(
-  POI_CATEGORIES.map((c) => [c, true])
-) as Record<PoiCategory, boolean>
+const ALL_ACTIVE = Object.fromEntries(POI_CATEGORIES.map((c) => [c, true])) as Record<
+  PoiCategory,
+  boolean
+>;
 
 export default function MapScreen() {
-  const { pois, error: poisError } = usePois()
-  const { avgRatings, error: ratingsError, refetch: refetchRatings } = useAllPoiRatings()
-  const { activePresence, setBroadcast, clearBroadcast } = useActivePresence()
-  const { friends, error: friendshipsError } = useFriendships()
-  const friendIds = useMemo(() => friends.map((f) => f.userId), [friends])
-  const { presences, error: presenceError } = useLivePresences(friendIds)
-  const { join, cancel, getJoinForPresence, error: joinsError } = usePresenceJoins()
-  const [activeCategories, setActiveCategories] = useState<Record<PoiCategory, boolean>>(ALL_ACTIVE)
-  const [selectedPoi, setSelectedPoi] = useState<Poi | null>(null)
-  const [viewMode, setViewMode] = useState<'map' | 'list'>('map')
-  const [locationGranted, setLocationGranted] = useState(false)
-  const [backgroundGranted, setBackgroundGranted] = useState(false)
-  const [bannerDismissed, setBannerDismissed] = useState(false)
-  const [locationError, setLocationError] = useState<string | null>(null)
-  const cameraRef = useRef<Mapbox.Camera>(null)
-  const pendingCamera = useRef<Poi | null>(null)
+  const { pois, error: poisError } = usePois();
+  const { avgRatings, error: ratingsError, refetch: refetchRatings } = useAllPoiRatings();
+  const { activePresence, setBroadcast, clearBroadcast } = useActivePresence();
+  const { friends, error: friendshipsError } = useFriendships();
+  const friendIds = useMemo(() => friends.map((f) => f.userId), [friends]);
+  const { presences, error: presenceError } = useLivePresences(friendIds);
+  const { join, cancel, getJoinForPresence, error: joinsError } = usePresenceJoins();
+  const [activeCategories, setActiveCategories] =
+    useState<Record<PoiCategory, boolean>>(ALL_ACTIVE);
+  const [selectedPoi, setSelectedPoi] = useState<Poi | null>(null);
+  const [viewMode, setViewMode] = useState<"map" | "list">("map");
+  const [locationGranted, setLocationGranted] = useState(false);
+  const [backgroundGranted, setBackgroundGranted] = useState(false);
+  const [bannerDismissed, setBannerDismissed] = useState(false);
+  const [locationError, setLocationError] = useState<string | null>(null);
+  const cameraRef = useRef<Mapbox.Camera>(null);
+  const pendingCamera = useRef<Poi | null>(null);
 
   useEffect(() => {
-    let active = true
+    let active = true;
     Location.requestForegroundPermissionsAsync()
       .then(({ status }) => {
-        if (active) setLocationGranted(status === 'granted')
+        if (active) setLocationGranted(status === "granted");
       })
-      .catch((err) => { console.error('Location permission request failed:', err) })
-    return () => { active = false }
-  }, [])
+      .catch((err) => {
+        console.error("Location permission request failed:", err);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   // Check if background location permission has already been granted.
   useEffect(() => {
-    if (!locationGranted) return
+    if (!locationGranted) return;
     Location.getBackgroundPermissionsAsync()
-      .then(({ status }) => { setBackgroundGranted(status === 'granted') })
-      .catch((err) => { console.error('[MapScreen] Failed to check background permissions:', err) })
-  }, [locationGranted])
+      .then(({ status }) => {
+        setBackgroundGranted(status === "granted");
+      })
+      .catch((err) => {
+        console.error("[MapScreen] Failed to check background permissions:", err);
+      });
+  }, [locationGranted]);
 
   // Stable key for geofence registration — only re-register when the actual
   // POI set changes, not on every pois array reference change. Without this,
@@ -70,110 +80,117 @@ export default function MapScreen() {
   const poisSlim = useMemo<PoiSlim[]>(
     () => pois.map((p) => ({ id: p.id, name: p.name, lat: p.lat, lng: p.lng })),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [pois.map((p) => p.id).join(',')]
-  )
+    [pois.map((p) => p.id).join(",")],
+  );
 
   // Register geofences once background permission + POIs are available.
   useEffect(() => {
-    if (!backgroundGranted || poisSlim.length === 0) return
-    let cancelled = false
+    if (!backgroundGranted || poisSlim.length === 0) return;
+    let cancelled = false;
 
     async function setup() {
       try {
-        const { status } = await Notifications.getPermissionsAsync()
-        if (status !== 'granted') {
-          const { status: newStatus } = await Notifications.requestPermissionsAsync()
-          if (newStatus !== 'granted') {
-            console.warn('[Geofences] Notification permission denied — skipping geofence registration')
-            return
+        const { status } = await Notifications.getPermissionsAsync();
+        if (status !== "granted") {
+          const { status: newStatus } = await Notifications.requestPermissionsAsync();
+          if (newStatus !== "granted") {
+            console.warn(
+              "[Geofences] Notification permission denied — skipping geofence registration",
+            );
+            return;
           }
         }
 
-        let currentLocation: { latitude: number; longitude: number } | undefined
+        let currentLocation: { latitude: number; longitude: number } | undefined;
         try {
-          const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Low })
-          currentLocation = { latitude: loc.coords.latitude, longitude: loc.coords.longitude }
+          const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Low });
+          currentLocation = { latitude: loc.coords.latitude, longitude: loc.coords.longitude };
         } catch {
           // Fall back to Copenhagen city center (handled inside registerGeofences)
         }
 
-        if (cancelled) return
-        await registerGeofences(poisSlim, currentLocation)
-        console.log('[Geofences] registered', poisSlim.length, 'POIs')
+        if (cancelled) return;
+        await registerGeofences(poisSlim, currentLocation);
+        console.log("[Geofences] registered", poisSlim.length, "POIs");
       } catch (err) {
-        console.error('[Geofence registration] failed:', err)
+        console.error("[Geofence registration] failed:", err);
         if (!cancelled) {
-          setLocationError('Automatic check-ins could not be started — try restarting the app.')
-          setTimeout(() => setLocationError(null), 5000)
+          setLocationError("Automatic check-ins could not be started — try restarting the app.");
+          setTimeout(() => setLocationError(null), 5000);
         }
       }
     }
 
-    setup()
-    return () => { cancelled = true }
-  }, [poisSlim, backgroundGranted])
+    setup();
+    return () => {
+      cancelled = true;
+    };
+  }, [poisSlim, backgroundGranted]);
 
   const filteredPois = useMemo(
     () => pois.filter((p) => activeCategories[p.category] !== false),
-    [pois, activeCategories]
-  )
+    [pois, activeCategories],
+  );
 
   const handlePoiPress = useCallback((poi: Poi) => {
-    setSelectedPoi(poi)
-  }, [])
+    setSelectedPoi(poi);
+  }, []);
 
   const handleSheetClose = useCallback(() => {
-    setSelectedPoi(null)
-    refetchRatings()
-  }, [refetchRatings])
+    setSelectedPoi(null);
+    refetchRatings();
+  }, [refetchRatings]);
 
   const handleListRowPress = useCallback((poi: Poi) => {
-    pendingCamera.current = poi
-    setViewMode('map')
-    setSelectedPoi(poi)
-  }, [])
+    pendingCamera.current = poi;
+    setViewMode("map");
+    setSelectedPoi(poi);
+  }, []);
 
   // setCamera must run after the map is visible again. Calling it synchronously inside
   // handleListRowPress (before the viewMode state update re-renders and unhides the map)
   // is unreliable — the native GL surface may not be ready. pendingCamera stores the
   // target POI so this effect can fire the camera command after the render commits.
   useEffect(() => {
-    if (viewMode === 'map' && pendingCamera.current) {
-      const poi = pendingCamera.current
-      pendingCamera.current = null
+    if (viewMode === "map" && pendingCamera.current) {
+      const poi = pendingCamera.current;
+      pendingCamera.current = null;
       cameraRef.current?.setCamera({
         centerCoordinate: [poi.lng, poi.lat],
         zoomLevel: 15,
         animationDuration: 800,
-      })
+      });
     }
-  }, [viewMode])
+  }, [viewMode]);
 
   const toggleViewMode = useCallback(() => {
-    setViewMode((v) => (v === 'map' ? 'list' : 'map'))
-  }, [])
+    setViewMode((v) => (v === "map" ? "list" : "map"));
+  }, []);
 
   const handleReturnToLocation = useCallback(async () => {
-    setLocationError(null)
+    setLocationError(null);
     try {
-      const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High })
+      const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
       cameraRef.current?.setCamera({
         centerCoordinate: [loc.coords.longitude, loc.coords.latitude],
         zoomLevel: 15,
         animationDuration: 800,
-      })
+      });
     } catch (err) {
-      console.error('handleReturnToLocation: failed to get current position', err)
-      setLocationError("Couldn't get your location — try again.")
-      setTimeout(() => setLocationError(null), 3000)
+      console.error("handleReturnToLocation: failed to get current position", err);
+      setLocationError("Couldn't get your location — try again.");
+      setTimeout(() => setLocationError(null), 3000);
     }
-  }, [])
+  }, []);
 
   return (
     <View style={styles.container}>
       {/* MapView stays mounted in list mode (display: none) — unmounting would destroy the
           native Mapbox GL context and invalidate cameraRef, requiring a full re-init on switch back */}
-      <Mapbox.MapView style={[styles.map, viewMode === 'list' && styles.hidden]} styleURL={Mapbox.StyleURL.Light}>
+      <Mapbox.MapView
+        style={[styles.map, viewMode === "list" && styles.hidden]}
+        styleURL={Mapbox.StyleURL.Light}
+      >
         <Mapbox.Camera
           ref={cameraRef}
           defaultSettings={{
@@ -191,26 +208,22 @@ export default function MapScreen() {
         {locationGranted && <Mapbox.LocationPuck puckBearingEnabled puckBearing="heading" />}
       </Mapbox.MapView>
 
-      {viewMode === 'list' && (
-        <PoiListView
-          pois={filteredPois}
-          avgRatings={avgRatings}
-          onPoiPress={handleListRowPress}
-        />
+      {viewMode === "list" && (
+        <PoiListView pois={filteredPois} avgRatings={avgRatings} onPoiPress={handleListRowPress} />
       )}
 
       <CategoryFilterBar value={activeCategories} onChange={setActiveCategories} />
 
       <Pressable style={styles.toggleButton} onPress={toggleViewMode} testID="view-mode-toggle">
-        <Ionicons
-          name={viewMode === 'map' ? 'list' : 'map'}
-          size={20}
-          color="#fff"
-        />
+        <Ionicons name={viewMode === "map" ? "list" : "map"} size={20} color="#fff" />
       </Pressable>
 
-      {locationGranted && viewMode === 'map' && (
-        <Pressable style={styles.locationButton} onPress={handleReturnToLocation} testID="return-to-location">
+      {locationGranted && viewMode === "map" && (
+        <Pressable
+          style={styles.locationButton}
+          onPress={handleReturnToLocation}
+          testID="return-to-location"
+        >
           <Ionicons name="locate" size={20} color="#fff" />
         </Pressable>
       )}
@@ -222,20 +235,25 @@ export default function MapScreen() {
         />
       )}
 
-      {(poisError || ratingsError || presenceError || friendshipsError || joinsError || locationError) && (
+      {(poisError ||
+        ratingsError ||
+        presenceError ||
+        friendshipsError ||
+        joinsError ||
+        locationError) && (
         <View style={styles.errorBanner}>
           <Text style={styles.errorText}>
             {poisError
               ? "Couldn't load places — check your connection."
               : ratingsError
-              ? 'Ratings unavailable.'
-              : presenceError
-              ? 'Live updates unavailable — check your connection.'
-              : friendshipsError
-              ? 'Friend list unavailable — some presences may be hidden.'
-              : locationError
-              ? locationError
-              : 'Could not load join status — check your connection.'}
+                ? "Ratings unavailable."
+                : presenceError
+                  ? "Live updates unavailable — check your connection."
+                  : friendshipsError
+                    ? "Friend list unavailable — some presences may be hidden."
+                    : locationError
+                      ? locationError
+                      : "Could not load join status — check your connection."}
           </Text>
         </View>
       )}
@@ -253,58 +271,58 @@ export default function MapScreen() {
         onCancelJoin={cancel}
       />
     </View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
   map: { flex: 1 },
-  hidden: { display: 'none' },
+  hidden: { display: "none" },
   errorBanner: {
-    position: 'absolute',
+    position: "absolute",
     bottom: 90,
     left: 16,
     right: 16,
-    backgroundColor: 'rgba(180, 30, 30, 0.92)',
+    backgroundColor: "rgba(180, 30, 30, 0.92)",
     borderRadius: 12,
     paddingVertical: 10,
     paddingHorizontal: 14,
   },
   errorText: {
-    color: '#fff',
+    color: "#fff",
     fontSize: 13,
-    fontWeight: '600',
+    fontWeight: "600",
   },
   toggleButton: {
-    position: 'absolute',
+    position: "absolute",
     top: 56,
     right: 16,
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: '#131313',
-    alignItems: 'center',
-    justifyContent: 'center',
-    shadowColor: '#000',
+    backgroundColor: "#131313",
+    alignItems: "center",
+    justifyContent: "center",
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.15,
     shadowRadius: 4,
     elevation: 4,
   },
   locationButton: {
-    position: 'absolute',
+    position: "absolute",
     top: 104,
     right: 16,
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: '#131313',
-    alignItems: 'center',
-    justifyContent: 'center',
-    shadowColor: '#000',
+    backgroundColor: "#131313",
+    alignItems: "center",
+    justifyContent: "center",
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.15,
     shadowRadius: 4,
     elevation: 4,
   },
-})
+});

--- a/app/(app)/(tabs)/passport.tsx
+++ b/app/(app)/(tabs)/passport.tsx
@@ -1,23 +1,23 @@
-import { useLayoutEffect } from 'react'
-import { View, Text, Pressable, StyleSheet } from 'react-native'
-import { useRouter, useNavigation } from 'expo-router'
-import { Ionicons } from '@expo/vector-icons'
-import { useAuth } from '@/hooks/useAuth'
+import { useLayoutEffect } from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { useRouter, useNavigation } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import { useAuth } from "@/hooks/useAuth";
 
 export default function PassportScreen() {
-  const router = useRouter()
-  const navigation = useNavigation()
-  const { signOut } = useAuth()
+  const router = useRouter();
+  const navigation = useNavigation();
+  const { signOut } = useAuth();
 
   useLayoutEffect(() => {
     navigation.setOptions({
       headerRight: () => (
-        <Pressable onPress={() => router.push('/(app)/profile-modal')} style={styles.headerButton}>
+        <Pressable onPress={() => router.push("/(app)/profile-modal")} style={styles.headerButton}>
           <Ionicons name="settings-outline" size={22} color="#0066FF" />
         </Pressable>
       ),
-    })
-  }, [navigation])
+    });
+  }, [navigation]);
 
   return (
     <View style={styles.container}>
@@ -26,12 +26,12 @@ export default function PassportScreen() {
         <Text style={styles.signOut}>Sign out</Text>
       </Pressable>
     </View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#fff' },
-  text: { fontSize: 16, color: '#999', marginBottom: 24 },
+  container: { flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: "#fff" },
+  text: { fontSize: 16, color: "#999", marginBottom: 24 },
   headerButton: { marginRight: 16 },
-  signOut: { color: '#FF3B30', fontSize: 16 },
-})
+  signOut: { color: "#FF3B30", fontSize: 16 },
+});

--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -1,10 +1,10 @@
-import { Stack } from 'expo-router'
-import { BottomSheetModalProvider } from '@gorhom/bottom-sheet'
-import { useGeofenceNotifications } from '@/hooks/useGeofenceNotifications'
-import { CheckInToast } from '@/components/CheckInToast'
+import { Stack } from "expo-router";
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+import { useGeofenceNotifications } from "@/hooks/useGeofenceNotifications";
+import { CheckInToast } from "@/components/CheckInToast";
 
 export default function AppLayout() {
-  const { toast } = useGeofenceNotifications()
+  const { toast } = useGeofenceNotifications();
 
   return (
     <BottomSheetModalProvider>
@@ -12,10 +12,10 @@ export default function AppLayout() {
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen
           name="profile-modal"
-          options={{ presentation: 'modal', title: 'Edit Profile' }}
+          options={{ presentation: "modal", title: "Edit Profile" }}
         />
       </Stack>
       <CheckInToast visible={toast.visible} message={toast.message} />
     </BottomSheetModalProvider>
-  )
+  );
 }

--- a/app/(app)/profile-modal.tsx
+++ b/app/(app)/profile-modal.tsx
@@ -1,92 +1,123 @@
-import { useState, useEffect } from 'react'
-import { View, Text, TextInput, Pressable, StyleSheet, Image } from 'react-native'
-import * as ImagePicker from 'expo-image-picker'
-import { useRouter } from 'expo-router'
-import { supabase } from '@/lib/supabase'
+import { useState, useEffect } from "react";
+import { View, Text, TextInput, Pressable, StyleSheet, Image } from "react-native";
+import * as ImagePicker from "expo-image-picker";
+import { useRouter } from "expo-router";
+import { supabase } from "@/lib/supabase";
 
 export default function ProfileModal() {
-  const [displayName, setDisplayName] = useState('')
-  const [avatarUrl, setAvatarUrl] = useState<string | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const router = useRouter()
+  const [displayName, setDisplayName] = useState("");
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     async function loadProfile() {
-      const { data: { user }, error: authError } = await supabase.auth.getUser()
-      if (authError) { console.error('Failed to get user:', authError.message); return }
-      if (!user) return
+      const {
+        data: { user },
+        error: authError,
+      } = await supabase.auth.getUser();
+      if (authError) {
+        console.error("Failed to get user:", authError.message);
+        return;
+      }
+      if (!user) return;
       const { data, error: profileError } = await supabase
-        .from('profiles')
-        .select('display_name, avatar_url')
-        .eq('id', user.id)
-        .single()
-      if (profileError) { console.error('Failed to load profile:', profileError.message); return }
+        .from("profiles")
+        .select("display_name, avatar_url")
+        .eq("id", user.id)
+        .single();
+      if (profileError) {
+        console.error("Failed to load profile:", profileError.message);
+        return;
+      }
       if (data) {
-        setDisplayName(data.display_name)
-        setAvatarUrl(data.avatar_url)
+        setDisplayName(data.display_name);
+        setAvatarUrl(data.avatar_url);
       }
     }
-    loadProfile()
-  }, [])
+    loadProfile();
+  }, []);
 
   async function pickAvatar() {
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: 'images',
+      mediaTypes: "images",
       allowsEditing: true,
       aspect: [1, 1],
       quality: 0.8,
-    })
+    });
     if (!result.canceled) {
-      await uploadAvatar(result.assets[0].uri)
+      await uploadAvatar(result.assets[0].uri);
     }
   }
 
   async function uploadAvatar(uri: string) {
-    setLoading(true)
-    const { data: { user }, error: authError } = await supabase.auth.getUser()
-    if (authError) { console.error('Failed to get user:', authError.message); setLoading(false); return }
-    if (!user) { setLoading(false); return }
-
-    const ext = uri.split('.').pop() ?? 'jpg'
-    const path = `${user.id}/avatar.${ext}`
-
-    const formData = new FormData()
-    formData.append('file', { uri, name: `avatar.${ext}`, type: `image/${ext}` } as any)
-
-    const { error } = await supabase.storage.from('avatars').upload(path, formData, { upsert: true })
-    if (error) {
-      console.error('Failed to upload avatar:', error.message)
-      setError('Failed to upload avatar.')
-    } else {
-      const { data } = supabase.storage.from('avatars').getPublicUrl(path)
-      setAvatarUrl(data.publicUrl)
+    setLoading(true);
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError) {
+      console.error("Failed to get user:", authError.message);
+      setLoading(false);
+      return;
     }
-    setLoading(false)
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+
+    const ext = uri.split(".").pop() ?? "jpg";
+    const path = `${user.id}/avatar.${ext}`;
+
+    const formData = new FormData();
+    formData.append("file", { uri, name: `avatar.${ext}`, type: `image/${ext}` } as any);
+
+    const { error } = await supabase.storage
+      .from("avatars")
+      .upload(path, formData, { upsert: true });
+    if (error) {
+      console.error("Failed to upload avatar:", error.message);
+      setError("Failed to upload avatar.");
+    } else {
+      const { data } = supabase.storage.from("avatars").getPublicUrl(path);
+      setAvatarUrl(data.publicUrl);
+    }
+    setLoading(false);
   }
 
   async function saveProfile() {
-    setError(null)
+    setError(null);
     if (displayName.trim().length < 2) {
-      setError('Display name must be at least 2 characters.')
-      return
+      setError("Display name must be at least 2 characters.");
+      return;
     }
-    setLoading(true)
-    const { data: { user }, error: authError } = await supabase.auth.getUser()
-    if (authError) { console.error('Failed to get user:', authError.message); setLoading(false); return }
-    if (!user) { setLoading(false); return }
+    setLoading(true);
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError) {
+      console.error("Failed to get user:", authError.message);
+      setLoading(false);
+      return;
+    }
+    if (!user) {
+      setLoading(false);
+      return;
+    }
 
     const { error } = await supabase
-      .from('profiles')
+      .from("profiles")
       .update({ display_name: displayName.trim(), avatar_url: avatarUrl })
-      .eq('id', user.id)
+      .eq("id", user.id);
 
     if (error) {
-      setError(error.message)
+      setError(error.message);
     } else {
-      router.back()
+      router.back();
     }
-    setLoading(false)
+    setLoading(false);
   }
 
   return (
@@ -112,23 +143,35 @@ export default function ProfileModal() {
       {error && <Text style={styles.error}>{error}</Text>}
 
       <Pressable style={styles.button} onPress={saveProfile} disabled={loading}>
-        <Text style={styles.buttonText}>{loading ? 'Saving...' : 'Save'}</Text>
+        <Text style={styles.buttonText}>{loading ? "Saving..." : "Save"}</Text>
       </Pressable>
     </View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 24, backgroundColor: '#fff' },
-  avatarContainer: { alignSelf: 'center', marginBottom: 24, marginTop: 8 },
+  container: { flex: 1, padding: 24, backgroundColor: "#fff" },
+  avatarContainer: { alignSelf: "center", marginBottom: 24, marginTop: 8 },
   avatar: { width: 96, height: 96, borderRadius: 48 },
   avatarPlaceholder: {
-    width: 96, height: 96, borderRadius: 48,
-    backgroundColor: '#f0f0f0', justifyContent: 'center', alignItems: 'center',
+    width: 96,
+    height: 96,
+    borderRadius: 48,
+    backgroundColor: "#f0f0f0",
+    justifyContent: "center",
+    alignItems: "center",
   },
-  avatarPlaceholderText: { fontSize: 13, color: '#999' },
-  input: { borderWidth: 1, borderColor: '#ddd', borderRadius: 8, padding: 14, marginBottom: 16, fontSize: 16, color: '#000' },
-  button: { backgroundColor: '#0066FF', borderRadius: 8, padding: 16, alignItems: 'center' },
-  buttonText: { color: '#fff', fontWeight: '600', fontSize: 16 },
-  error: { color: '#CC0000', marginBottom: 12, fontSize: 14 },
-})
+  avatarPlaceholderText: { fontSize: 13, color: "#999" },
+  input: {
+    borderWidth: 1,
+    borderColor: "#ddd",
+    borderRadius: 8,
+    padding: 14,
+    marginBottom: 16,
+    fontSize: 16,
+    color: "#000",
+  },
+  button: { backgroundColor: "#0066FF", borderRadius: 8, padding: 16, alignItems: "center" },
+  buttonText: { color: "#fff", fontWeight: "600", fontSize: 16 },
+  error: { color: "#CC0000", marginBottom: 12, fontSize: 14 },
+});

--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,5 +1,5 @@
-import { Stack } from 'expo-router'
+import { Stack } from "expo-router";
 
 export default function AuthLayout() {
-  return <Stack screenOptions={{ headerShown: false }} />
+  return <Stack screenOptions={{ headerShown: false }} />;
 }

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,21 +1,21 @@
-import { useState } from 'react'
-import { View, Text, TextInput, Pressable, StyleSheet } from 'react-native'
-import { Link } from 'expo-router'
-import { supabase } from '@/lib/supabase'
-import { friendlyAuthError } from '@/lib/authErrors'
+import { useState } from "react";
+import { View, Text, TextInput, Pressable, StyleSheet } from "react-native";
+import { Link } from "expo-router";
+import { supabase } from "@/lib/supabase";
+import { friendlyAuthError } from "@/lib/authErrors";
 
 export default function LoginScreen() {
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   async function signIn() {
-    setError(null)
-    setLoading(true)
-    const { error } = await supabase.auth.signInWithPassword({ email, password })
-    if (error) setError(friendlyAuthError(error.message))
-    setLoading(false)
+    setError(null);
+    setLoading(true);
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) setError(friendlyAuthError(error.message));
+    setLoading(false);
   }
 
   return (
@@ -44,23 +44,37 @@ export default function LoginScreen() {
       {error && <Text style={styles.error}>{error}</Text>}
 
       <Pressable style={styles.button} onPress={signIn} disabled={loading}>
-        <Text style={styles.buttonText}>{loading ? 'Signing in...' : 'Sign in'}</Text>
+        <Text style={styles.buttonText}>{loading ? "Signing in..." : "Sign in"}</Text>
       </Pressable>
 
       <Link href="/(auth)/signup" style={styles.link}>
         Don't have an account? Sign up
       </Link>
     </View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 24, justifyContent: 'center', backgroundColor: '#fff' },
-  title: { fontSize: 32, fontWeight: '700', marginBottom: 4 },
-  subtitle: { fontSize: 16, color: '#666', marginBottom: 32 },
-  input: { borderWidth: 1, borderColor: '#ddd', borderRadius: 8, padding: 14, marginBottom: 12, fontSize: 16, color: '#000' },
-  button: { backgroundColor: '#0066FF', borderRadius: 8, padding: 16, alignItems: 'center', marginTop: 8 },
-  buttonText: { color: '#fff', fontWeight: '600', fontSize: 16 },
-  link: { marginTop: 16, textAlign: 'center', color: '#0066FF' },
-  error: { color: '#CC0000', marginBottom: 12, fontSize: 14 },
-})
+  container: { flex: 1, padding: 24, justifyContent: "center", backgroundColor: "#fff" },
+  title: { fontSize: 32, fontWeight: "700", marginBottom: 4 },
+  subtitle: { fontSize: 16, color: "#666", marginBottom: 32 },
+  input: {
+    borderWidth: 1,
+    borderColor: "#ddd",
+    borderRadius: 8,
+    padding: 14,
+    marginBottom: 12,
+    fontSize: 16,
+    color: "#000",
+  },
+  button: {
+    backgroundColor: "#0066FF",
+    borderRadius: 8,
+    padding: 16,
+    alignItems: "center",
+    marginTop: 8,
+  },
+  buttonText: { color: "#fff", fontWeight: "600", fontSize: 16 },
+  link: { marginTop: 16, textAlign: "center", color: "#0066FF" },
+  error: { color: "#CC0000", marginBottom: 12, fontSize: 14 },
+});

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -48,9 +48,7 @@ export default function SignupScreen() {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Join Dispatch</Text>
-      <Text style={styles.subtitle}>
-        Use your university .edu email to sign up.
-      </Text>
+      <Text style={styles.subtitle}>Use your university .edu email to sign up.</Text>
 
       <TextInput
         style={styles.input}
@@ -81,9 +79,7 @@ export default function SignupScreen() {
       {error && <Text style={styles.error}>{error}</Text>}
 
       <Pressable style={styles.button} onPress={signUp} disabled={loading}>
-        <Text style={styles.buttonText}>
-          {loading ? "Creating account..." : "Create account"}
-        </Text>
+        <Text style={styles.buttonText}>{loading ? "Creating account..." : "Create account"}</Text>
       </Pressable>
 
       <Link href="/(auth)/login" style={styles.link}>

--- a/app/(auth)/verify-email.tsx
+++ b/app/(auth)/verify-email.tsx
@@ -1,5 +1,5 @@
-import { View, Text, Pressable, StyleSheet } from 'react-native'
-import { supabase } from '@/lib/supabase'
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { supabase } from "@/lib/supabase";
 
 export default function VerifyEmailScreen() {
   return (
@@ -13,14 +13,20 @@ export default function VerifyEmailScreen() {
         <Text style={styles.linkText}>Use a different email</Text>
       </Pressable>
     </View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 24, justifyContent: 'center', alignItems: 'center', backgroundColor: '#fff' },
+  container: {
+    flex: 1,
+    padding: 24,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "#fff",
+  },
   emoji: { fontSize: 48, marginBottom: 16 },
-  title: { fontSize: 24, fontWeight: '700', marginBottom: 12 },
-  body: { fontSize: 16, color: '#666', textAlign: 'center', lineHeight: 24, marginBottom: 32 },
+  title: { fontSize: 24, fontWeight: "700", marginBottom: 12 },
+  body: { fontSize: 16, color: "#666", textAlign: "center", lineHeight: 24, marginBottom: 32 },
   link: { padding: 12 },
-  linkText: { color: '#0066FF', fontSize: 16 },
-})
+  linkText: { color: "#0066FF", fontSize: 16 },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,27 +1,31 @@
-import { useEffect } from 'react'
-import { Slot, useRouter, useSegments } from 'expo-router'
-import { GestureHandlerRootView } from 'react-native-gesture-handler'
-import Mapbox from '@rnmapbox/maps'
-import { useAuth } from '@/hooks/useAuth'
+import { useEffect } from "react";
+import { Slot, useRouter, useSegments } from "expo-router";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import Mapbox from "@rnmapbox/maps";
+import { useAuth } from "@/hooks/useAuth";
 
-const mapboxToken = process.env.EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN
-if (!mapboxToken) throw new Error('EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN is not set')
-Mapbox.setAccessToken(mapboxToken)
+const mapboxToken = process.env.EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN;
+if (!mapboxToken) throw new Error("EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN is not set");
+Mapbox.setAccessToken(mapboxToken);
 
 export default function RootLayout() {
-  const { session, loading } = useAuth()
-  const router = useRouter()
-  const segments = useSegments()
+  const { session, loading } = useAuth();
+  const router = useRouter();
+  const segments = useSegments();
 
   useEffect(() => {
-    if (loading) return
-    const inAuthGroup = segments[0] === '(auth)'
+    if (loading) return;
+    const inAuthGroup = segments[0] === "(auth)";
     if (!session && !inAuthGroup) {
-      router.replace('/(auth)/login')
+      router.replace("/(auth)/login");
     } else if (session && inAuthGroup) {
-      router.replace('/(app)/(tabs)')
+      router.replace("/(app)/(tabs)");
     }
-  }, [session, loading, segments])
+  }, [session, loading, segments]);
 
-  return <GestureHandlerRootView style={{ flex: 1 }}><Slot /></GestureHandlerRootView>
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <Slot />
+    </GestureHandlerRootView>
+  );
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,7 @@
 module.exports = function (api) {
-  api.cache(true)
+  api.cache(true);
   return {
-    presets: ['babel-preset-expo'],
-    plugins: ['react-native-reanimated/plugin'],
-  }
-}
+    presets: ["babel-preset-expo"],
+    plugins: ["react-native-reanimated/plugin"],
+  };
+};

--- a/components/BackgroundPermissionBanner.tsx
+++ b/components/BackgroundPermissionBanner.tsx
@@ -1,50 +1,46 @@
-import { useState } from 'react'
-import { Linking, Platform, Pressable, StyleSheet, Text, View } from 'react-native'
-import * as Location from 'expo-location'
+import { useState } from "react";
+import { Linking, Platform, Pressable, StyleSheet, Text, View } from "react-native";
+import * as Location from "expo-location";
 
 type Props = {
-  onGranted: () => void
-  onDismiss: () => void
-}
+  onGranted: () => void;
+  onDismiss: () => void;
+};
 
 export function BackgroundPermissionBanner({ onGranted, onDismiss }: Props) {
-  const [requesting, setRequesting] = useState(false)
-  const [denied, setDenied] = useState(false)
+  const [requesting, setRequesting] = useState(false);
+  const [denied, setDenied] = useState(false);
 
   const handlePress = async () => {
     if (denied) {
       // After denial, guide the user to the OS settings screen.
-      Linking.openSettings()
-      return
+      Linking.openSettings();
+      return;
     }
 
-    setRequesting(true)
+    setRequesting(true);
     try {
-      const { status } = await Location.requestBackgroundPermissionsAsync()
-      if (status === 'granted') {
-        onGranted()
+      const { status } = await Location.requestBackgroundPermissionsAsync();
+      if (status === "granted") {
+        onGranted();
       } else {
-        setDenied(true)
+        setDenied(true);
       }
     } catch (err) {
-      console.error('[BackgroundPermissionBanner] request failed:', err)
-      setDenied(true)
+      console.error("[BackgroundPermissionBanner] request failed:", err);
+      setDenied(true);
     } finally {
-      setRequesting(false)
+      setRequesting(false);
     }
-  }
+  };
 
   const message = denied
-    ? Platform.OS === 'ios'
-      ? 'Go to Settings \u2192 Location \u2192 Always to enable automatic check-ins.'
+    ? Platform.OS === "ios"
+      ? "Go to Settings \u2192 Location \u2192 Always to enable automatic check-ins."
       : 'Open Settings and allow location access "All the time" for automatic check-ins.'
-    : 'Allow background location to get automatic check-ins when you visit places.'
+    : "Allow background location to get automatic check-ins when you visit places.";
 
-  const buttonLabel = denied
-    ? 'Open Settings'
-    : requesting
-      ? 'Requesting...'
-      : 'Enable'
+  const buttonLabel = denied ? "Open Settings" : requesting ? "Requesting..." : "Enable";
 
   return (
     <View style={styles.banner}>
@@ -55,63 +51,63 @@ export function BackgroundPermissionBanner({ onGranted, onDismiss }: Props) {
             <Text style={styles.buttonText}>{buttonLabel}</Text>
           </Pressable>
           <Pressable onPress={onDismiss} style={styles.closeButton} hitSlop={8}>
-            <Text style={styles.closeText}>{'\u00D7'}</Text>
+            <Text style={styles.closeText}>{"\u00D7"}</Text>
           </Pressable>
         </View>
       </View>
     </View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
   banner: {
-    position: 'absolute',
+    position: "absolute",
     bottom: 90,
     left: 16,
     right: 16,
-    backgroundColor: 'rgba(19, 19, 19, 0.88)',
+    backgroundColor: "rgba(19, 19, 19, 0.88)",
     borderRadius: 14,
     paddingVertical: 14,
     paddingHorizontal: 16,
   },
   content: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     gap: 12,
   },
   text: {
     flex: 1,
-    color: '#fff',
+    color: "#fff",
     fontSize: 13,
-    fontWeight: '500',
+    fontWeight: "500",
     lineHeight: 18,
   },
   actions: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     gap: 8,
   },
   button: {
-    backgroundColor: '#fff',
+    backgroundColor: "#fff",
     borderRadius: 8,
     paddingVertical: 8,
     paddingHorizontal: 14,
   },
   buttonText: {
-    color: '#131313',
+    color: "#131313",
     fontSize: 13,
-    fontWeight: '700',
+    fontWeight: "700",
   },
   closeButton: {
     width: 28,
     height: 28,
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
   },
   closeText: {
-    color: 'rgba(255, 255, 255, 0.6)',
+    color: "rgba(255, 255, 255, 0.6)",
     fontSize: 20,
-    fontWeight: '600',
+    fontWeight: "600",
     lineHeight: 22,
   },
-})
+});

--- a/components/CheckInToast.tsx
+++ b/components/CheckInToast.tsx
@@ -1,44 +1,44 @@
-import { useEffect, useRef } from 'react'
-import { Animated, StyleSheet, Text } from 'react-native'
+import { useEffect, useRef } from "react";
+import { Animated, StyleSheet, Text } from "react-native";
 
 type Props = {
-  visible: boolean
-  message: string
-}
+  visible: boolean;
+  message: string;
+};
 
 export function CheckInToast({ visible, message }: Props) {
-  const opacity = useRef(new Animated.Value(0)).current
+  const opacity = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
     Animated.timing(opacity, {
       toValue: visible ? 1 : 0,
       duration: 250,
       useNativeDriver: true,
-    }).start()
-  }, [visible, opacity])
+    }).start();
+  }, [visible, opacity]);
 
   return (
     <Animated.View style={[styles.container, { opacity }]} pointerEvents="none">
       <Text style={styles.text}>{message}</Text>
     </Animated.View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
   container: {
-    position: 'absolute',
+    position: "absolute",
     bottom: 100,
     left: 24,
     right: 24,
-    backgroundColor: 'rgba(19, 19, 19, 0.92)',
+    backgroundColor: "rgba(19, 19, 19, 0.92)",
     borderRadius: 12,
     paddingVertical: 12,
     paddingHorizontal: 16,
-    alignItems: 'center',
+    alignItems: "center",
   },
   text: {
-    color: '#fff',
+    color: "#fff",
     fontSize: 14,
-    fontWeight: '600',
+    fontWeight: "600",
   },
-})
+});

--- a/components/UserAvatar.tsx
+++ b/components/UserAvatar.tsx
@@ -1,33 +1,39 @@
-import { useState } from 'react'
-import { Image, StyleSheet, Text, View } from 'react-native'
+import { useState } from "react";
+import { Image, StyleSheet, Text, View } from "react-native";
 
 interface UserAvatarProps {
-  displayName: string
-  avatarUrl: string | null
-  size?: number
-  borderWidth?: number
-  borderColor?: string
+  displayName: string;
+  avatarUrl: string | null;
+  size?: number;
+  borderWidth?: number;
+  borderColor?: string;
 }
 
 const BUBBLE_COLORS = [
-  '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4',
-  '#DDA0DD', '#98D8C8', '#F7DC6F', '#BB8FCE',
-]
+  "#FF6B6B",
+  "#4ECDC4",
+  "#45B7D1",
+  "#96CEB4",
+  "#DDA0DD",
+  "#98D8C8",
+  "#F7DC6F",
+  "#BB8FCE",
+];
 
 export function getInitials(displayName: string): string {
-  const parts = displayName.trim().split(/\s+/)
+  const parts = displayName.trim().split(/\s+/);
   return parts
     .slice(0, 2)
-    .map((p) => p[0]?.toUpperCase() ?? '')
-    .join('')
+    .map((p) => p[0]?.toUpperCase() ?? "")
+    .join("");
 }
 
 export function getBubbleColor(displayName: string): string {
-  let hash = 0
+  let hash = 0;
   for (let i = 0; i < displayName.length; i++) {
-    hash = (hash * 31 + displayName.charCodeAt(i)) & 0xffff
+    hash = (hash * 31 + displayName.charCodeAt(i)) & 0xffff;
   }
-  return BUBBLE_COLORS[hash % BUBBLE_COLORS.length]
+  return BUBBLE_COLORS[hash % BUBBLE_COLORS.length];
 }
 
 export function UserAvatar({
@@ -35,14 +41,14 @@ export function UserAvatar({
   avatarUrl,
   size = 32,
   borderWidth = 2,
-  borderColor = '#ffffff',
+  borderColor = "#ffffff",
 }: UserAvatarProps) {
-  const [imageError, setImageError] = useState(false)
+  const [imageError, setImageError] = useState(false);
   // Fall back to '?' placeholder if displayName is empty to avoid an invisible circle
-  const effectiveName = displayName.trim() || '?'
-  const initials = getInitials(effectiveName)
-  const bgColor = getBubbleColor(effectiveName)
-  const radius = size / 2
+  const effectiveName = displayName.trim() || "?";
+  const initials = getInitials(effectiveName);
+  const bgColor = getBubbleColor(effectiveName);
+  const radius = size / 2;
 
   const containerStyle = {
     width: size,
@@ -50,8 +56,8 @@ export function UserAvatar({
     borderRadius: radius,
     borderWidth,
     borderColor,
-    overflow: 'hidden' as const,
-  }
+    overflow: "hidden" as const,
+  };
 
   if (avatarUrl && !imageError) {
     return (
@@ -60,24 +66,29 @@ export function UserAvatar({
           source={{ uri: avatarUrl }}
           style={{ width: size, height: size }}
           onError={() => {
-            console.warn('UserAvatar: failed to load avatar image', avatarUrl)
-            setImageError(true)
+            console.warn("UserAvatar: failed to load avatar image", avatarUrl);
+            setImageError(true);
           }}
         />
       </View>
-    )
+    );
   }
 
   return (
-    <View style={[containerStyle, { backgroundColor: bgColor, alignItems: 'center', justifyContent: 'center' }]}>
+    <View
+      style={[
+        containerStyle,
+        { backgroundColor: bgColor, alignItems: "center", justifyContent: "center" },
+      ]}
+    >
       <Text style={[styles.initials, { fontSize: size * 0.38 }]}>{initials}</Text>
     </View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
   initials: {
-    color: '#ffffff',
-    fontWeight: '700',
+    color: "#ffffff",
+    fontWeight: "700",
   },
-})
+});

--- a/components/friends/FriendRequestRow.tsx
+++ b/components/friends/FriendRequestRow.tsx
@@ -1,92 +1,92 @@
-import { useState } from 'react'
-import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
-import { UserAvatar } from '@/components/UserAvatar'
-import { IncomingRequestEntry } from '@/hooks/useFriendships'
+import { useState } from "react";
+import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { UserAvatar } from "@/components/UserAvatar";
+import { IncomingRequestEntry } from "@/hooks/useFriendships";
 
 interface Props {
-  entry: IncomingRequestEntry
-  onAccept: () => Promise<void>
-  onDecline: () => Promise<void>
+  entry: IncomingRequestEntry;
+  onAccept: () => Promise<void>;
+  onDecline: () => Promise<void>;
 }
 
 export function FriendRequestRow({ entry, onAccept, onDecline }: Props) {
-  const [busy, setBusy] = useState<'accept' | 'decline' | null>(null)
-  const [errorText, setErrorText] = useState<string | null>(null)
+  const [busy, setBusy] = useState<"accept" | "decline" | null>(null);
+  const [errorText, setErrorText] = useState<string | null>(null);
 
   const handleAccept = async () => {
-    if (busy) return
-    setBusy('accept')
-    setErrorText(null)
+    if (busy) return;
+    setBusy("accept");
+    setErrorText(null);
     try {
-      await onAccept()
+      await onAccept();
     } catch (err) {
-      console.error('FriendRequestRow accept:', err)
-      setErrorText('Could not accept request. Try again.')
+      console.error("FriendRequestRow accept:", err);
+      setErrorText("Could not accept request. Try again.");
     } finally {
-      setBusy(null)
+      setBusy(null);
     }
-  }
+  };
 
   const handleDecline = async () => {
-    if (busy) return
-    setBusy('decline')
-    setErrorText(null)
+    if (busy) return;
+    setBusy("decline");
+    setErrorText(null);
     try {
-      await onDecline()
+      await onDecline();
     } catch (err) {
-      console.error('FriendRequestRow decline:', err)
-      setErrorText('Could not decline request. Try again.')
+      console.error("FriendRequestRow decline:", err);
+      setErrorText("Could not decline request. Try again.");
     } finally {
-      setBusy(null)
+      setBusy(null);
     }
-  }
+  };
 
   return (
     <View>
-    <View style={styles.row}>
-      <UserAvatar
-        displayName={entry.displayName}
-        avatarUrl={entry.avatarUrl}
-        size={40}
-        borderWidth={0}
-      />
-      <View style={styles.info}>
-        <Text style={styles.name}>{entry.displayName}</Text>
+      <View style={styles.row}>
+        <UserAvatar
+          displayName={entry.displayName}
+          avatarUrl={entry.avatarUrl}
+          size={40}
+          borderWidth={0}
+        />
+        <View style={styles.info}>
+          <Text style={styles.name}>{entry.displayName}</Text>
+        </View>
+        <TouchableOpacity
+          style={styles.declineButton}
+          onPress={handleDecline}
+          disabled={busy !== null}
+          activeOpacity={0.8}
+        >
+          {busy === "decline" ? (
+            <ActivityIndicator size="small" color="#666" />
+          ) : (
+            <Text style={styles.declineText}>Decline</Text>
+          )}
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.acceptButton}
+          onPress={handleAccept}
+          disabled={busy !== null}
+          activeOpacity={0.8}
+        >
+          {busy === "accept" ? (
+            <ActivityIndicator size="small" color="#fff" />
+          ) : (
+            <Text style={styles.acceptText}>Accept</Text>
+          )}
+        </TouchableOpacity>
       </View>
-      <TouchableOpacity
-        style={styles.declineButton}
-        onPress={handleDecline}
-        disabled={busy !== null}
-        activeOpacity={0.8}
-      >
-        {busy === 'decline' ? (
-          <ActivityIndicator size="small" color="#666" />
-        ) : (
-          <Text style={styles.declineText}>Decline</Text>
-        )}
-      </TouchableOpacity>
-      <TouchableOpacity
-        style={styles.acceptButton}
-        onPress={handleAccept}
-        disabled={busy !== null}
-        activeOpacity={0.8}
-      >
-        {busy === 'accept' ? (
-          <ActivityIndicator size="small" color="#fff" />
-        ) : (
-          <Text style={styles.acceptText}>Accept</Text>
-        )}
-      </TouchableOpacity>
+      {errorText ? <Text style={styles.errorText}>{errorText}</Text> : null}
     </View>
-    {errorText ? <Text style={styles.errorText}>{errorText}</Text> : null}
-    </View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
   row: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     gap: 8,
     paddingVertical: 10,
     paddingHorizontal: 16,
@@ -96,41 +96,41 @@ const styles = StyleSheet.create({
   },
   name: {
     fontSize: 15,
-    fontWeight: '600',
-    color: '#131313',
+    fontWeight: "600",
+    color: "#131313",
   },
   declineButton: {
     borderWidth: 1,
-    borderColor: '#d1d1d1',
+    borderColor: "#d1d1d1",
     paddingHorizontal: 12,
     paddingVertical: 7,
     borderRadius: 10,
     minWidth: 68,
-    alignItems: 'center',
+    alignItems: "center",
   },
   declineText: {
     fontSize: 13,
-    fontWeight: '600',
-    color: '#666',
+    fontWeight: "600",
+    color: "#666",
   },
   acceptButton: {
-    backgroundColor: '#131313',
+    backgroundColor: "#131313",
     paddingHorizontal: 12,
     paddingVertical: 7,
     borderRadius: 10,
     minWidth: 68,
-    alignItems: 'center',
+    alignItems: "center",
   },
   acceptText: {
     fontSize: 13,
-    fontWeight: '600',
-    color: '#fff',
+    fontWeight: "600",
+    color: "#fff",
   },
   errorText: {
     fontSize: 12,
-    color: '#E51E1E',
-    fontWeight: '500',
+    color: "#E51E1E",
+    fontWeight: "500",
     paddingHorizontal: 16,
     paddingBottom: 6,
   },
-})
+});

--- a/components/friends/FriendRow.tsx
+++ b/components/friends/FriendRow.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState } from "react";
 import {
   ActivityIndicator,
   Modal,
@@ -7,33 +7,33 @@ import {
   Text,
   TouchableOpacity,
   View,
-} from 'react-native'
-import { UserAvatar } from '@/components/UserAvatar'
-import { FriendEntry } from '@/hooks/useFriendships'
+} from "react-native";
+import { UserAvatar } from "@/components/UserAvatar";
+import { FriendEntry } from "@/hooks/useFriendships";
 
 interface Props {
-  entry: FriendEntry
-  onUnfriend: () => Promise<void>
+  entry: FriendEntry;
+  onUnfriend: () => Promise<void>;
 }
 
 export function FriendRow({ entry, onUnfriend }: Props) {
-  const [modalVisible, setModalVisible] = useState(false)
-  const [busy, setBusy] = useState(false)
-  const [errorText, setErrorText] = useState<string | null>(null)
+  const [modalVisible, setModalVisible] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [errorText, setErrorText] = useState<string | null>(null);
 
   const handleConfirmUnfriend = async () => {
-    setBusy(true)
-    setErrorText(null)
+    setBusy(true);
+    setErrorText(null);
     try {
-      await onUnfriend()
-      setModalVisible(false)
+      await onUnfriend();
+      setModalVisible(false);
     } catch (err) {
-      console.error('FriendRow unfriend:', err)
-      setErrorText('Could not unfriend. Try again.')
+      console.error("FriendRow unfriend:", err);
+      setErrorText("Could not unfriend. Try again.");
     } finally {
-      setBusy(false)
+      setBusy(false);
     }
-  }
+  };
 
   return (
     <>
@@ -60,9 +60,16 @@ export function FriendRow({ entry, onUnfriend }: Props) {
         visible={modalVisible}
         transparent
         animationType="fade"
-        onRequestClose={() => { if (!busy) setModalVisible(false) }}
+        onRequestClose={() => {
+          if (!busy) setModalVisible(false);
+        }}
       >
-        <Pressable style={styles.backdrop} onPress={() => { if (!busy) setModalVisible(false) }} />
+        <Pressable
+          style={styles.backdrop}
+          onPress={() => {
+            if (!busy) setModalVisible(false);
+          }}
+        />
         <View style={styles.overlay}>
           <View style={styles.card}>
             <Text style={styles.title}>Unfriend {entry.displayName}?</Text>
@@ -95,13 +102,13 @@ export function FriendRow({ entry, onUnfriend }: Props) {
         </View>
       </Modal>
     </>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
   row: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     gap: 12,
     paddingVertical: 10,
     paddingHorizontal: 16,
@@ -111,30 +118,30 @@ const styles = StyleSheet.create({
   },
   name: {
     fontSize: 15,
-    fontWeight: '600',
-    color: '#131313',
+    fontWeight: "600",
+    color: "#131313",
   },
   menu: {
     fontSize: 16,
-    color: '#666',
+    color: "#666",
     letterSpacing: 1,
   },
   overlay: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
   },
   backdrop: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.45)',
+    backgroundColor: "rgba(0,0,0,0.45)",
   },
   card: {
-    width: '80%',
-    backgroundColor: '#FAFAF8',
+    width: "80%",
+    backgroundColor: "#FAFAF8",
     borderRadius: 24,
     padding: 24,
     gap: 12,
-    shadowColor: '#000',
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 8 },
     shadowOpacity: 0.15,
     shadowRadius: 24,
@@ -142,42 +149,42 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 20,
-    fontWeight: '800',
-    color: '#131313',
+    fontWeight: "800",
+    color: "#131313",
     letterSpacing: -0.3,
   },
   subtitle: {
     fontSize: 14,
-    color: '#AAAAAA',
-    fontWeight: '400',
+    color: "#AAAAAA",
+    fontWeight: "400",
     marginBottom: 4,
   },
   button: {
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
     borderRadius: 14,
     paddingVertical: 14,
   },
   destructiveButton: {
-    backgroundColor: '#E51E1E',
+    backgroundColor: "#E51E1E",
   },
   destructiveText: {
     fontSize: 15,
-    fontWeight: '700',
-    color: '#fff',
+    fontWeight: "700",
+    color: "#fff",
   },
   cancelButton: {
-    backgroundColor: '#F2F2F2',
+    backgroundColor: "#F2F2F2",
   },
   cancelText: {
     fontSize: 15,
-    fontWeight: '600',
-    color: '#131313',
+    fontWeight: "600",
+    color: "#131313",
   },
   errorText: {
     fontSize: 13,
-    color: '#E51E1E',
-    fontWeight: '500',
-    textAlign: 'center',
+    color: "#E51E1E",
+    fontWeight: "500",
+    textAlign: "center",
   },
-})
+});

--- a/components/friends/IncomingRequestsSection.tsx
+++ b/components/friends/IncomingRequestsSection.tsx
@@ -1,23 +1,23 @@
-import { useState } from 'react'
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
-import { FriendRequestRow } from '@/components/friends/FriendRequestRow'
-import { IncomingRequestEntry } from '@/hooks/useFriendships'
+import { useState } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { FriendRequestRow } from "@/components/friends/FriendRequestRow";
+import { IncomingRequestEntry } from "@/hooks/useFriendships";
 
-const INITIAL_VISIBLE = 3
+const INITIAL_VISIBLE = 3;
 
 interface Props {
-  requests: IncomingRequestEntry[]
-  onAccept: (friendshipId: string) => Promise<void>
-  onDecline: (friendshipId: string) => Promise<void>
+  requests: IncomingRequestEntry[];
+  onAccept: (friendshipId: string) => Promise<void>;
+  onDecline: (friendshipId: string) => Promise<void>;
 }
 
 export function IncomingRequestsSection({ requests, onAccept, onDecline }: Props) {
-  const [expanded, setExpanded] = useState(false)
+  const [expanded, setExpanded] = useState(false);
 
-  if (requests.length === 0) return null
+  if (requests.length === 0) return null;
 
-  const visible = expanded ? requests : requests.slice(0, INITIAL_VISIBLE)
-  const hiddenCount = requests.length - INITIAL_VISIBLE
+  const visible = expanded ? requests : requests.slice(0, INITIAL_VISIBLE);
+  const hiddenCount = requests.length - INITIAL_VISIBLE;
 
   return (
     <View style={styles.section}>
@@ -39,7 +39,7 @@ export function IncomingRequestsSection({ requests, onAccept, onDecline }: Props
         </TouchableOpacity>
       )}
     </View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
   },
   showMoreText: {
     fontSize: 14,
-    color: '#0066FF',
-    fontWeight: '600',
+    color: "#0066FF",
+    fontWeight: "600",
   },
-})
+});

--- a/components/friends/UserSearchResult.tsx
+++ b/components/friends/UserSearchResult.tsx
@@ -1,111 +1,132 @@
-import { useState } from 'react'
-import { ActivityIndicator, Modal, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
-import { UserAvatar } from '@/components/UserAvatar'
-import { SearchUser } from '@/lib/friends'
-import { FriendshipStatus } from '@/lib/friendships'
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { UserAvatar } from "@/components/UserAvatar";
+import { SearchUser } from "@/lib/friends";
+import { FriendshipStatus } from "@/lib/friendships";
 
 interface Props {
-  user: SearchUser
-  status: FriendshipStatus
-  onSendRequest: () => Promise<void>
-  onCancelRequest: () => Promise<void>
-  onAcceptRequest: () => Promise<void>
+  user: SearchUser;
+  status: FriendshipStatus;
+  onSendRequest: () => Promise<void>;
+  onCancelRequest: () => Promise<void>;
+  onAcceptRequest: () => Promise<void>;
 }
 
-export function UserSearchResult({ user, status, onSendRequest, onCancelRequest, onAcceptRequest }: Props) {
-  const [busy, setBusy] = useState(false)
-  const [cancelModalVisible, setCancelModalVisible] = useState(false)
-  const [rowError, setRowError] = useState<string | null>(null)
-  const [modalError, setModalError] = useState<string | null>(null)
+export function UserSearchResult({
+  user,
+  status,
+  onSendRequest,
+  onCancelRequest,
+  onAcceptRequest,
+}: Props) {
+  const [busy, setBusy] = useState(false);
+  const [cancelModalVisible, setCancelModalVisible] = useState(false);
+  const [rowError, setRowError] = useState<string | null>(null);
+  const [modalError, setModalError] = useState<string | null>(null);
 
   const handlePress = async () => {
-    if (busy) return
+    if (busy) return;
 
-    if (status === 'none') {
-      setBusy(true)
-      setRowError(null)
+    if (status === "none") {
+      setBusy(true);
+      setRowError(null);
       try {
-        await onSendRequest()
+        await onSendRequest();
       } catch (err) {
-        console.error('UserSearchResult sendRequest:', err)
-        setRowError('Could not send friend request. Try again.')
+        console.error("UserSearchResult sendRequest:", err);
+        setRowError("Could not send friend request. Try again.");
       } finally {
-        setBusy(false)
+        setBusy(false);
       }
-      return
+      return;
     }
 
-    if (status === 'pending_sent') {
-      setCancelModalVisible(true)
-      return
+    if (status === "pending_sent") {
+      setCancelModalVisible(true);
+      return;
     }
 
-    if (status === 'pending_received') {
-      setBusy(true)
-      setRowError(null)
+    if (status === "pending_received") {
+      setBusy(true);
+      setRowError(null);
       try {
-        await onAcceptRequest()
+        await onAcceptRequest();
       } catch (err) {
-        console.error('UserSearchResult acceptRequest:', err)
-        setRowError('Could not accept request. Try again.')
+        console.error("UserSearchResult acceptRequest:", err);
+        setRowError("Could not accept request. Try again.");
       } finally {
-        setBusy(false)
+        setBusy(false);
       }
     }
-  }
+  };
 
   const handleConfirmCancel = async () => {
-    setBusy(true)
-    setModalError(null)
+    setBusy(true);
+    setModalError(null);
     try {
-      await onCancelRequest()
-      setCancelModalVisible(false)
+      await onCancelRequest();
+      setCancelModalVisible(false);
     } catch (err) {
-      console.error('UserSearchResult cancelRequest:', err)
-      setModalError('Could not cancel request. Try again.')
+      console.error("UserSearchResult cancelRequest:", err);
+      setModalError("Could not cancel request. Try again.");
     } finally {
-      setBusy(false)
+      setBusy(false);
     }
-  }
+  };
 
-  const buttonConfig = getButtonConfig(status)
+  const buttonConfig = getButtonConfig(status);
 
   return (
     <>
       <View>
-      <View style={styles.row}>
-        <UserAvatar
-          displayName={user.display_name}
-          avatarUrl={user.avatar_url}
-          size={40}
-          borderWidth={0}
-        />
-        <View style={styles.info}>
-          <Text style={styles.name}>{user.display_name}</Text>
+        <View style={styles.row}>
+          <UserAvatar
+            displayName={user.display_name}
+            avatarUrl={user.avatar_url}
+            size={40}
+            borderWidth={0}
+          />
+          <View style={styles.info}>
+            <Text style={styles.name}>{user.display_name}</Text>
+          </View>
+          <TouchableOpacity
+            style={[styles.button, buttonConfig.buttonStyle]}
+            onPress={handlePress}
+            disabled={busy || status === "accepted"}
+            activeOpacity={0.8}
+          >
+            {busy ? (
+              <ActivityIndicator size="small" color={buttonConfig.spinnerColor} />
+            ) : (
+              <Text style={[styles.buttonText, buttonConfig.textStyle]}>{buttonConfig.label}</Text>
+            )}
+          </TouchableOpacity>
         </View>
-        <TouchableOpacity
-          style={[styles.button, buttonConfig.buttonStyle]}
-          onPress={handlePress}
-          disabled={busy || status === 'accepted'}
-          activeOpacity={0.8}
-        >
-          {busy ? (
-            <ActivityIndicator size="small" color={buttonConfig.spinnerColor} />
-          ) : (
-            <Text style={[styles.buttonText, buttonConfig.textStyle]}>{buttonConfig.label}</Text>
-          )}
-        </TouchableOpacity>
-      </View>
-      {rowError ? <Text style={styles.rowErrorText}>{rowError}</Text> : null}
+        {rowError ? <Text style={styles.rowErrorText}>{rowError}</Text> : null}
       </View>
 
       <Modal
         visible={cancelModalVisible}
         transparent
         animationType="fade"
-        onRequestClose={() => { if (!busy) setCancelModalVisible(false) }}
+        onRequestClose={() => {
+          if (!busy) setCancelModalVisible(false);
+        }}
       >
-        <Pressable style={styles.backdrop} onPress={() => { if (!busy) setCancelModalVisible(false) }} />
+        <Pressable
+          style={styles.backdrop}
+          onPress={() => {
+            if (!busy) setCancelModalVisible(false);
+          }}
+        />
         <View style={styles.overlay}>
           <View style={styles.card}>
             <Text style={styles.title}>Cancel request?</Text>
@@ -138,66 +159,66 @@ export function UserSearchResult({ user, status, onSendRequest, onCancelRequest,
         </View>
       </Modal>
     </>
-  )
+  );
 }
 
 type ButtonConfig = {
-  label: string
-  buttonStyle: object
-  textStyle: object
-  spinnerColor: string
-}
+  label: string;
+  buttonStyle: object;
+  textStyle: object;
+  spinnerColor: string;
+};
 
 function getButtonConfig(status: FriendshipStatus): ButtonConfig {
   switch (status) {
-    case 'none':
+    case "none":
       return {
-        label: 'Add Friend',
+        label: "Add Friend",
         buttonStyle: styles.buttonDark,
         textStyle: styles.textLight,
-        spinnerColor: '#fff',
-      }
-    case 'pending_sent':
+        spinnerColor: "#fff",
+      };
+    case "pending_sent":
       return {
-        label: 'Pending',
+        label: "Pending",
         buttonStyle: styles.buttonGrey,
         textStyle: styles.textDark,
-        spinnerColor: '#131313',
-      }
-    case 'pending_received':
+        spinnerColor: "#131313",
+      };
+    case "pending_received":
       return {
-        label: 'Accept',
+        label: "Accept",
         buttonStyle: styles.buttonBlue,
         textStyle: styles.textLight,
-        spinnerColor: '#fff',
-      }
-    case 'accepted':
+        spinnerColor: "#fff",
+      };
+    case "accepted":
       return {
-        label: 'Friends',
+        label: "Friends",
         buttonStyle: styles.buttonOutline,
         textStyle: styles.textMuted,
-        spinnerColor: '#999',
-      }
+        spinnerColor: "#999",
+      };
   }
 }
 
 const styles = StyleSheet.create({
   overlay: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
   },
   backdrop: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.45)',
+    backgroundColor: "rgba(0,0,0,0.45)",
   },
   card: {
-    width: '80%',
-    backgroundColor: '#FAFAF8',
+    width: "80%",
+    backgroundColor: "#FAFAF8",
     borderRadius: 24,
     padding: 24,
     gap: 12,
-    shadowColor: '#000',
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 8 },
     shadowOpacity: 0.15,
     shadowRadius: 24,
@@ -205,41 +226,41 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 20,
-    fontWeight: '800',
-    color: '#131313',
+    fontWeight: "800",
+    color: "#131313",
     letterSpacing: -0.3,
   },
   subtitle: {
     fontSize: 14,
-    color: '#AAAAAA',
-    fontWeight: '400',
+    color: "#AAAAAA",
+    fontWeight: "400",
     marginBottom: 4,
   },
   modalButton: {
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
     borderRadius: 14,
     paddingVertical: 14,
   },
   destructiveButton: {
-    backgroundColor: '#E51E1E',
+    backgroundColor: "#E51E1E",
   },
   destructiveText: {
     fontSize: 15,
-    fontWeight: '700',
-    color: '#fff',
+    fontWeight: "700",
+    color: "#fff",
   },
   cancelButton: {
-    backgroundColor: '#F2F2F2',
+    backgroundColor: "#F2F2F2",
   },
   cancelText: {
     fontSize: 15,
-    fontWeight: '600',
-    color: '#131313',
+    fontWeight: "600",
+    color: "#131313",
   },
   row: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     gap: 12,
     paddingVertical: 10,
     paddingHorizontal: 16,
@@ -249,53 +270,53 @@ const styles = StyleSheet.create({
   },
   name: {
     fontSize: 15,
-    fontWeight: '600',
-    color: '#131313',
+    fontWeight: "600",
+    color: "#131313",
   },
   button: {
     paddingHorizontal: 14,
     paddingVertical: 7,
     borderRadius: 10,
     minWidth: 90,
-    alignItems: 'center',
+    alignItems: "center",
   },
   buttonText: {
     fontSize: 13,
-    fontWeight: '600',
+    fontWeight: "600",
   },
   buttonDark: {
-    backgroundColor: '#131313',
+    backgroundColor: "#131313",
   },
   buttonGrey: {
-    backgroundColor: '#e5e5e5',
+    backgroundColor: "#e5e5e5",
   },
   buttonBlue: {
-    backgroundColor: '#0066FF',
+    backgroundColor: "#0066FF",
   },
   buttonOutline: {
     borderWidth: 1,
-    borderColor: '#d1d1d1',
+    borderColor: "#d1d1d1",
   },
   textLight: {
-    color: '#fff',
+    color: "#fff",
   },
   textDark: {
-    color: '#131313',
+    color: "#131313",
   },
   textMuted: {
-    color: '#999',
+    color: "#999",
   },
   rowErrorText: {
     fontSize: 12,
-    color: '#E51E1E',
-    fontWeight: '500',
+    color: "#E51E1E",
+    fontWeight: "500",
     paddingHorizontal: 16,
     paddingBottom: 6,
   },
   modalErrorText: {
     fontSize: 13,
-    color: '#E51E1E',
-    fontWeight: '500',
-    textAlign: 'center',
+    color: "#E51E1E",
+    fontWeight: "500",
+    textAlign: "center",
   },
-})
+});

--- a/components/friends/__tests__/FriendRequestRow.test.tsx
+++ b/components/friends/__tests__/FriendRequestRow.test.tsx
@@ -1,119 +1,171 @@
-import React from 'react'
-import { TouchableOpacity } from 'react-native'
-import { act, create, ReactTestInstance } from 'react-test-renderer'
-import { FriendRequestRow } from '../FriendRequestRow'
+import React from "react";
+import { TouchableOpacity } from "react-native";
+import { act, create, ReactTestInstance } from "react-test-renderer";
+import { FriendRequestRow } from "../FriendRequestRow";
 
 const MOCK_ENTRY = {
-  friendshipId: 'fs-req-1',
-  requesterId: 'user-requester',
-  displayName: 'Sam Lee',
+  friendshipId: "fs-req-1",
+  requesterId: "user-requester",
+  displayName: "Sam Lee",
   avatarUrl: null,
-}
+};
 
 function findButtonWithLabel(root: ReturnType<typeof create>, label: string) {
-  const touchables = root.root.findAllByType(TouchableOpacity)
+  const touchables = root.root.findAllByType(TouchableOpacity);
   return touchables.find((n) => {
-    const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
-    return texts.some((t) => String(t.props.children) === label)
-  })
+    const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === "Text");
+    return texts.some((t) => String(t.props.children) === label);
+  });
 }
 
-describe('FriendRequestRow', () => {
-  it('renders the display name', () => {
-    const onAccept = jest.fn().mockResolvedValue(undefined)
-    const onDecline = jest.fn().mockResolvedValue(undefined)
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />) })
+describe("FriendRequestRow", () => {
+  it("renders the display name", () => {
+    const onAccept = jest.fn().mockResolvedValue(undefined);
+    const onDecline = jest.fn().mockResolvedValue(undefined);
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(
+        <FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />,
+      );
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'Sam Lee')).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(texts.some((n) => String(n.props.children) === "Sam Lee")).toBe(true);
+  });
 
-  it('calls onAccept when Accept is pressed', async () => {
-    const onAccept = jest.fn().mockResolvedValue(undefined)
-    const onDecline = jest.fn().mockResolvedValue(undefined)
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />) })
-
-    await act(async () => {
-      findButtonWithLabel(root!, 'Accept')!.props.onPress()
-    })
-
-    expect(onAccept).toHaveBeenCalled()
-    expect(onDecline).not.toHaveBeenCalled()
-  })
-
-  it('calls onDecline when Decline is pressed', async () => {
-    const onAccept = jest.fn().mockResolvedValue(undefined)
-    const onDecline = jest.fn().mockResolvedValue(undefined)
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />) })
+  it("calls onAccept when Accept is pressed", async () => {
+    const onAccept = jest.fn().mockResolvedValue(undefined);
+    const onDecline = jest.fn().mockResolvedValue(undefined);
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(
+        <FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />,
+      );
+    });
 
     await act(async () => {
-      findButtonWithLabel(root!, 'Decline')!.props.onPress()
-    })
+      findButtonWithLabel(root!, "Accept")!.props.onPress();
+    });
 
-    expect(onDecline).toHaveBeenCalled()
-    expect(onAccept).not.toHaveBeenCalled()
-  })
+    expect(onAccept).toHaveBeenCalled();
+    expect(onDecline).not.toHaveBeenCalled();
+  });
 
-  it('shows ActivityIndicator while accept is in progress', async () => {
-    let resolveAccept!: () => void
-    const onAccept = jest.fn().mockReturnValue(new Promise<void>((r) => { resolveAccept = r }))
-    const onDecline = jest.fn().mockResolvedValue(undefined)
+  it("calls onDecline when Decline is pressed", async () => {
+    const onAccept = jest.fn().mockResolvedValue(undefined);
+    const onDecline = jest.fn().mockResolvedValue(undefined);
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(
+        <FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />,
+      );
+    });
 
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />) })
+    await act(async () => {
+      findButtonWithLabel(root!, "Decline")!.props.onPress();
+    });
 
-    act(() => { findButtonWithLabel(root!, 'Accept')!.props.onPress() })
+    expect(onDecline).toHaveBeenCalled();
+    expect(onAccept).not.toHaveBeenCalled();
+  });
 
-    const spinners = root!.root.findAll(
-      (n: ReactTestInstance) => (n.type as string) === 'ActivityIndicator'
-    )
-    expect(spinners.length).toBeGreaterThan(0)
+  it("shows ActivityIndicator while accept is in progress", async () => {
+    let resolveAccept!: () => void;
+    const onAccept = jest.fn().mockReturnValue(
+      new Promise<void>((r) => {
+        resolveAccept = r;
+      }),
+    );
+    const onDecline = jest.fn().mockResolvedValue(undefined);
 
-    await act(async () => { resolveAccept() })
-  })
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(
+        <FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />,
+      );
+    });
 
-  it('shows inline error when onAccept rejects', async () => {
-    const onAccept = jest.fn().mockRejectedValue(new Error('network'))
-    const onDecline = jest.fn().mockResolvedValue(undefined)
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />) })
-
-    await act(async () => { findButtonWithLabel(root!, 'Accept')!.props.onPress() })
-
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'Could not accept request. Try again.')).toBe(true)
-  })
-
-  it('shows inline error when onDecline rejects', async () => {
-    const onAccept = jest.fn().mockResolvedValue(undefined)
-    const onDecline = jest.fn().mockRejectedValue(new Error('network'))
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />) })
-
-    await act(async () => { findButtonWithLabel(root!, 'Decline')!.props.onPress() })
-
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'Could not decline request. Try again.')).toBe(true)
-  })
-
-  it('shows ActivityIndicator while decline is in progress', async () => {
-    let resolveDecline!: () => void
-    const onAccept = jest.fn().mockResolvedValue(undefined)
-    const onDecline = jest.fn().mockReturnValue(new Promise<void>((r) => { resolveDecline = r }))
-
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />) })
-
-    act(() => { findButtonWithLabel(root!, 'Decline')!.props.onPress() })
+    act(() => {
+      findButtonWithLabel(root!, "Accept")!.props.onPress();
+    });
 
     const spinners = root!.root.findAll(
-      (n: ReactTestInstance) => (n.type as string) === 'ActivityIndicator'
-    )
-    expect(spinners.length).toBeGreaterThan(0)
+      (n: ReactTestInstance) => (n.type as string) === "ActivityIndicator",
+    );
+    expect(spinners.length).toBeGreaterThan(0);
 
-    await act(async () => { resolveDecline() })
-  })
-})
+    await act(async () => {
+      resolveAccept();
+    });
+  });
+
+  it("shows inline error when onAccept rejects", async () => {
+    const onAccept = jest.fn().mockRejectedValue(new Error("network"));
+    const onDecline = jest.fn().mockResolvedValue(undefined);
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(
+        <FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />,
+      );
+    });
+
+    await act(async () => {
+      findButtonWithLabel(root!, "Accept")!.props.onPress();
+    });
+
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(
+      texts.some((n) => String(n.props.children) === "Could not accept request. Try again."),
+    ).toBe(true);
+  });
+
+  it("shows inline error when onDecline rejects", async () => {
+    const onAccept = jest.fn().mockResolvedValue(undefined);
+    const onDecline = jest.fn().mockRejectedValue(new Error("network"));
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(
+        <FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />,
+      );
+    });
+
+    await act(async () => {
+      findButtonWithLabel(root!, "Decline")!.props.onPress();
+    });
+
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(
+      texts.some((n) => String(n.props.children) === "Could not decline request. Try again."),
+    ).toBe(true);
+  });
+
+  it("shows ActivityIndicator while decline is in progress", async () => {
+    let resolveDecline!: () => void;
+    const onAccept = jest.fn().mockResolvedValue(undefined);
+    const onDecline = jest.fn().mockReturnValue(
+      new Promise<void>((r) => {
+        resolveDecline = r;
+      }),
+    );
+
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(
+        <FriendRequestRow entry={MOCK_ENTRY} onAccept={onAccept} onDecline={onDecline} />,
+      );
+    });
+
+    act(() => {
+      findButtonWithLabel(root!, "Decline")!.props.onPress();
+    });
+
+    const spinners = root!.root.findAll(
+      (n: ReactTestInstance) => (n.type as string) === "ActivityIndicator",
+    );
+    expect(spinners.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      resolveDecline();
+    });
+  });
+});

--- a/components/friends/__tests__/FriendRow.test.tsx
+++ b/components/friends/__tests__/FriendRow.test.tsx
@@ -1,110 +1,138 @@
-import React from 'react'
-import { TouchableOpacity } from 'react-native'
-import { act, create, ReactTestInstance } from 'react-test-renderer'
-import { FriendRow } from '../FriendRow'
+import React from "react";
+import { TouchableOpacity } from "react-native";
+import { act, create, ReactTestInstance } from "react-test-renderer";
+import { FriendRow } from "../FriendRow";
 
 const MOCK_ENTRY = {
-  friendshipId: 'fs-1',
-  userId: 'user-abc',
-  displayName: 'Alex Kim',
+  friendshipId: "fs-1",
+  userId: "user-abc",
+  displayName: "Alex Kim",
   avatarUrl: null,
-}
+};
 
-describe('FriendRow', () => {
-  it('renders the display name', () => {
-    const onUnfriend = jest.fn().mockResolvedValue(undefined)
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
+describe("FriendRow", () => {
+  it("renders the display name", () => {
+    const onUnfriend = jest.fn().mockResolvedValue(undefined);
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />);
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'Alex Kim')).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(texts.some((n) => String(n.props.children) === "Alex Kim")).toBe(true);
+  });
 
-  it('renders initials avatar fallback', () => {
-    const onUnfriend = jest.fn().mockResolvedValue(undefined)
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
+  it("renders initials avatar fallback", () => {
+    const onUnfriend = jest.fn().mockResolvedValue(undefined);
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />);
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    const initialsNode = texts.find((n) => String(n.props.children) === 'AK')
-    expect(initialsNode).toBeDefined()
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    const initialsNode = texts.find((n) => String(n.props.children) === "AK");
+    expect(initialsNode).toBeDefined();
+  });
 
   it('pressing "..." opens the in-app confirmation modal', () => {
-    const onUnfriend = jest.fn().mockResolvedValue(undefined)
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
+    const onUnfriend = jest.fn().mockResolvedValue(undefined);
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />);
+    });
 
-    const touchables = root!.root.findAllByType(TouchableOpacity)
-    const menuBtn = touchables.find((n) => n.props.accessibilityLabel === 'Friend options')
-    act(() => { menuBtn!.props.onPress() })
+    const touchables = root!.root.findAllByType(TouchableOpacity);
+    const menuBtn = touchables.find((n) => n.props.accessibilityLabel === "Friend options");
+    act(() => {
+      menuBtn!.props.onPress();
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children).startsWith('Unfriend'))).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(texts.some((n) => String(n.props.children).startsWith("Unfriend"))).toBe(true);
+  });
 
-  it('calls onUnfriend when Unfriend button in modal is pressed', async () => {
-    const onUnfriend = jest.fn().mockResolvedValue(undefined)
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
+  it("calls onUnfriend when Unfriend button in modal is pressed", async () => {
+    const onUnfriend = jest.fn().mockResolvedValue(undefined);
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />);
+    });
 
     // Open modal
-    const touchables = root!.root.findAllByType(TouchableOpacity)
-    const menuBtn = touchables.find((n) => n.props.accessibilityLabel === 'Friend options')
-    act(() => { menuBtn!.props.onPress() })
+    const touchables = root!.root.findAllByType(TouchableOpacity);
+    const menuBtn = touchables.find((n) => n.props.accessibilityLabel === "Friend options");
+    act(() => {
+      menuBtn!.props.onPress();
+    });
 
     // Press Unfriend button
-    const allTouchables = root!.root.findAllByType(TouchableOpacity)
+    const allTouchables = root!.root.findAllByType(TouchableOpacity);
     const unfriendBtn = allTouchables.find((n) => {
-      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
-      return texts.some((t) => String(t.props.children) === 'Unfriend')
-    })
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === "Text");
+      return texts.some((t) => String(t.props.children) === "Unfriend");
+    });
 
-    await act(async () => { unfriendBtn!.props.onPress() })
+    await act(async () => {
+      unfriendBtn!.props.onPress();
+    });
 
-    expect(onUnfriend).toHaveBeenCalled()
-  })
+    expect(onUnfriend).toHaveBeenCalled();
+  });
 
-  it('shows inline error inside modal when onUnfriend rejects', async () => {
-    const onUnfriend = jest.fn().mockRejectedValue(new Error('Network error'))
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
+  it("shows inline error inside modal when onUnfriend rejects", async () => {
+    const onUnfriend = jest.fn().mockRejectedValue(new Error("Network error"));
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />);
+    });
 
     // Open modal
-    const menuBtn = root!.root.findAllByType(TouchableOpacity).find(
-      (n) => n.props.accessibilityLabel === 'Friend options'
-    )
-    act(() => { menuBtn!.props.onPress() })
+    const menuBtn = root!.root
+      .findAllByType(TouchableOpacity)
+      .find((n) => n.props.accessibilityLabel === "Friend options");
+    act(() => {
+      menuBtn!.props.onPress();
+    });
 
     // Press Unfriend — should reject
     const unfriendBtn = root!.root.findAllByType(TouchableOpacity).find((n) => {
-      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
-      return texts.some((t) => String(t.props.children) === 'Unfriend')
-    })
-    await act(async () => { unfriendBtn!.props.onPress() })
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === "Text");
+      return texts.some((t) => String(t.props.children) === "Unfriend");
+    });
+    await act(async () => {
+      unfriendBtn!.props.onPress();
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'Could not unfriend. Try again.')).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(texts.some((n) => String(n.props.children) === "Could not unfriend. Try again.")).toBe(
+      true,
+    );
+  });
 
-  it('Cancel button closes the modal without calling onUnfriend', () => {
-    const onUnfriend = jest.fn().mockResolvedValue(undefined)
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />) })
+  it("Cancel button closes the modal without calling onUnfriend", () => {
+    const onUnfriend = jest.fn().mockResolvedValue(undefined);
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<FriendRow entry={MOCK_ENTRY} onUnfriend={onUnfriend} />);
+    });
 
     // Open modal
-    const touchables = root!.root.findAllByType(TouchableOpacity)
-    const menuBtn = touchables.find((n) => n.props.accessibilityLabel === 'Friend options')
-    act(() => { menuBtn!.props.onPress() })
+    const touchables = root!.root.findAllByType(TouchableOpacity);
+    const menuBtn = touchables.find((n) => n.props.accessibilityLabel === "Friend options");
+    act(() => {
+      menuBtn!.props.onPress();
+    });
 
     // Press Cancel
-    const allTouchables = root!.root.findAllByType(TouchableOpacity)
+    const allTouchables = root!.root.findAllByType(TouchableOpacity);
     const cancelBtn = allTouchables.find((n) => {
-      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
-      return texts.some((t) => String(t.props.children) === 'Cancel')
-    })
-    act(() => { cancelBtn!.props.onPress() })
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === "Text");
+      return texts.some((t) => String(t.props.children) === "Cancel");
+    });
+    act(() => {
+      cancelBtn!.props.onPress();
+    });
 
-    expect(onUnfriend).not.toHaveBeenCalled()
-  })
-})
+    expect(onUnfriend).not.toHaveBeenCalled();
+  });
+});

--- a/components/friends/__tests__/IncomingRequestsSection.test.tsx
+++ b/components/friends/__tests__/IncomingRequestsSection.test.tsx
@@ -1,18 +1,20 @@
-import React from 'react'
-import { TouchableOpacity, View } from 'react-native'
-import { act, create, ReactTestInstance } from 'react-test-renderer'
-import { IncomingRequestsSection } from '../IncomingRequestsSection'
+import React from "react";
+import { TouchableOpacity, View } from "react-native";
+import { act, create, ReactTestInstance } from "react-test-renderer";
+import { IncomingRequestsSection } from "../IncomingRequestsSection";
 
-jest.mock('../FriendRequestRow', () => {
-  const React = require('react')
-  const { View, Text } = require('react-native')
+jest.mock("../FriendRequestRow", () => {
+  const React = require("react");
+  const { View, Text } = require("react-native");
   return {
     FriendRequestRow: ({ entry }: { entry: { displayName: string } }) =>
-      React.createElement(View, { testID: 'request-row' },
-        React.createElement(Text, null, entry.displayName)
+      React.createElement(
+        View,
+        { testID: "request-row" },
+        React.createElement(Text, null, entry.displayName),
       ),
-  }
-})
+  };
+});
 
 function makeRequests(count: number) {
   return Array.from({ length: count }, (_, i) => ({
@@ -20,105 +22,107 @@ function makeRequests(count: number) {
     requesterId: `user-${i}`,
     displayName: `User ${i}`,
     avatarUrl: null,
-  }))
+  }));
 }
 
-const onAccept = jest.fn().mockResolvedValue(undefined)
-const onDecline = jest.fn().mockResolvedValue(undefined)
+const onAccept = jest.fn().mockResolvedValue(undefined);
+const onDecline = jest.fn().mockResolvedValue(undefined);
 
 beforeEach(() => {
-  jest.clearAllMocks()
-})
+  jest.clearAllMocks();
+});
 
 function countRows(root: ReturnType<typeof create>) {
   // Only count View-type nodes with testID to avoid deep duplicates
   return root.root.findAll(
-    (n: ReactTestInstance) => n.type === View && n.props.testID === 'request-row'
-  ).length
+    (n: ReactTestInstance) => n.type === View && n.props.testID === "request-row",
+  ).length;
 }
 
 function getTextContent(root: ReturnType<typeof create>): string[] {
   return root.root
-    .findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
+    .findAll((n: ReactTestInstance) => (n.type as string) === "Text")
     .map((n) => {
-      const c = n.props.children
-      return Array.isArray(c) ? c.join('') : String(c)
-    })
+      const c = n.props.children;
+      return Array.isArray(c) ? c.join("") : String(c);
+    });
 }
 
-describe('IncomingRequestsSection', () => {
-  it('returns null when requests is empty', () => {
-    let root: ReturnType<typeof create>
+describe("IncomingRequestsSection", () => {
+  it("returns null when requests is empty", () => {
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
-        <IncomingRequestsSection requests={[]} onAccept={onAccept} onDecline={onDecline} />
-      )
-    })
-    expect(root!.toJSON()).toBeNull()
-  })
+        <IncomingRequestsSection requests={[]} onAccept={onAccept} onDecline={onDecline} />,
+      );
+    });
+    expect(root!.toJSON()).toBeNull();
+  });
 
-  it('renders all entries when there are 3 or fewer requests', () => {
-    const requests = makeRequests(3)
-    let root: ReturnType<typeof create>
+  it("renders all entries when there are 3 or fewer requests", () => {
+    const requests = makeRequests(3);
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
-        <IncomingRequestsSection requests={requests} onAccept={onAccept} onDecline={onDecline} />
-      )
-    })
+        <IncomingRequestsSection requests={requests} onAccept={onAccept} onDecline={onDecline} />,
+      );
+    });
 
-    expect(countRows(root!)).toBe(3)
+    expect(countRows(root!)).toBe(3);
 
     // No "View more" button
-    const touchables = root!.root.findAllByType(TouchableOpacity)
-    expect(touchables).toHaveLength(0)
-  })
+    const touchables = root!.root.findAllByType(TouchableOpacity);
+    expect(touchables).toHaveLength(0);
+  });
 
-  it('shows only first 3 entries when there are more than 3', () => {
-    const requests = makeRequests(5)
-    let root: ReturnType<typeof create>
+  it("shows only first 3 entries when there are more than 3", () => {
+    const requests = makeRequests(5);
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
-        <IncomingRequestsSection requests={requests} onAccept={onAccept} onDecline={onDecline} />
-      )
-    })
+        <IncomingRequestsSection requests={requests} onAccept={onAccept} onDecline={onDecline} />,
+      );
+    });
 
-    expect(countRows(root!)).toBe(3)
-  })
+    expect(countRows(root!)).toBe(3);
+  });
 
   it('shows "View N more" button with correct count', () => {
-    const requests = makeRequests(6)
-    let root: ReturnType<typeof create>
+    const requests = makeRequests(6);
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
-        <IncomingRequestsSection requests={requests} onAccept={onAccept} onDecline={onDecline} />
-      )
-    })
+        <IncomingRequestsSection requests={requests} onAccept={onAccept} onDecline={onDecline} />,
+      );
+    });
 
-    const texts = getTextContent(root!)
-    expect(texts.some((t) => t === 'View 3 more')).toBe(true)
-  })
+    const texts = getTextContent(root!);
+    expect(texts.some((t) => t === "View 3 more")).toBe(true);
+  });
 
   it('pressing "View N more" shows all entries', () => {
-    const requests = makeRequests(5)
-    let root: ReturnType<typeof create>
+    const requests = makeRequests(5);
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
-        <IncomingRequestsSection requests={requests} onAccept={onAccept} onDecline={onDecline} />
-      )
-    })
+        <IncomingRequestsSection requests={requests} onAccept={onAccept} onDecline={onDecline} />,
+      );
+    });
 
     // Initially 3 visible
-    expect(countRows(root!)).toBe(3)
+    expect(countRows(root!)).toBe(3);
 
     // Press "View more"
-    const touchable = root!.root.findAllByType(TouchableOpacity)[0]
-    act(() => { touchable.props.onPress() })
+    const touchable = root!.root.findAllByType(TouchableOpacity)[0];
+    act(() => {
+      touchable.props.onPress();
+    });
 
     // Now all 5 visible
-    expect(countRows(root!)).toBe(5)
+    expect(countRows(root!)).toBe(5);
 
     // "View more" button is gone
-    const touchables = root!.root.findAllByType(TouchableOpacity)
-    expect(touchables).toHaveLength(0)
-  })
-})
+    const touchables = root!.root.findAllByType(TouchableOpacity);
+    expect(touchables).toHaveLength(0);
+  });
+});

--- a/components/friends/__tests__/UserSearchResult.test.tsx
+++ b/components/friends/__tests__/UserSearchResult.test.tsx
@@ -1,173 +1,225 @@
-import React from 'react'
-import { TouchableOpacity } from 'react-native'
-import { act, create, ReactTestInstance } from 'react-test-renderer'
-import { UserSearchResult } from '../UserSearchResult'
+import React from "react";
+import { TouchableOpacity } from "react-native";
+import { act, create, ReactTestInstance } from "react-test-renderer";
+import { UserSearchResult } from "../UserSearchResult";
 
-const MOCK_USER = { id: 'user-123', display_name: 'Jane Doe', avatar_url: null }
+const MOCK_USER = { id: "user-123", display_name: "Jane Doe", avatar_url: null };
 
-const noop = () => Promise.resolve()
+const noop = () => Promise.resolve();
 
-function makeProps(status: 'none' | 'pending_sent' | 'pending_received' | 'accepted') {
+function makeProps(status: "none" | "pending_sent" | "pending_received" | "accepted") {
   return {
     user: MOCK_USER,
     status,
     onSendRequest: jest.fn().mockResolvedValue(undefined),
     onCancelRequest: jest.fn().mockResolvedValue(undefined),
     onAcceptRequest: jest.fn().mockResolvedValue(undefined),
-  }
+  };
 }
 
 function findButtonWithLabel(root: ReturnType<typeof create>, label: string) {
-  const touchables = root.root.findAllByType(TouchableOpacity)
+  const touchables = root.root.findAllByType(TouchableOpacity);
   return touchables.find((n) => {
-    const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
-    return texts.some((t) => String(t.props.children) === label)
-  })
+    const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === "Text");
+    return texts.some((t) => String(t.props.children) === label);
+  });
 }
 
-describe('UserSearchResult', () => {
-  it('renders the display name', () => {
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult {...makeProps('none')} />) })
+describe("UserSearchResult", () => {
+  it("renders the display name", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<UserSearchResult {...makeProps("none")} />);
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'Jane Doe')).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(texts.some((n) => String(n.props.children) === "Jane Doe")).toBe(true);
+  });
 
   it('shows "Add Friend" button when status is none', () => {
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult {...makeProps('none')} />) })
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<UserSearchResult {...makeProps("none")} />);
+    });
 
-    expect(findButtonWithLabel(root!, 'Add Friend')).toBeDefined()
-  })
+    expect(findButtonWithLabel(root!, "Add Friend")).toBeDefined();
+  });
 
-  it('calls onSendRequest when Add Friend is pressed', async () => {
-    const props = makeProps('none')
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult {...props} />) })
+  it("calls onSendRequest when Add Friend is pressed", async () => {
+    const props = makeProps("none");
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<UserSearchResult {...props} />);
+    });
 
     await act(async () => {
-      findButtonWithLabel(root!, 'Add Friend')!.props.onPress()
-    })
+      findButtonWithLabel(root!, "Add Friend")!.props.onPress();
+    });
 
-    expect(props.onSendRequest).toHaveBeenCalled()
-  })
+    expect(props.onSendRequest).toHaveBeenCalled();
+  });
 
   it('shows "Pending" button when status is pending_sent', () => {
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult {...makeProps('pending_sent')} />) })
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<UserSearchResult {...makeProps("pending_sent")} />);
+    });
 
-    expect(findButtonWithLabel(root!, 'Pending')).toBeDefined()
-  })
+    expect(findButtonWithLabel(root!, "Pending")).toBeDefined();
+  });
 
   it('pressing "Pending" opens the in-app cancel confirmation modal', () => {
-    const props = makeProps('pending_sent')
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult {...props} />) })
+    const props = makeProps("pending_sent");
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<UserSearchResult {...props} />);
+    });
 
-    act(() => { findButtonWithLabel(root!, 'Pending')!.props.onPress() })
+    act(() => {
+      findButtonWithLabel(root!, "Pending")!.props.onPress();
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'Cancel request?')).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(texts.some((n) => String(n.props.children) === "Cancel request?")).toBe(true);
+  });
 
   it('calls onCancelRequest when "Cancel request" button in modal is pressed', async () => {
-    const props = makeProps('pending_sent')
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult {...props} />) })
+    const props = makeProps("pending_sent");
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<UserSearchResult {...props} />);
+    });
 
-    act(() => { findButtonWithLabel(root!, 'Pending')!.props.onPress() })
-
-    await act(async () => { findButtonWithLabel(root!, 'Cancel request')!.props.onPress() })
-
-    expect(props.onCancelRequest).toHaveBeenCalled()
-  })
-
-  it('"Keep" button closes the modal without calling onCancelRequest', () => {
-    const props = makeProps('pending_sent')
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult {...props} />) })
-
-    act(() => { findButtonWithLabel(root!, 'Pending')!.props.onPress() })
-    act(() => { findButtonWithLabel(root!, 'Keep')!.props.onPress() })
-
-    expect(props.onCancelRequest).not.toHaveBeenCalled()
-  })
-
-  it('shows "Accept" button when status is pending_received', () => {
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult {...makeProps('pending_received')} />) })
-
-    expect(findButtonWithLabel(root!, 'Accept')).toBeDefined()
-  })
-
-  it('calls onAcceptRequest when Accept is pressed', async () => {
-    const props = makeProps('pending_received')
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult {...props} />) })
+    act(() => {
+      findButtonWithLabel(root!, "Pending")!.props.onPress();
+    });
 
     await act(async () => {
-      findButtonWithLabel(root!, 'Accept')!.props.onPress()
-    })
+      findButtonWithLabel(root!, "Cancel request")!.props.onPress();
+    });
 
-    expect(props.onAcceptRequest).toHaveBeenCalled()
-  })
+    expect(props.onCancelRequest).toHaveBeenCalled();
+  });
+
+  it('"Keep" button closes the modal without calling onCancelRequest', () => {
+    const props = makeProps("pending_sent");
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<UserSearchResult {...props} />);
+    });
+
+    act(() => {
+      findButtonWithLabel(root!, "Pending")!.props.onPress();
+    });
+    act(() => {
+      findButtonWithLabel(root!, "Keep")!.props.onPress();
+    });
+
+    expect(props.onCancelRequest).not.toHaveBeenCalled();
+  });
+
+  it('shows "Accept" button when status is pending_received', () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<UserSearchResult {...makeProps("pending_received")} />);
+    });
+
+    expect(findButtonWithLabel(root!, "Accept")).toBeDefined();
+  });
+
+  it("calls onAcceptRequest when Accept is pressed", async () => {
+    const props = makeProps("pending_received");
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<UserSearchResult {...props} />);
+    });
+
+    await act(async () => {
+      findButtonWithLabel(root!, "Accept")!.props.onPress();
+    });
+
+    expect(props.onAcceptRequest).toHaveBeenCalled();
+  });
 
   it('shows "Friends" label when status is accepted and button is disabled', () => {
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult {...makeProps('accepted')} />) })
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<UserSearchResult {...makeProps("accepted")} />);
+    });
 
-    const btn = findButtonWithLabel(root!, 'Friends')
-    expect(btn).toBeDefined()
-    expect(btn!.props.disabled).toBe(true)
-  })
+    const btn = findButtonWithLabel(root!, "Friends");
+    expect(btn).toBeDefined();
+    expect(btn!.props.disabled).toBe(true);
+  });
 
-  it('shows rowError below the row when onSendRequest rejects', async () => {
-    const props = makeProps('none')
-    props.onSendRequest.mockRejectedValue(new Error('network'))
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult {...props} />) })
+  it("shows rowError below the row when onSendRequest rejects", async () => {
+    const props = makeProps("none");
+    props.onSendRequest.mockRejectedValue(new Error("network"));
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<UserSearchResult {...props} />);
+    });
 
-    await act(async () => { findButtonWithLabel(root!, 'Add Friend')!.props.onPress() })
+    await act(async () => {
+      findButtonWithLabel(root!, "Add Friend")!.props.onPress();
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'Could not send friend request. Try again.')).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(
+      texts.some((n) => String(n.props.children) === "Could not send friend request. Try again."),
+    ).toBe(true);
+  });
 
-  it('shows rowError below the row when onAcceptRequest rejects', async () => {
-    const props = makeProps('pending_received')
-    props.onAcceptRequest.mockRejectedValue(new Error('network'))
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult {...props} />) })
+  it("shows rowError below the row when onAcceptRequest rejects", async () => {
+    const props = makeProps("pending_received");
+    props.onAcceptRequest.mockRejectedValue(new Error("network"));
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<UserSearchResult {...props} />);
+    });
 
-    await act(async () => { findButtonWithLabel(root!, 'Accept')!.props.onPress() })
+    await act(async () => {
+      findButtonWithLabel(root!, "Accept")!.props.onPress();
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'Could not accept request. Try again.')).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(
+      texts.some((n) => String(n.props.children) === "Could not accept request. Try again."),
+    ).toBe(true);
+  });
 
-  it('shows modalError inside cancel modal when onCancelRequest rejects', async () => {
-    const props = makeProps('pending_sent')
-    props.onCancelRequest.mockRejectedValue(new Error('network'))
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult {...props} />) })
+  it("shows modalError inside cancel modal when onCancelRequest rejects", async () => {
+    const props = makeProps("pending_sent");
+    props.onCancelRequest.mockRejectedValue(new Error("network"));
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<UserSearchResult {...props} />);
+    });
 
     // Open cancel modal
-    act(() => { findButtonWithLabel(root!, 'Pending')!.props.onPress() })
+    act(() => {
+      findButtonWithLabel(root!, "Pending")!.props.onPress();
+    });
 
     // Press cancel — should reject
-    await act(async () => { findButtonWithLabel(root!, 'Cancel request')!.props.onPress() })
+    await act(async () => {
+      findButtonWithLabel(root!, "Cancel request")!.props.onPress();
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'Could not cancel request. Try again.')).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(
+      texts.some((n) => String(n.props.children) === "Could not cancel request. Try again."),
+    ).toBe(true);
+  });
 
-  it('renders initials fallback when avatarUrl is null', () => {
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<UserSearchResult {...makeProps('none')} />) })
+  it("renders initials fallback when avatarUrl is null", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<UserSearchResult {...makeProps("none")} />);
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    const initialsNode = texts.find((n) => String(n.props.children).match(/^[A-Z]{1,2}$/))
-    expect(initialsNode?.props.children).toBe('JD')
-  })
-})
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    const initialsNode = texts.find((n) => String(n.props.children).match(/^[A-Z]{1,2}$/));
+    expect(initialsNode?.props.children).toBe("JD");
+  });
+});

--- a/components/map/BroadcastModal.tsx
+++ b/components/map/BroadcastModal.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useState } from 'react'
+import { forwardRef, useImperativeHandle, useState } from "react";
 import {
   View,
   Text,
@@ -10,66 +10,77 @@ import {
   KeyboardAvoidingView,
   Platform,
   Pressable,
-} from 'react-native'
-import { supabase } from '@/lib/supabase'
-import { broadcastPresence, ActivePresence, VisibilityType } from '@/lib/presence'
+} from "react-native";
+import { supabase } from "@/lib/supabase";
+import { broadcastPresence, ActivePresence, VisibilityType } from "@/lib/presence";
 
 export type BroadcastModalHandle = {
-  present: () => void
-  dismiss: () => void
-}
+  present: () => void;
+  dismiss: () => void;
+};
 
 type Props = {
-  poiId: string
-  onSubmitted: (presence: ActivePresence) => void
-}
+  poiId: string;
+  onSubmitted: (presence: ActivePresence) => void;
+};
 
 export const BroadcastModal = forwardRef<BroadcastModalHandle, Props>(function BroadcastModal(
   { poiId, onSubmitted },
-  ref
+  ref,
 ) {
-  const [visible, setVisible] = useState(false)
-  const [message, setMessage] = useState('')
-  const [visibleTo, setVisibleTo] = useState<VisibilityType>('friends')
-  const [submitting, setSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [visible, setVisible] = useState(false);
+  const [message, setMessage] = useState("");
+  const [visibleTo, setVisibleTo] = useState<VisibilityType>("friends");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useImperativeHandle(ref, () => ({
     present: () => {
-      setMessage('')
-      setVisibleTo('friends')
-      setError(null)
-      setVisible(true)
+      setMessage("");
+      setVisibleTo("friends");
+      setError(null);
+      setVisible(true);
     },
     dismiss: () => setVisible(false),
-  }))
+  }));
 
   const handleSubmit = async () => {
-    setSubmitting(true)
-    setError(null)
+    setSubmitting(true);
+    setError(null);
     try {
-      const presence = await broadcastPresence(supabase, { poiId, message, visibleTo })
-      onSubmitted(presence)
-      setVisible(false)
+      const presence = await broadcastPresence(supabase, {
+        poiId,
+        message,
+        visibleTo,
+      });
+      onSubmitted(presence);
+      setVisible(false);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Something went wrong')
+      setError(e instanceof Error ? e.message : "Something went wrong");
     } finally {
-      setSubmitting(false)
+      setSubmitting(false);
     }
-  }
+  };
 
   return (
     <Modal
       visible={visible}
       transparent
       animationType="fade"
-      onRequestClose={() => { if (!submitting) setVisible(false) }}
+      onRequestClose={() => {
+        if (!submitting) setVisible(false);
+      }}
     >
       <KeyboardAvoidingView
         style={styles.overlay}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
       >
-        <Pressable style={styles.backdrop} onPress={() => { if (!submitting) setVisible(false) }} />
+        <Pressable
+          style={styles.backdrop}
+          onPress={() => {
+            if (!submitting) setVisible(false);
+          }}
+        />
 
         <View style={styles.card}>
           {/* Header */}
@@ -95,20 +106,24 @@ export const BroadcastModal = forwardRef<BroadcastModalHandle, Props>(function B
           {/* Visibility toggle */}
           <View style={styles.segmentedControl}>
             <TouchableOpacity
-              style={[styles.segment, visibleTo === 'friends' && styles.segmentActive]}
-              onPress={() => setVisibleTo('friends')}
+              style={[styles.segment, visibleTo === "friends" && styles.segmentActive]}
+              onPress={() => setVisibleTo("friends")}
               activeOpacity={0.85}
             >
-              <Text style={[styles.segmentText, visibleTo === 'friends' && styles.segmentTextActive]}>
+              <Text
+                style={[styles.segmentText, visibleTo === "friends" && styles.segmentTextActive]}
+              >
                 Friends
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
-              style={[styles.segment, visibleTo === 'community' && styles.segmentActive]}
-              onPress={() => setVisibleTo('community')}
+              style={[styles.segment, visibleTo === "community" && styles.segmentActive]}
+              onPress={() => setVisibleTo("community")}
               activeOpacity={0.85}
             >
-              <Text style={[styles.segmentText, visibleTo === 'community' && styles.segmentTextActive]}>
+              <Text
+                style={[styles.segmentText, visibleTo === "community" && styles.segmentTextActive]}
+              >
                 Community
               </Text>
             </TouchableOpacity>
@@ -138,26 +153,26 @@ export const BroadcastModal = forwardRef<BroadcastModalHandle, Props>(function B
         </View>
       </KeyboardAvoidingView>
     </Modal>
-  )
-})
+  );
+});
 
 const styles = StyleSheet.create({
   overlay: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
   },
   backdrop: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.45)',
+    backgroundColor: "rgba(0,0,0,0.45)",
   },
   card: {
-    width: '88%',
-    backgroundColor: '#FAFAF8',
+    width: "88%",
+    backgroundColor: "#FAFAF8",
     borderRadius: 24,
     padding: 24,
     gap: 18,
-    shadowColor: '#000',
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 8 },
     shadowOpacity: 0.15,
     shadowRadius: 24,
@@ -168,102 +183,102 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 24,
-    fontWeight: '800',
-    color: '#131313',
+    fontWeight: "800",
+    color: "#131313",
     letterSpacing: -0.5,
   },
   subtitle: {
     fontSize: 14,
-    color: '#AAAAAA',
-    fontWeight: '400',
+    color: "#AAAAAA",
+    fontWeight: "400",
   },
   inputWrapper: {
-    position: 'relative',
+    position: "relative",
   },
   input: {
     borderWidth: 1.5,
-    borderColor: '#EDECEA',
+    borderColor: "#EDECEA",
     borderRadius: 14,
     paddingHorizontal: 14,
     paddingTop: 13,
     paddingBottom: 32,
     fontSize: 15,
-    color: '#131313',
+    color: "#131313",
     minHeight: 90,
-    textAlignVertical: 'top',
-    backgroundColor: '#fff',
+    textAlignVertical: "top",
+    backgroundColor: "#fff",
     lineHeight: 22,
   },
   charCount: {
-    position: 'absolute',
+    position: "absolute",
     bottom: 10,
     right: 14,
     fontSize: 11,
-    color: '#CCCCCC',
-    fontWeight: '500',
+    color: "#CCCCCC",
+    fontWeight: "500",
   },
   segmentedControl: {
-    flexDirection: 'row',
+    flexDirection: "row",
     borderRadius: 12,
     borderWidth: 1.5,
-    borderColor: '#EDECEA',
-    overflow: 'hidden',
+    borderColor: "#EDECEA",
+    overflow: "hidden",
   },
   segment: {
     flex: 1,
     paddingVertical: 11,
-    alignItems: 'center',
-    backgroundColor: '#fff',
+    alignItems: "center",
+    backgroundColor: "#fff",
   },
   segmentActive: {
-    backgroundColor: '#131313',
+    backgroundColor: "#131313",
   },
   segmentText: {
     fontSize: 14,
-    fontWeight: '700',
-    color: '#131313',
+    fontWeight: "700",
+    color: "#131313",
     letterSpacing: 0.1,
   },
   segmentTextActive: {
-    color: '#fff',
+    color: "#fff",
   },
   errorRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     gap: 6,
-    backgroundColor: '#FFF1F1',
+    backgroundColor: "#FFF1F1",
     borderRadius: 10,
     paddingHorizontal: 12,
     paddingVertical: 9,
   },
   errorIcon: {
     fontSize: 13,
-    color: '#E51E1E',
+    color: "#E51E1E",
   },
   error: {
-    color: '#E51E1E',
+    color: "#E51E1E",
     fontSize: 13,
-    fontWeight: '500',
+    fontWeight: "500",
     flex: 1,
   },
   submitButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
     borderRadius: 14,
     paddingVertical: 15,
     gap: 8,
   },
   submitActive: {
-    backgroundColor: '#131313',
+    backgroundColor: "#131313",
   },
   submitDisabled: {
-    backgroundColor: '#EDECEA',
+    backgroundColor: "#EDECEA",
   },
   submitText: {
-    fontWeight: '700',
+    fontWeight: "700",
     fontSize: 15,
-    color: '#fff',
+    color: "#fff",
     letterSpacing: 0.1,
   },
-})
+});

--- a/components/map/CategoryFilterBar.tsx
+++ b/components/map/CategoryFilterBar.tsx
@@ -1,15 +1,15 @@
-import { ScrollView, Pressable, Text, View, StyleSheet } from 'react-native'
-import { POI_CATEGORIES, CATEGORY_LABELS, CATEGORY_COLORS, PoiCategory } from '@/lib/poiCategories'
+import { ScrollView, Pressable, Text, View, StyleSheet } from "react-native";
+import { POI_CATEGORIES, CATEGORY_LABELS, CATEGORY_COLORS, PoiCategory } from "@/lib/poiCategories";
 
 interface Props {
-  value: Record<PoiCategory, boolean>
-  onChange: (next: Record<PoiCategory, boolean>) => void
+  value: Record<PoiCategory, boolean>;
+  onChange: (next: Record<PoiCategory, boolean>) => void;
 }
 
 export function CategoryFilterBar({ value, onChange }: Props) {
   const toggle = (category: PoiCategory) => {
-    onChange({ ...value, [category]: !value[category] })
-  }
+    onChange({ ...value, [category]: !value[category] });
+  };
 
   return (
     <View style={styles.wrapper} pointerEvents="box-none">
@@ -19,34 +19,32 @@ export function CategoryFilterBar({ value, onChange }: Props) {
         contentContainerStyle={styles.scrollContent}
       >
         {POI_CATEGORIES.map((cat) => {
-          const active = value[cat]
-          const color = CATEGORY_COLORS[cat]
+          const active = value[cat];
+          const color = CATEGORY_COLORS[cat];
           return (
             <Pressable
               key={cat}
               onPress={() => toggle(cat)}
               style={[
                 styles.pill,
-                active
-                  ? { backgroundColor: color, borderColor: color }
-                  : styles.pillInactive,
+                active ? { backgroundColor: color, borderColor: color } : styles.pillInactive,
               ]}
             >
-              <View style={[styles.dot, { backgroundColor: active ? '#fff' : color }]} />
+              <View style={[styles.dot, { backgroundColor: active ? "#fff" : color }]} />
               <Text style={[styles.label, active ? styles.labelActive : styles.labelInactive]}>
                 {CATEGORY_LABELS[cat]}
               </Text>
             </Pressable>
-          )
+          );
         })}
       </ScrollView>
     </View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
   wrapper: {
-    position: 'absolute',
+    position: "absolute",
     bottom: 24,
     left: 0,
     right: 0,
@@ -56,8 +54,8 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   pill: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     paddingVertical: 7,
     paddingHorizontal: 12,
     borderRadius: 20,
@@ -65,8 +63,8 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   pillInactive: {
-    backgroundColor: '#fff',
-    borderColor: '#ccc',
+    backgroundColor: "#fff",
+    borderColor: "#ccc",
   },
   dot: {
     width: 8,
@@ -75,12 +73,12 @@ const styles = StyleSheet.create({
   },
   label: {
     fontSize: 13,
-    fontWeight: '600',
+    fontWeight: "600",
   },
   labelActive: {
-    color: '#fff',
+    color: "#fff",
   },
   labelInactive: {
-    color: '#555',
+    color: "#555",
   },
-})
+});

--- a/components/map/PoiBottomSheet.tsx
+++ b/components/map/PoiBottomSheet.tsx
@@ -1,12 +1,5 @@
 import { useRef, useMemo, useCallback, useEffect, useState } from "react";
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  Linking,
-  Platform,
-  StyleSheet,
-} from "react-native";
+import { View, Text, TouchableOpacity, Linking, Platform, StyleSheet } from "react-native";
 import BottomSheet, {
   BottomSheetBackdrop,
   BottomSheetFlatList,
@@ -15,14 +8,8 @@ import BottomSheet, {
 import { Tables } from "@/types/supabase";
 import { CATEGORY_COLORS, CATEGORY_LABELS } from "@/lib/poiCategories";
 import { usePoiRatings, RatingComment } from "@/hooks/usePoiRatings";
-import {
-  PoiRatingModal,
-  PoiRatingModalHandle,
-} from "@/components/map/PoiRatingModal";
-import {
-  BroadcastModal,
-  BroadcastModalHandle,
-} from "@/components/map/BroadcastModal";
+import { PoiRatingModal, PoiRatingModalHandle } from "@/components/map/PoiRatingModal";
+import { BroadcastModal, BroadcastModalHandle } from "@/components/map/BroadcastModal";
 import { PresenceCard } from "@/components/map/PresenceCard";
 import { UserAvatar } from "@/components/UserAvatar";
 import { useProximity } from "@/hooks/useProximity";
@@ -91,9 +78,7 @@ function CommentRow({ item }: { item: RatingComment }) {
             <Text style={styles.commentDate}>{date}</Text>
           </View>
         </View>
-        {item.comment ? (
-          <Text style={styles.commentText}>{item.comment}</Text>
-        ) : null}
+        {item.comment ? <Text style={styles.commentText}>{item.comment}</Text> : null}
       </View>
     </View>
   );
@@ -118,15 +103,11 @@ export function PoiBottomSheet({
   const ratingModalRef = useRef<PoiRatingModalHandle>(null);
   const broadcastModalRef = useRef<BroadcastModalHandle>(null);
   const { session } = useAuth();
-  const { avgRating, ratingCount, comments, myRating, refetch } = usePoiRatings(
-    poi?.id,
-  );
-  const { isNearby } = useProximity(
-    locationGranted && poi ? { lat: poi.lat, lng: poi.lng } : null
-  );
+  const { avgRating, ratingCount, comments, myRating, refetch } = usePoiRatings(poi?.id);
+  const { isNearby } = useProximity(locationGranted && poi ? { lat: poi.lat, lng: poi.lng } : null);
   const poiPresences = useMemo(
     () => presences.filter((p) => p.poiId === poi?.id),
-    [presences, poi?.id]
+    [presences, poi?.id],
   );
 
   // Drive open/close imperatively so that a swipe-down (which calls onClose → clears poi)
@@ -172,22 +153,22 @@ export function PoiBottomSheet({
   // ENTER event will fire (they're already inside). Auto-confirm immediately.
   const handleJoin = useCallback(
     async (presenceId: string): Promise<PresenceJoin | void> => {
-      const result = await onJoinPresence(presenceId)
+      const result = await onJoinPresence(presenceId);
       if (result && isNearby && poi?.id) {
         try {
-          await confirmJoins(supabase, { poiId: poi.id })
+          await confirmJoins(supabase, { poiId: poi.id });
         } catch (err) {
-          console.error('[PoiBottomSheet] immediate confirmJoins failed:', err)
+          console.error("[PoiBottomSheet] immediate confirmJoins failed:", err);
         }
       }
-      return result
+      return result;
     },
-    [onJoinPresence, isNearby, poi?.id]
+    [onJoinPresence, isNearby, poi?.id],
   );
 
   const categoryColor = poi ? CATEGORY_COLORS[poi.category] : "#999";
   const categoryLabel = poi ? CATEGORY_LABELS[poi.category] : "";
-  const categoryIcon = poi ? CATEGORY_ICONS[poi.category] ?? "" : "";
+  const categoryIcon = poi ? (CATEGORY_ICONS[poi.category] ?? "") : "";
 
   return (
     <>
@@ -204,9 +185,7 @@ export function PoiBottomSheet({
         <BottomSheetFlatList
           data={comments}
           keyExtractor={(item: RatingComment) => item.id}
-          renderItem={({ item }: { item: RatingComment }) => (
-            <CommentRow item={item} />
-          )}
+          renderItem={({ item }: { item: RatingComment }) => <CommentRow item={item} />}
           contentContainerStyle={styles.listContent}
           ListHeaderComponent={
             <>
@@ -303,8 +282,8 @@ export function PoiBottomSheet({
                             await dismissPresence(supabase, { presenceId: activePresence!.id });
                             onDismissBroadcast();
                           } catch (err) {
-                            console.error('dismissPresence failed:', err)
-                            setDismissError('Could not end broadcast. Try again.');
+                            console.error("dismissPresence failed:", err);
+                            setDismissError("Could not end broadcast. Try again.");
                           } finally {
                             setDismissing(false);
                           }
@@ -312,7 +291,9 @@ export function PoiBottomSheet({
                       >
                         <Text style={styles.leaveButtonText}>Leave</Text>
                       </TouchableOpacity>
-                      {dismissError ? <Text style={styles.dismissErrorText}>{dismissError}</Text> : null}
+                      {dismissError ? (
+                        <Text style={styles.dismissErrorText}>{dismissError}</Text>
+                      ) : null}
                     </>
                   );
                 }
@@ -341,8 +322,7 @@ export function PoiBottomSheet({
                 <>
                   <View style={styles.whosHereLabel}>
                     <Text style={styles.whosHereLabelText}>
-                      {poiPresences.length}{" "}
-                      {poiPresences.length === 1 ? "Person" : "People"} here
+                      {poiPresences.length} {poiPresences.length === 1 ? "Person" : "People"} here
                     </Text>
                   </View>
                   {poiPresences.map((p) => (
@@ -372,29 +352,15 @@ export function PoiBottomSheet({
             <View style={styles.emptyContainer}>
               <Text style={styles.emptyEmoji}>💬</Text>
               <Text style={styles.emptyComments}>No comments yet</Text>
-              <Text style={styles.emptySubtext}>
-                Share what you think of this place
-              </Text>
+              <Text style={styles.emptySubtext}>Share what you think of this place</Text>
             </View>
           }
         />
       </BottomSheet>
 
-      {poi && (
-        <PoiRatingModal
-          ref={ratingModalRef}
-          poiId={poi.id}
-          onSubmitted={refetch}
-        />
-      )}
+      {poi && <PoiRatingModal ref={ratingModalRef} poiId={poi.id} onSubmitted={refetch} />}
 
-      {poi && (
-        <BroadcastModal
-          ref={broadcastModalRef}
-          poiId={poi.id}
-          onSubmitted={onBroadcast}
-        />
-      )}
+      {poi && <BroadcastModal ref={broadcastModalRef} poiId={poi.id} onSubmitted={onBroadcast} />}
     </>
   );
 }
@@ -539,46 +505,46 @@ const styles = StyleSheet.create({
     fontWeight: "600",
   },
   imHereButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#131313',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#131313",
     borderRadius: 14,
     paddingVertical: 13,
     marginBottom: 4,
   },
   imHereButtonText: {
-    color: '#fff',
-    fontWeight: '700',
+    color: "#fff",
+    fontWeight: "700",
     fontSize: 14,
     letterSpacing: 0.1,
   },
   imHereButtonDisabled: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#EDECEA',
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#EDECEA",
     borderRadius: 14,
     paddingVertical: 13,
     marginBottom: 4,
   },
   imHereButtonDisabledText: {
-    color: '#AAAAAA',
-    fontWeight: '600',
+    color: "#AAAAAA",
+    fontWeight: "600",
     fontSize: 14,
   },
   leaveButton: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#FFF1F1',
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#FFF1F1",
     borderWidth: 1.5,
-    borderColor: '#E51E1E30',
+    borderColor: "#E51E1E30",
     borderRadius: 14,
     paddingVertical: 13,
     marginBottom: 4,
   },
   leaveButtonText: {
-    color: '#E51E1E',
-    fontWeight: '700',
+    color: "#E51E1E",
+    fontWeight: "700",
     fontSize: 14,
     letterSpacing: 0.1,
   },
@@ -587,9 +553,9 @@ const styles = StyleSheet.create({
   },
   dismissErrorText: {
     fontSize: 12,
-    color: '#E51E1E',
-    fontWeight: '500',
-    textAlign: 'center',
+    color: "#E51E1E",
+    fontWeight: "500",
+    textAlign: "center",
     marginTop: 4,
     marginBottom: 4,
   },

--- a/components/map/PoiLayer.tsx
+++ b/components/map/PoiLayer.tsx
@@ -1,69 +1,74 @@
-import { useMemo, useCallback } from 'react'
-import Mapbox from '@rnmapbox/maps'
-import { Tables } from '@/types/supabase'
-import { POI_CATEGORIES, CATEGORY_COLORS } from '@/lib/poiCategories'
+import { useMemo, useCallback } from "react";
+import Mapbox from "@rnmapbox/maps";
+import { Tables } from "@/types/supabase";
+import { POI_CATEGORIES, CATEGORY_COLORS } from "@/lib/poiCategories";
 
-type Poi = Tables<'pois'>
+type Poi = Tables<"pois">;
 
 interface Props {
-  pois: Poi[]
-  onPoiPress: (poi: Poi) => void
+  pois: Poi[];
+  onPoiPress: (poi: Poi) => void;
 }
 
 // Mapbox 'match' expression: ['match', input, v1, out1, v2, out2, ..., fallback]
-const circleColorExpression: Mapbox.CircleLayerStyle['circleColor'] = [
-  'match',
-  ['get', 'category'],
+const circleColorExpression: Mapbox.CircleLayerStyle["circleColor"] = [
+  "match",
+  ["get", "category"],
   ...POI_CATEGORIES.flatMap((cat) => [cat, CATEGORY_COLORS[cat]]),
-  '#999999', // fallback
-]
+  "#999999", // fallback
+];
 
 const circleStyle = {
   circleColor: circleColorExpression,
   circleRadius: 8,
-  circleStrokeColor: '#ffffff',
+  circleStrokeColor: "#ffffff",
   circleStrokeWidth: 2,
-}
+};
 
 const labelStyle = {
-  textField: '{name}',
+  textField: "{name}",
   textSize: 12,
   textOffset: [0, 1.5] as [number, number],
-  textAnchor: 'top' as const,
-  textColor: '#333333',
-  textHaloColor: '#ffffff',
+  textAnchor: "top" as const,
+  textColor: "#333333",
+  textHaloColor: "#ffffff",
   textHaloWidth: 1.5,
   textOptional: true,
-}
+};
 
 export function PoiLayer({ pois, onPoiPress }: Props) {
-  const featureCollection = useMemo(() => ({
-    type: 'FeatureCollection' as const,
-    features: pois.map((poi) => ({
-      type: 'Feature' as const,
-      id: poi.id,
-      geometry: {
-        type: 'Point' as const,
-        coordinates: [poi.lng, poi.lat],
-      },
-      properties: {
-        name: poi.name,
-        category: poi.category,
-      },
-    })),
-  }), [pois])
-
-  const poiById = useMemo(
-    () => new Map(pois.map((p) => [p.id, p])),
+  const featureCollection = useMemo(
+    () => ({
+      type: "FeatureCollection" as const,
+      features: pois.map((poi) => ({
+        type: "Feature" as const,
+        id: poi.id,
+        geometry: {
+          type: "Point" as const,
+          coordinates: [poi.lng, poi.lat],
+        },
+        properties: {
+          name: poi.name,
+          category: poi.category,
+        },
+      })),
+    }),
     [pois],
-  )
+  );
 
-  const handlePress = useCallback((event: { features: { id?: string | number; properties?: Record<string, unknown> | null }[] }) => {
-    const feature = event.features[0]
-    if (!feature) return
-    const poi = poiById.get(String(feature.id ?? ''))
-    if (poi) onPoiPress(poi)
-  }, [poiById, onPoiPress])
+  const poiById = useMemo(() => new Map(pois.map((p) => [p.id, p])), [pois]);
+
+  const handlePress = useCallback(
+    (event: {
+      features: { id?: string | number; properties?: Record<string, unknown> | null }[];
+    }) => {
+      const feature = event.features[0];
+      if (!feature) return;
+      const poi = poiById.get(String(feature.id ?? ""));
+      if (poi) onPoiPress(poi);
+    },
+    [poiById, onPoiPress],
+  );
 
   return (
     <Mapbox.ShapeSource
@@ -72,15 +77,8 @@ export function PoiLayer({ pois, onPoiPress }: Props) {
       onPress={handlePress}
       hitbox={{ width: 30, height: 30 }}
     >
-      <Mapbox.CircleLayer
-        id="poi-circles"
-        style={circleStyle}
-      />
-      <Mapbox.SymbolLayer
-        id="poi-labels"
-        style={labelStyle}
-        minZoomLevel={15}
-      />
+      <Mapbox.CircleLayer id="poi-circles" style={circleStyle} />
+      <Mapbox.SymbolLayer id="poi-labels" style={labelStyle} minZoomLevel={15} />
     </Mapbox.ShapeSource>
-  )
+  );
 }

--- a/components/map/PoiListRow.tsx
+++ b/components/map/PoiListRow.tsx
@@ -1,44 +1,42 @@
-import { Pressable, Text, View, StyleSheet } from 'react-native'
-import { Tables } from '@/types/supabase'
-import { CATEGORY_COLORS, CATEGORY_LABELS } from '@/lib/poiCategories'
+import { Pressable, Text, View, StyleSheet } from "react-native";
+import { Tables } from "@/types/supabase";
+import { CATEGORY_COLORS, CATEGORY_LABELS } from "@/lib/poiCategories";
 
-type Poi = Tables<'pois'>
+type Poi = Tables<"pois">;
 
 type Props = {
-  poi: Poi
-  avgRating: number | null
-  onPress: (poi: Poi) => void
-}
+  poi: Poi;
+  avgRating: number | null;
+  onPress: (poi: Poi) => void;
+};
 
 export function PoiListRow({ poi, avgRating, onPress }: Props) {
-  const color = CATEGORY_COLORS[poi.category]
-  const label = CATEGORY_LABELS[poi.category]
-  const hasRating = avgRating !== null
+  const color = CATEGORY_COLORS[poi.category];
+  const label = CATEGORY_LABELS[poi.category];
+  const hasRating = avgRating !== null;
 
   return (
-    <Pressable
-      style={styles.row}
-      onPress={() => onPress(poi)}
-      testID="poi-list-row"
-    >
+    <Pressable style={styles.row} onPress={() => onPress(poi)} testID="poi-list-row">
       <View style={styles.left}>
-        <Text style={styles.name} numberOfLines={1}>{poi.name}</Text>
-        <View style={[styles.pill, { backgroundColor: color + '18', borderColor: color + '40' }]}>
+        <Text style={styles.name} numberOfLines={1}>
+          {poi.name}
+        </Text>
+        <View style={[styles.pill, { backgroundColor: color + "18", borderColor: color + "40" }]}>
           <Text style={[styles.pillText, { color }]}>{label}</Text>
         </View>
       </View>
       <Text style={hasRating ? styles.rating : styles.noRating}>
-        {hasRating ? `★ ${avgRating.toFixed(1)}` : 'No ratings'}
+        {hasRating ? `★ ${avgRating.toFixed(1)}` : "No ratings"}
       </Text>
     </Pressable>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
   row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
     paddingVertical: 14,
     paddingHorizontal: 20,
   },
@@ -49,12 +47,12 @@ const styles = StyleSheet.create({
   },
   name: {
     fontSize: 16,
-    fontWeight: '700',
-    color: '#131313',
+    fontWeight: "700",
+    color: "#131313",
     letterSpacing: -0.2,
   },
   pill: {
-    alignSelf: 'flex-start',
+    alignSelf: "flex-start",
     borderRadius: 12,
     borderWidth: 1,
     paddingHorizontal: 8,
@@ -62,18 +60,18 @@ const styles = StyleSheet.create({
   },
   pillText: {
     fontSize: 11,
-    fontWeight: '700',
+    fontWeight: "700",
     letterSpacing: 0.2,
   },
   rating: {
     fontSize: 14,
-    fontWeight: '700',
-    color: '#F5A623',
+    fontWeight: "700",
+    color: "#F5A623",
     letterSpacing: -0.1,
   },
   noRating: {
     fontSize: 12,
-    color: '#BBBBBB',
-    fontStyle: 'italic',
+    color: "#BBBBBB",
+    fontStyle: "italic",
   },
-})
+});

--- a/components/map/PoiListView.tsx
+++ b/components/map/PoiListView.tsx
@@ -1,17 +1,17 @@
-import { FlatList, Text, View, StyleSheet } from 'react-native'
-import { Tables } from '@/types/supabase'
-import { PoiListRow } from '@/components/map/PoiListRow'
+import { FlatList, Text, View, StyleSheet } from "react-native";
+import { Tables } from "@/types/supabase";
+import { PoiListRow } from "@/components/map/PoiListRow";
 
-type Poi = Tables<'pois'>
+type Poi = Tables<"pois">;
 
 type Props = {
-  pois: Poi[]
-  avgRatings: Record<string, number>
-  onPoiPress: (poi: Poi) => void
-}
+  pois: Poi[];
+  avgRatings: Record<string, number>;
+  onPoiPress: (poi: Poi) => void;
+};
 
 function Separator() {
-  return <View style={styles.separator} />
+  return <View style={styles.separator} />;
 }
 
 export function PoiListView({ pois, avgRatings, onPoiPress }: Props) {
@@ -20,7 +20,7 @@ export function PoiListView({ pois, avgRatings, onPoiPress }: Props) {
       <View style={styles.emptyContainer} testID="poi-list-empty">
         <Text style={styles.emptyText}>No POIs match your filters.</Text>
       </View>
-    )
+    );
   }
 
   return (
@@ -28,41 +28,37 @@ export function PoiListView({ pois, avgRatings, onPoiPress }: Props) {
       data={pois}
       keyExtractor={(item) => item.id}
       renderItem={({ item }) => (
-        <PoiListRow
-          poi={item}
-          avgRating={avgRatings[item.id] ?? null}
-          onPress={onPoiPress}
-        />
+        <PoiListRow poi={item} avgRating={avgRatings[item.id] ?? null} onPress={onPoiPress} />
       )}
       ItemSeparatorComponent={Separator}
       contentContainerStyle={styles.listContent}
       style={styles.list}
     />
-  )
+  );
 }
 
 const styles = StyleSheet.create({
   list: {
     flex: 1,
-    backgroundColor: '#FAFAF8',
+    backgroundColor: "#FAFAF8",
   },
   listContent: {
     paddingBottom: 80,
   },
   separator: {
     height: 1,
-    backgroundColor: '#EDECEA',
+    backgroundColor: "#EDECEA",
     marginHorizontal: 20,
   },
   emptyContainer: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#FAFAF8',
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#FAFAF8",
   },
   emptyText: {
     fontSize: 15,
-    color: '#AAAAAA',
-    fontStyle: 'italic',
+    color: "#AAAAAA",
+    fontStyle: "italic",
   },
-})
+});

--- a/components/map/PoiRatingModal.tsx
+++ b/components/map/PoiRatingModal.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useState } from 'react'
+import { forwardRef, useImperativeHandle, useState } from "react";
 import {
   View,
   Text,
@@ -10,58 +10,58 @@ import {
   KeyboardAvoidingView,
   Platform,
   Pressable,
-} from 'react-native'
-import { supabase } from '@/lib/supabase'
-import { submitRating } from '@/lib/ratings'
+} from "react-native";
+import { supabase } from "@/lib/supabase";
+import { submitRating } from "@/lib/ratings";
 
 export type PoiRatingModalHandle = {
-  present: () => void
-  dismiss: () => void
-}
+  present: () => void;
+  dismiss: () => void;
+};
 
 type Props = {
-  poiId: string
-  onSubmitted: () => void
-}
+  poiId: string;
+  onSubmitted: () => void;
+};
 
-const STAR_LABELS = ['', 'Poor', 'Fair', 'Good', 'Great', 'Excellent']
+const STAR_LABELS = ["", "Poor", "Fair", "Good", "Great", "Excellent"];
 
 export const PoiRatingModal = forwardRef<PoiRatingModalHandle, Props>(function PoiRatingModal(
   { poiId, onSubmitted },
-  ref
+  ref,
 ) {
-  const [visible, setVisible] = useState(false)
-  const [selectedRating, setSelectedRating] = useState<number | null>(null)
-  const [comment, setComment] = useState('')
-  const [submitting, setSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [visible, setVisible] = useState(false);
+  const [selectedRating, setSelectedRating] = useState<number | null>(null);
+  const [comment, setComment] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useImperativeHandle(ref, () => ({
     present: () => {
-      setSelectedRating(null)
-      setComment('')
-      setError(null)
-      setVisible(true)
+      setSelectedRating(null);
+      setComment("");
+      setError(null);
+      setVisible(true);
     },
     dismiss: () => setVisible(false),
-  }))
+  }));
 
   const handleSubmit = async () => {
-    if (!selectedRating) return
-    setSubmitting(true)
-    setError(null)
+    if (!selectedRating) return;
+    setSubmitting(true);
+    setError(null);
     try {
-      await submitRating(supabase, { poiId, rating: selectedRating, comment })
-      onSubmitted()
-      setVisible(false)
+      await submitRating(supabase, { poiId, rating: selectedRating, comment });
+      onSubmitted();
+      setVisible(false);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Something went wrong')
+      setError(e instanceof Error ? e.message : "Something went wrong");
     } finally {
-      setSubmitting(false)
+      setSubmitting(false);
     }
-  }
+  };
 
-  const isReady = !!selectedRating && !submitting
+  const isReady = !!selectedRating && !submitting;
 
   return (
     <Modal
@@ -70,10 +70,7 @@ export const PoiRatingModal = forwardRef<PoiRatingModalHandle, Props>(function P
       animationType="fade"
       onRequestClose={() => setVisible(false)}
     >
-      <KeyboardAvoidingView
-        style={styles.overlay}
-        behavior="padding"
-      >
+      <KeyboardAvoidingView style={styles.overlay} behavior="padding">
         <Pressable style={styles.backdrop} onPress={() => setVisible(false)} />
 
         <View style={styles.card}>
@@ -102,13 +99,13 @@ export const PoiRatingModal = forwardRef<PoiRatingModalHandle, Props>(function P
                         : styles.starInactive,
                     ]}
                   >
-                    {selectedRating !== null && i <= selectedRating ? '★' : '☆'}
+                    {selectedRating !== null && i <= selectedRating ? "★" : "☆"}
                   </Text>
                 </TouchableOpacity>
               ))}
             </View>
             <Text style={styles.starLabel}>
-              {selectedRating ? STAR_LABELS[selectedRating] : 'Tap to rate'}
+              {selectedRating ? STAR_LABELS[selectedRating] : "Tap to rate"}
             </Text>
           </View>
 
@@ -146,7 +143,7 @@ export const PoiRatingModal = forwardRef<PoiRatingModalHandle, Props>(function P
             ) : (
               <>
                 <Text style={styles.submitText}>
-                  {isReady ? 'Submit Review' : 'Select a rating first'}
+                  {isReady ? "Submit Review" : "Select a rating first"}
                 </Text>
                 {isReady && <Text style={styles.submitArrow}>→</Text>}
               </>
@@ -155,26 +152,26 @@ export const PoiRatingModal = forwardRef<PoiRatingModalHandle, Props>(function P
         </View>
       </KeyboardAvoidingView>
     </Modal>
-  )
-})
+  );
+});
 
 const styles = StyleSheet.create({
   overlay: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
   },
   backdrop: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.45)',
+    backgroundColor: "rgba(0,0,0,0.45)",
   },
   card: {
-    width: '88%',
-    backgroundColor: '#FAFAF8',
+    width: "88%",
+    backgroundColor: "#FAFAF8",
     borderRadius: 24,
     padding: 24,
     gap: 18,
-    shadowColor: '#000',
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 8 },
     shadowOpacity: 0.15,
     shadowRadius: 24,
@@ -185,22 +182,22 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 24,
-    fontWeight: '800',
-    color: '#131313',
+    fontWeight: "800",
+    color: "#131313",
     letterSpacing: -0.5,
   },
   subtitle: {
     fontSize: 14,
-    color: '#AAAAAA',
-    fontWeight: '400',
+    color: "#AAAAAA",
+    fontWeight: "400",
   },
   starsSection: {
-    alignItems: 'center',
+    alignItems: "center",
     gap: 10,
     paddingVertical: 6,
   },
   starsRow: {
-    flexDirection: 'row',
+    flexDirection: "row",
     gap: 6,
   },
   starButton: {
@@ -210,85 +207,85 @@ const styles = StyleSheet.create({
     fontSize: 44,
   },
   starActive: {
-    color: '#F5A623',
+    color: "#F5A623",
   },
   starInactive: {
-    color: '#DDD9D3',
+    color: "#DDD9D3",
   },
   starLabel: {
     fontSize: 13,
-    fontWeight: '600',
-    color: '#AAAAAA',
+    fontWeight: "600",
+    color: "#AAAAAA",
     letterSpacing: 0.3,
     minHeight: 18,
   },
   inputWrapper: {
-    position: 'relative',
+    position: "relative",
   },
   input: {
     borderWidth: 1.5,
-    borderColor: '#EDECEA',
+    borderColor: "#EDECEA",
     borderRadius: 14,
     paddingHorizontal: 14,
     paddingTop: 13,
     paddingBottom: 32,
     fontSize: 15,
-    color: '#131313',
+    color: "#131313",
     minHeight: 90,
-    textAlignVertical: 'top',
-    backgroundColor: '#fff',
+    textAlignVertical: "top",
+    backgroundColor: "#fff",
     lineHeight: 22,
   },
   charCount: {
-    position: 'absolute',
+    position: "absolute",
     bottom: 10,
     right: 14,
     fontSize: 11,
-    color: '#CCCCCC',
-    fontWeight: '500',
+    color: "#CCCCCC",
+    fontWeight: "500",
   },
   errorRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     gap: 6,
-    backgroundColor: '#FFF1F1',
+    backgroundColor: "#FFF1F1",
     borderRadius: 10,
     paddingHorizontal: 12,
     paddingVertical: 9,
   },
   errorIcon: {
     fontSize: 13,
-    color: '#E51E1E',
+    color: "#E51E1E",
   },
   error: {
-    color: '#E51E1E',
+    color: "#E51E1E",
     fontSize: 13,
-    fontWeight: '500',
+    fontWeight: "500",
     flex: 1,
   },
   submitButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
     borderRadius: 14,
     paddingVertical: 15,
     gap: 8,
   },
   submitActive: {
-    backgroundColor: '#131313',
+    backgroundColor: "#131313",
   },
   submitDisabled: {
-    backgroundColor: '#EDECEA',
+    backgroundColor: "#EDECEA",
   },
   submitText: {
-    fontWeight: '700',
+    fontWeight: "700",
     fontSize: 15,
-    color: '#fff',
+    color: "#fff",
     letterSpacing: 0.1,
   },
   submitArrow: {
-    color: '#ffffff90',
+    color: "#ffffff90",
     fontSize: 16,
-    fontWeight: '600',
+    fontWeight: "600",
   },
-})
+});

--- a/components/map/PresenceBubble.tsx
+++ b/components/map/PresenceBubble.tsx
@@ -1,11 +1,11 @@
-import { UserAvatar } from '@/components/UserAvatar'
+import { UserAvatar } from "@/components/UserAvatar";
 
 interface Props {
-  displayName: string
-  avatarUrl: string | null
-  size?: number
+  displayName: string;
+  avatarUrl: string | null;
+  size?: number;
 }
 
 export function PresenceBubble({ displayName, avatarUrl, size = 32 }: Props) {
-  return <UserAvatar displayName={displayName} avatarUrl={avatarUrl} size={size} />
+  return <UserAvatar displayName={displayName} avatarUrl={avatarUrl} size={size} />;
 }

--- a/components/map/PresenceCard.tsx
+++ b/components/map/PresenceCard.tsx
@@ -1,96 +1,103 @@
-import { useState } from 'react'
-import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
-import { LivePresenceEntry } from '@/hooks/useLivePresences'
-import { PresenceJoin } from '@/lib/presenceJoins'
-import { PresenceBubble } from '@/components/map/PresenceBubble'
+import { useState } from "react";
+import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { LivePresenceEntry } from "@/hooks/useLivePresences";
+import { PresenceJoin } from "@/lib/presenceJoins";
+import { PresenceBubble } from "@/components/map/PresenceBubble";
 
 type Props = {
-  presence: LivePresenceEntry
-  existingJoin: PresenceJoin | undefined
-  onJoin: (presenceId: string) => Promise<PresenceJoin | void>
-  onCancel: (joinId: string) => Promise<void>
-  isOwnPresence: boolean
-}
+  presence: LivePresenceEntry;
+  existingJoin: PresenceJoin | undefined;
+  onJoin: (presenceId: string) => Promise<PresenceJoin | void>;
+  onCancel: (joinId: string) => Promise<void>;
+  isOwnPresence: boolean;
+};
 
 export function PresenceCard({ presence, existingJoin, onJoin, onCancel, isOwnPresence }: Props) {
-  const [busy, setBusy] = useState(false)
-  const [errorText, setErrorText] = useState<string | null>(null)
-  const firstName = presence.displayName.split(' ')[0]
+  const [busy, setBusy] = useState(false);
+  const [errorText, setErrorText] = useState<string | null>(null);
+  const firstName = presence.displayName.split(" ")[0];
 
   const handleJoin = async () => {
-    setBusy(true)
-    setErrorText(null)
+    setBusy(true);
+    setErrorText(null);
     try {
-      await onJoin(presence.id)
+      await onJoin(presence.id);
     } catch (err) {
-      console.error('PresenceCard.handleJoin failed:', err)
-      const message = err instanceof Error && err.message.includes('already joined')
-        ? err.message
-        : 'Could not join. Try again.'
-      setErrorText(message)
+      console.error("PresenceCard.handleJoin failed:", err);
+      const message =
+        err instanceof Error && err.message.includes("already joined")
+          ? err.message
+          : "Could not join. Try again.";
+      setErrorText(message);
     } finally {
-      setBusy(false)
+      setBusy(false);
     }
-  }
+  };
 
   const handleCancel = async (joinId: string) => {
-    setBusy(true)
-    setErrorText(null)
+    setBusy(true);
+    setErrorText(null);
     try {
-      await onCancel(joinId)
+      await onCancel(joinId);
     } catch (err) {
-      console.error('PresenceCard.handleCancel failed:', err)
-      setErrorText('Could not cancel. Try again.')
+      console.error("PresenceCard.handleCancel failed:", err);
+      setErrorText("Could not cancel. Try again.");
     } finally {
-      setBusy(false)
+      setBusy(false);
     }
-  }
+  };
 
   return (
     <View>
-    <View style={styles.row}>
-      <PresenceBubble displayName={presence.displayName} avatarUrl={presence.avatarUrl} size={40} />
+      <View style={styles.row}>
+        <PresenceBubble
+          displayName={presence.displayName}
+          avatarUrl={presence.avatarUrl}
+          size={40}
+        />
 
-      <View style={styles.info}>
-        <Text style={styles.name}>{presence.displayName}</Text>
-        {presence.message ? (
-          <Text style={styles.message} numberOfLines={1}>{presence.message}</Text>
-        ) : null}
-      </View>
-
-      {!isOwnPresence && (
-        <View style={styles.action}>
-          {busy ? (
-            <ActivityIndicator size="small" color="#131313" />
-          ) : existingJoin?.confirmed ? (
-            <Text style={styles.arrivedText}>Arrived</Text>
-          ) : existingJoin ? (
-            <View style={styles.joinedState}>
-              <Text style={styles.onMyWayText}>On my way</Text>
-              <TouchableOpacity onPress={() => handleCancel(existingJoin.id)} hitSlop={8}>
-                <Text style={styles.cancelText}>Cancel</Text>
-              </TouchableOpacity>
-            </View>
-          ) : (
-            <TouchableOpacity style={styles.joinButton} onPress={handleJoin} activeOpacity={0.8}>
-              <Text style={styles.joinButtonText}>{`Join ${firstName}`}</Text>
-            </TouchableOpacity>
-          )}
+        <View style={styles.info}>
+          <Text style={styles.name}>{presence.displayName}</Text>
+          {presence.message ? (
+            <Text style={styles.message} numberOfLines={1}>
+              {presence.message}
+            </Text>
+          ) : null}
         </View>
-      )}
+
+        {!isOwnPresence && (
+          <View style={styles.action}>
+            {busy ? (
+              <ActivityIndicator size="small" color="#131313" />
+            ) : existingJoin?.confirmed ? (
+              <Text style={styles.arrivedText}>Arrived</Text>
+            ) : existingJoin ? (
+              <View style={styles.joinedState}>
+                <Text style={styles.onMyWayText}>On my way</Text>
+                <TouchableOpacity onPress={() => handleCancel(existingJoin.id)} hitSlop={8}>
+                  <Text style={styles.cancelText}>Cancel</Text>
+                </TouchableOpacity>
+              </View>
+            ) : (
+              <TouchableOpacity style={styles.joinButton} onPress={handleJoin} activeOpacity={0.8}>
+                <Text style={styles.joinButtonText}>{`Join ${firstName}`}</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        )}
+      </View>
+      {errorText ? <Text style={styles.errorText}>{errorText}</Text> : null}
     </View>
-    {errorText ? <Text style={styles.errorText}>{errorText}</Text> : null}
-    </View>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
   row: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     paddingVertical: 10,
     borderTopWidth: 1,
-    borderTopColor: '#EDECEA',
+    borderTopColor: "#EDECEA",
     gap: 12,
   },
   info: {
@@ -98,51 +105,51 @@ const styles = StyleSheet.create({
   },
   name: {
     fontSize: 14,
-    fontWeight: '700',
-    color: '#131313',
+    fontWeight: "700",
+    color: "#131313",
   },
   message: {
     fontSize: 13,
-    color: '#888',
+    color: "#888",
     marginTop: 2,
   },
   action: {
-    alignItems: 'flex-end',
+    alignItems: "flex-end",
   },
   joinButton: {
-    backgroundColor: '#131313',
+    backgroundColor: "#131313",
     borderRadius: 10,
     paddingHorizontal: 12,
     paddingVertical: 7,
   },
   joinButtonText: {
-    color: '#fff',
+    color: "#fff",
     fontSize: 13,
-    fontWeight: '700',
+    fontWeight: "700",
   },
   joinedState: {
-    alignItems: 'flex-end',
+    alignItems: "flex-end",
     gap: 4,
   },
   arrivedText: {
     fontSize: 12,
-    fontWeight: '600',
-    color: '#2D8A4E',
+    fontWeight: "600",
+    color: "#2D8A4E",
   },
   onMyWayText: {
     fontSize: 12,
-    fontWeight: '600',
-    color: '#2D8A4E',
+    fontWeight: "600",
+    color: "#2D8A4E",
   },
   cancelText: {
     fontSize: 12,
-    fontWeight: '600',
-    color: '#E51E1E',
+    fontWeight: "600",
+    color: "#E51E1E",
   },
   errorText: {
     fontSize: 12,
-    color: '#E51E1E',
-    fontWeight: '500',
+    color: "#E51E1E",
+    fontWeight: "500",
     paddingBottom: 6,
   },
-})
+});

--- a/components/map/PresenceLayer.tsx
+++ b/components/map/PresenceLayer.tsx
@@ -1,47 +1,44 @@
-import { useMemo } from 'react'
-import { Pressable, StyleSheet, Text, View } from 'react-native'
-import Mapbox from '@rnmapbox/maps'
-import { Tables } from '@/types/supabase'
-import { LivePresenceEntry } from '@/hooks/useLivePresences'
-import { PresenceBubble } from './PresenceBubble'
+import { useMemo } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import Mapbox from "@rnmapbox/maps";
+import { Tables } from "@/types/supabase";
+import { LivePresenceEntry } from "@/hooks/useLivePresences";
+import { PresenceBubble } from "./PresenceBubble";
 
-type Poi = Tables<'pois'>
+type Poi = Tables<"pois">;
 
 interface Props {
-  presences: LivePresenceEntry[]
-  pois: Poi[]
-  onPoiPress: (poi: Poi) => void
+  presences: LivePresenceEntry[];
+  pois: Poi[];
+  onPoiPress: (poi: Poi) => void;
 }
 
-const MAX_VISIBLE = 3
+const MAX_VISIBLE = 3;
 
 export function PresenceLayer({ presences, pois, onPoiPress }: Props) {
-  const poiById = useMemo(
-    () => new Map(pois.map((p) => [p.id, p])),
-    [pois],
-  )
+  const poiById = useMemo(() => new Map(pois.map((p) => [p.id, p])), [pois]);
 
   const byPoi = useMemo(() => {
-    const map = new Map<string, LivePresenceEntry[]>()
+    const map = new Map<string, LivePresenceEntry[]>();
     for (const p of presences) {
-      const existing = map.get(p.poiId)
+      const existing = map.get(p.poiId);
       if (existing) {
-        existing.push(p)
+        existing.push(p);
       } else {
-        map.set(p.poiId, [p])
+        map.set(p.poiId, [p]);
       }
     }
-    return map
-  }, [presences])
+    return map;
+  }, [presences]);
 
   return (
     <>
       {Array.from(byPoi.entries()).map(([poiId, group]) => {
-        const poi = poiById.get(poiId)
-        if (!poi) return null
+        const poi = poiById.get(poiId);
+        if (!poi) return null;
 
-        const visible = group.slice(0, MAX_VISIBLE)
-        const overflow = group.length - MAX_VISIBLE
+        const visible = group.slice(0, MAX_VISIBLE);
+        const overflow = group.length - MAX_VISIBLE;
 
         return (
           <Mapbox.MarkerView
@@ -64,16 +61,16 @@ export function PresenceLayer({ presences, pois, onPoiPress }: Props) {
               )}
             </Pressable>
           </Mapbox.MarkerView>
-        )
+        );
       })}
     </>
-  )
+  );
 }
 
 const styles = StyleSheet.create({
   row: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
   },
   overlap: {
     marginLeft: -10,
@@ -82,15 +79,15 @@ const styles = StyleSheet.create({
     width: 32,
     height: 32,
     borderRadius: 16,
-    backgroundColor: 'rgba(0,0,0,0.55)',
-    alignItems: 'center',
-    justifyContent: 'center',
+    backgroundColor: "rgba(0,0,0,0.55)",
+    alignItems: "center",
+    justifyContent: "center",
     borderWidth: 2,
-    borderColor: '#ffffff',
+    borderColor: "#ffffff",
   },
   overflowText: {
-    color: '#ffffff',
+    color: "#ffffff",
     fontSize: 11,
-    fontWeight: '700',
+    fontWeight: "700",
   },
-})
+});

--- a/components/map/__tests__/PoiBottomSheet.test.tsx
+++ b/components/map/__tests__/PoiBottomSheet.test.tsx
@@ -6,52 +6,52 @@
  * so only the component's own logic is under test.
  */
 
-import React from 'react'
-import { Text } from 'react-native'
-import { act, create, ReactTestInstance } from 'react-test-renderer'
-import { Tables } from '@/types/supabase'
-import { LivePresenceEntry } from '@/hooks/useLivePresences'
-import { PresenceJoin } from '@/lib/presenceJoins'
+import React from "react";
+import { Text } from "react-native";
+import { act, create, ReactTestInstance } from "react-test-renderer";
+import { Tables } from "@/types/supabase";
+import { LivePresenceEntry } from "@/hooks/useLivePresences";
+import { PresenceJoin } from "@/lib/presenceJoins";
 
 // ---------------------------------------------------------------------------
 // Mock @gorhom/bottom-sheet — render ListHeaderComponent directly
 // ---------------------------------------------------------------------------
-jest.mock('@gorhom/bottom-sheet', () => {
-  const React = require('react')
+jest.mock("@gorhom/bottom-sheet", () => {
+  const React = require("react");
   return {
     __esModule: true,
     default: React.forwardRef(function MockBottomSheet({ children }: any, _: any) {
-      return React.createElement(React.Fragment, null, children)
+      return React.createElement(React.Fragment, null, children);
     }),
     BottomSheetBackdrop: () => null,
     BottomSheetFlatList: function MockBSFlatList({ ListHeaderComponent }: any) {
-      return React.createElement(React.Fragment, null, ListHeaderComponent)
+      return React.createElement(React.Fragment, null, ListHeaderComponent);
     },
-  }
-})
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Mock PresenceCard — exposes props as testable text nodes.
 // mockPresenceCardProps is prefixed with "mock" so Jest hoisting allows it in the factory.
 // ---------------------------------------------------------------------------
-const mockPresenceCardProps: any[] = []
-jest.mock('@/components/map/PresenceCard', () => ({
+const mockPresenceCardProps: any[] = [];
+jest.mock("@/components/map/PresenceCard", () => ({
   PresenceCard: (props: any) => {
-    mockPresenceCardProps.push(props)
-    const React = require('react')
-    const { Text } = require('react-native')
+    mockPresenceCardProps.push(props);
+    const React = require("react");
+    const { Text } = require("react-native");
     return React.createElement(
       Text,
-      { testID: 'presence-card' },
-      props.presence.displayName + (props.isOwnPresence ? ':own' : ':other')
-    )
+      { testID: "presence-card" },
+      props.presence.displayName + (props.isOwnPresence ? ":own" : ":other"),
+    );
   },
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Mock all hooks and heavy deps
 // ---------------------------------------------------------------------------
-jest.mock('@/hooks/usePoiRatings', () => ({
+jest.mock("@/hooks/usePoiRatings", () => ({
   usePoiRatings: jest.fn(() => ({
     avgRating: null,
     ratingCount: 0,
@@ -59,51 +59,51 @@ jest.mock('@/hooks/usePoiRatings', () => ({
     myRating: null,
     refetch: jest.fn(),
   })),
-}))
+}));
 
-jest.mock('@/hooks/useProximity', () => ({
+jest.mock("@/hooks/useProximity", () => ({
   useProximity: jest.fn(() => ({ isNearby: false })),
-}))
+}));
 
-jest.mock('@/hooks/useAuth', () => ({
-  useAuth: jest.fn(() => ({ session: { user: { id: 'current-user-id' } } })),
-}))
+jest.mock("@/hooks/useAuth", () => ({
+  useAuth: jest.fn(() => ({ session: { user: { id: "current-user-id" } } })),
+}));
 
-jest.mock('@/lib/supabase', () => ({ supabase: {} }))
-jest.mock('@/lib/presence', () => ({ dismissPresence: jest.fn() }))
-jest.mock('@/lib/presenceJoins', () => ({ confirmJoins: jest.fn().mockResolvedValue(undefined) }))
+jest.mock("@/lib/supabase", () => ({ supabase: {} }));
+jest.mock("@/lib/presence", () => ({ dismissPresence: jest.fn() }));
+jest.mock("@/lib/presenceJoins", () => ({ confirmJoins: jest.fn().mockResolvedValue(undefined) }));
 
-jest.mock('@/components/map/PoiRatingModal', () => ({
-  PoiRatingModal: require('react').forwardRef(() => null),
-}))
+jest.mock("@/components/map/PoiRatingModal", () => ({
+  PoiRatingModal: require("react").forwardRef(() => null),
+}));
 
-jest.mock('@/components/map/BroadcastModal', () => ({
-  BroadcastModal: require('react').forwardRef(() => null),
-}))
+jest.mock("@/components/map/BroadcastModal", () => ({
+  BroadcastModal: require("react").forwardRef(() => null),
+}));
 
-jest.mock('@/lib/poiCategories', () => ({
-  CATEGORY_COLORS: { food_drink: '#FF0000' },
-  CATEGORY_LABELS: { food_drink: 'Food & Drink' },
-}))
+jest.mock("@/lib/poiCategories", () => ({
+  CATEGORY_COLORS: { food_drink: "#FF0000" },
+  CATEGORY_LABELS: { food_drink: "Food & Drink" },
+}));
 
-import { PoiBottomSheet } from '../PoiBottomSheet'
-import { dismissPresence } from '@/lib/presence'
-import { confirmJoins } from '@/lib/presenceJoins'
+import { PoiBottomSheet } from "../PoiBottomSheet";
+import { dismissPresence } from "@/lib/presence";
+import { confirmJoins } from "@/lib/presenceJoins";
 
-type Poi = Tables<'pois'>
+type Poi = Tables<"pois">;
 
 function makePoi(overrides: Partial<Poi> = {}): Poi {
   return {
-    id: 'poi-1',
-    name: 'Test Cafe',
-    category: 'food_drink',
+    id: "poi-1",
+    name: "Test Cafe",
+    category: "food_drink",
     lat: 55.6761,
     lng: 12.5683,
     description: null,
-    created_by: 'user-system',
-    created_at: '2026-01-01T00:00:00Z',
+    created_by: "user-system",
+    created_at: "2026-01-01T00:00:00Z",
     ...overrides,
-  } as Poi
+  } as Poi;
 }
 
 const BASE_PROPS = {
@@ -117,146 +117,150 @@ const BASE_PROPS = {
   getJoinForPresence: jest.fn(() => undefined),
   onJoinPresence: jest.fn(),
   onCancelJoin: jest.fn(),
-}
+};
 
 function makePresence(overrides: Partial<LivePresenceEntry> = {}): LivePresenceEntry {
   return {
-    id: 'presence-1',
-    userId: 'other-user-id',
-    poiId: 'poi-1',
-    displayName: 'Jane Doe',
+    id: "presence-1",
+    userId: "other-user-id",
+    poiId: "poi-1",
+    displayName: "Jane Doe",
     avatarUrl: null,
     message: null,
     ...overrides,
-  }
+  };
 }
 
 beforeEach(() => {
-  jest.clearAllMocks()
-  mockPresenceCardProps.length = 0
+  jest.clearAllMocks();
+  mockPresenceCardProps.length = 0;
   // clearAllMocks clears call history but not mockReturnValue — reset the default explicitly
-  require('@/hooks/useProximity').useProximity.mockReturnValue({ isNearby: false })
-})
+  require("@/hooks/useProximity").useProximity.mockReturnValue({ isNearby: false });
+});
 
-describe('PoiBottomSheet — Who\'s here section', () => {
-  it('does not render Who\'s here section when no presences are at the current POI', () => {
-    let root: ReturnType<typeof create>
+describe("PoiBottomSheet — Who's here section", () => {
+  it("does not render Who's here section when no presences are at the current POI", () => {
+    let root: ReturnType<typeof create>;
     act(() => {
-      root = create(<PoiBottomSheet {...BASE_PROPS} presences={[]} />)
-    })
+      root = create(<PoiBottomSheet {...BASE_PROPS} presences={[]} />);
+    });
 
     const presenceCards = root!.root.findAll(
-      (n: ReactTestInstance) => n.props.testID === 'presence-card'
-    )
-    expect(presenceCards.length).toBe(0)
+      (n: ReactTestInstance) => n.props.testID === "presence-card",
+    );
+    expect(presenceCards.length).toBe(0);
 
     const texts = root!.root
-      .findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-      .map((n) => String(n.props.children))
-    expect(texts.some((t) => t.includes('here'))).toBe(false)
-  })
+      .findAll((n: ReactTestInstance) => (n.type as string) === "Text")
+      .map((n) => String(n.props.children));
+    expect(texts.some((t) => t.includes("here"))).toBe(false);
+  });
 
-  it('filters presences to only those at the current POI', () => {
-    const presenceAtPoi = makePresence({ poiId: 'poi-1' })
-    const presenceAtOtherPoi = makePresence({ id: 'presence-other', poiId: 'poi-99' })
+  it("filters presences to only those at the current POI", () => {
+    const presenceAtPoi = makePresence({ poiId: "poi-1" });
+    const presenceAtOtherPoi = makePresence({ id: "presence-other", poiId: "poi-99" });
 
     act(() => {
-      create(
-        <PoiBottomSheet
-          {...BASE_PROPS}
-          presences={[presenceAtPoi, presenceAtOtherPoi]}
-        />
-      )
-    })
+      create(<PoiBottomSheet {...BASE_PROPS} presences={[presenceAtPoi, presenceAtOtherPoi]} />);
+    });
 
     // Deduplicate by presence id to be robust against React re-renders calling the mock twice
-    const uniquePresenceIds = [...new Set(mockPresenceCardProps.map((p) => p.presence.id))]
-    expect(uniquePresenceIds).toEqual(['presence-1'])
-    expect(mockPresenceCardProps.every((p) => p.presence.poiId !== 'poi-99')).toBe(true)
-  })
+    const uniquePresenceIds = [...new Set(mockPresenceCardProps.map((p) => p.presence.id))];
+    expect(uniquePresenceIds).toEqual(["presence-1"]);
+    expect(mockPresenceCardProps.every((p) => p.presence.poiId !== "poi-99")).toBe(true);
+  });
 
   it('shows "1 Person here" label for a single presence', () => {
-    const presences = [makePresence()]
+    const presences = [makePresence()];
 
-    let root: ReturnType<typeof create>
+    let root: ReturnType<typeof create>;
     act(() => {
-      root = create(<PoiBottomSheet {...BASE_PROPS} presences={presences} />)
-    })
+      root = create(<PoiBottomSheet {...BASE_PROPS} presences={presences} />);
+    });
 
     const texts = root!.root
-      .findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-      .map((n) => String(n.props.children))
-    expect(texts.some((t) => t.includes('1') && t.includes('Person'))).toBe(true)
-  })
+      .findAll((n: ReactTestInstance) => (n.type as string) === "Text")
+      .map((n) => String(n.props.children));
+    expect(texts.some((t) => t.includes("1") && t.includes("Person"))).toBe(true);
+  });
 
   it('shows "N People here" label for multiple presences', () => {
     const presences = [
-      makePresence({ id: 'p-1' }),
-      makePresence({ id: 'p-2', userId: 'user-b', displayName: 'Bob' }),
-    ]
+      makePresence({ id: "p-1" }),
+      makePresence({ id: "p-2", userId: "user-b", displayName: "Bob" }),
+    ];
 
-    let root: ReturnType<typeof create>
+    let root: ReturnType<typeof create>;
     act(() => {
-      root = create(<PoiBottomSheet {...BASE_PROPS} presences={presences} />)
-    })
+      root = create(<PoiBottomSheet {...BASE_PROPS} presences={presences} />);
+    });
 
     const texts = root!.root
-      .findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-      .map((n) => String(n.props.children))
-    expect(texts.some((t) => t.includes('2') && t.includes('People'))).toBe(true)
-  })
+      .findAll((n: ReactTestInstance) => (n.type as string) === "Text")
+      .map((n) => String(n.props.children));
+    expect(texts.some((t) => t.includes("2") && t.includes("People"))).toBe(true);
+  });
 
-  it('marks own presence with isOwnPresence=true', () => {
-    const ownPresence = makePresence({ userId: 'current-user-id' })
-    const otherPresence = makePresence({ id: 'p-other', userId: 'someone-else' })
+  it("marks own presence with isOwnPresence=true", () => {
+    const ownPresence = makePresence({ userId: "current-user-id" });
+    const otherPresence = makePresence({ id: "p-other", userId: "someone-else" });
 
     act(() => {
-      create(
-        <PoiBottomSheet
-          {...BASE_PROPS}
-          presences={[ownPresence, otherPresence]}
-        />
-      )
-    })
+      create(<PoiBottomSheet {...BASE_PROPS} presences={[ownPresence, otherPresence]} />);
+    });
 
-    expect(mockPresenceCardProps).toHaveLength(2)
-    const own = mockPresenceCardProps.find((p) => p.presence.userId === 'current-user-id')
-    const other = mockPresenceCardProps.find((p) => p.presence.userId === 'someone-else')
-    expect(own?.isOwnPresence).toBe(true)
-    expect(other?.isOwnPresence).toBe(false)
-  })
+    expect(mockPresenceCardProps).toHaveLength(2);
+    const own = mockPresenceCardProps.find((p) => p.presence.userId === "current-user-id");
+    const other = mockPresenceCardProps.find((p) => p.presence.userId === "someone-else");
+    expect(own?.isOwnPresence).toBe(true);
+    expect(other?.isOwnPresence).toBe(false);
+  });
 
-  it('shows dismissError below Leave button when dismissPresence rejects', async () => {
-    const { TouchableOpacity } = require('react-native')
-    ;(dismissPresence as jest.Mock).mockRejectedValue(new Error('network'))
+  it("shows dismissError below Leave button when dismissPresence rejects", async () => {
+    const { TouchableOpacity } = require("react-native");
+    (dismissPresence as jest.Mock).mockRejectedValue(new Error("network"));
 
-    const activePresence = { id: 'presence-1', poi_id: 'poi-1', message: null, visible_to: 'community' as const }
-    let root: ReturnType<typeof create>
+    const activePresence = {
+      id: "presence-1",
+      poi_id: "poi-1",
+      message: null,
+      visible_to: "community" as const,
+    };
+    let root: ReturnType<typeof create>;
     act(() => {
-      root = create(<PoiBottomSheet {...BASE_PROPS} activePresence={activePresence} locationGranted={true} />)
-    })
+      root = create(
+        <PoiBottomSheet {...BASE_PROPS} activePresence={activePresence} locationGranted={true} />,
+      );
+    });
 
     const leaveBtn = root!.root.findAllByType(TouchableOpacity).find((n: ReactTestInstance) => {
-      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
-      return texts.some((t) => String(t.props.children) === 'Leave')
-    })
-    expect(leaveBtn).toBeDefined()
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === "Text");
+      return texts.some((t) => String(t.props.children) === "Leave");
+    });
+    expect(leaveBtn).toBeDefined();
 
-    await act(async () => { leaveBtn!.props.onPress() })
+    await act(async () => {
+      leaveBtn!.props.onPress();
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    expect(texts.some((n) => String(n.props.children) === 'Could not end broadcast. Try again.')).toBe(true)
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    expect(
+      texts.some((n) => String(n.props.children) === "Could not end broadcast. Try again."),
+    ).toBe(true);
+  });
 
-  it('calls confirmJoins immediately when joiner is already at the POI', async () => {
-    const { useProximity } = require('@/hooks/useProximity')
-    useProximity.mockReturnValue({ isNearby: true })
+  it("calls confirmJoins immediately when joiner is already at the POI", async () => {
+    const { useProximity } = require("@/hooks/useProximity");
+    useProximity.mockReturnValue({ isNearby: true });
 
     const mockJoin: PresenceJoin = {
-      id: 'join-1', presence_id: 'presence-1', joiner_user_id: 'current-user-id',
-      joined_at: '2026-01-01T00:00:00Z', confirmed: false,
-    }
-    const onJoinPresence = jest.fn().mockResolvedValue(mockJoin)
+      id: "join-1",
+      presence_id: "presence-1",
+      joiner_user_id: "current-user-id",
+      joined_at: "2026-01-01T00:00:00Z",
+      confirmed: false,
+    };
+    const onJoinPresence = jest.fn().mockResolvedValue(mockJoin);
 
     act(() => {
       create(
@@ -264,26 +268,29 @@ describe('PoiBottomSheet — Who\'s here section', () => {
           {...BASE_PROPS}
           presences={[makePresence()]}
           onJoinPresence={onJoinPresence}
-        />
-      )
-    })
+        />,
+      );
+    });
 
     // Invoke the onJoin passed to PresenceCard
     await act(async () => {
-      await mockPresenceCardProps[0].onJoin('presence-1')
-    })
+      await mockPresenceCardProps[0].onJoin("presence-1");
+    });
 
-    expect(onJoinPresence).toHaveBeenCalledWith('presence-1')
-    expect(confirmJoins).toHaveBeenCalledWith(expect.anything(), { poiId: 'poi-1' })
-  })
+    expect(onJoinPresence).toHaveBeenCalledWith("presence-1");
+    expect(confirmJoins).toHaveBeenCalledWith(expect.anything(), { poiId: "poi-1" });
+  });
 
-  it('does not call confirmJoins when joiner is not nearby', async () => {
+  it("does not call confirmJoins when joiner is not nearby", async () => {
     // useProximity default is isNearby: false (set in mock at top of file)
     const mockJoin: PresenceJoin = {
-      id: 'join-1', presence_id: 'presence-1', joiner_user_id: 'current-user-id',
-      joined_at: '2026-01-01T00:00:00Z', confirmed: false,
-    }
-    const onJoinPresence = jest.fn().mockResolvedValue(mockJoin)
+      id: "join-1",
+      presence_id: "presence-1",
+      joiner_user_id: "current-user-id",
+      joined_at: "2026-01-01T00:00:00Z",
+      confirmed: false,
+    };
+    const onJoinPresence = jest.fn().mockResolvedValue(mockJoin);
 
     act(() => {
       create(
@@ -291,29 +298,29 @@ describe('PoiBottomSheet — Who\'s here section', () => {
           {...BASE_PROPS}
           presences={[makePresence()]}
           onJoinPresence={onJoinPresence}
-        />
-      )
-    })
+        />,
+      );
+    });
 
     await act(async () => {
-      await mockPresenceCardProps[0].onJoin('presence-1')
-    })
+      await mockPresenceCardProps[0].onJoin("presence-1");
+    });
 
-    expect(onJoinPresence).toHaveBeenCalledWith('presence-1')
-    expect(confirmJoins).not.toHaveBeenCalled()
-  })
+    expect(onJoinPresence).toHaveBeenCalledWith("presence-1");
+    expect(confirmJoins).not.toHaveBeenCalled();
+  });
 
-  it('passes getJoinForPresence result to PresenceCard as existingJoin', () => {
+  it("passes getJoinForPresence result to PresenceCard as existingJoin", () => {
     const mockJoin: PresenceJoin = {
-      id: 'join-1',
-      presence_id: 'presence-1',
-      joiner_user_id: 'current-user-id',
-      joined_at: '2026-01-01T00:00:00Z',
+      id: "join-1",
+      presence_id: "presence-1",
+      joiner_user_id: "current-user-id",
+      joined_at: "2026-01-01T00:00:00Z",
       confirmed: false,
-    }
+    };
     const getJoinForPresence = jest.fn((id: string) =>
-      id === 'presence-1' ? mockJoin : undefined
-    )
+      id === "presence-1" ? mockJoin : undefined,
+    );
 
     act(() => {
       create(
@@ -321,11 +328,11 @@ describe('PoiBottomSheet — Who\'s here section', () => {
           {...BASE_PROPS}
           presences={[makePresence()]}
           getJoinForPresence={getJoinForPresence}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    expect(getJoinForPresence).toHaveBeenCalledWith('presence-1')
-    expect(mockPresenceCardProps[0].existingJoin).toEqual(mockJoin)
-  })
-})
+    expect(getJoinForPresence).toHaveBeenCalledWith("presence-1");
+    expect(mockPresenceCardProps[0].existingJoin).toEqual(mockJoin);
+  });
+});

--- a/components/map/__tests__/PoiListRow.test.tsx
+++ b/components/map/__tests__/PoiListRow.test.tsx
@@ -5,87 +5,86 @@
  * and onPress(poi) wiring.
  */
 
-import React from 'react'
-import { Text } from 'react-native'
-import { act, create, ReactTestInstance } from 'react-test-renderer'
-import { PoiListRow } from '../PoiListRow'
-import { CATEGORY_LABELS } from '@/lib/poiCategories'
-import { Tables } from '@/types/supabase'
+import React from "react";
+import { Text } from "react-native";
+import { act, create, ReactTestInstance } from "react-test-renderer";
+import { PoiListRow } from "../PoiListRow";
+import { CATEGORY_LABELS } from "@/lib/poiCategories";
+import { Tables } from "@/types/supabase";
 
-type Poi = Tables<'pois'>
+type Poi = Tables<"pois">;
 
 function makePoi(overrides: Partial<Poi> = {}): Poi {
   return {
-    id: 'poi-1',
-    name: 'Test Cafe',
-    category: 'food_drink',
+    id: "poi-1",
+    name: "Test Cafe",
+    category: "food_drink",
     lat: 55.6761,
     lng: 12.5683,
     description: null,
-    created_by: 'user-1',
-    created_at: '2025-01-01T00:00:00Z',
+    created_by: "user-1",
+    created_at: "2025-01-01T00:00:00Z",
     ...overrides,
-  } as Poi
+  } as Poi;
 }
 
 function findTexts(root: ReturnType<typeof create>): string[] {
-  return root.root
-    .findAllByType(Text)
-    .map((n: ReactTestInstance) => String(n.props.children))
+  return root.root.findAllByType(Text).map((n: ReactTestInstance) => String(n.props.children));
 }
 
-describe('PoiListRow', () => {
+describe("PoiListRow", () => {
   it('shows "No ratings" when avgRating is null', () => {
-    const poi = makePoi()
-    let root: ReturnType<typeof create>
+    const poi = makePoi();
+    let root: ReturnType<typeof create>;
 
     act(() => {
-      root = create(<PoiListRow poi={poi} avgRating={null} onPress={jest.fn()} />)
-    })
+      root = create(<PoiListRow poi={poi} avgRating={null} onPress={jest.fn()} />);
+    });
 
-    expect(findTexts(root!)).toContain('No ratings')
-  })
+    expect(findTexts(root!)).toContain("No ratings");
+  });
 
-  it('formats avgRating with one decimal and a star when not null', () => {
-    const poi = makePoi()
-    let root: ReturnType<typeof create>
-
-    act(() => {
-      root = create(<PoiListRow poi={poi} avgRating={4.567} onPress={jest.fn()} />)
-    })
-
-    expect(findTexts(root!)).toContain('★ 4.6')
-  })
-
-  it('shows the correct category label from CATEGORY_LABELS', () => {
-    const poi = makePoi({ category: 'nightlife' })
-    let root: ReturnType<typeof create>
+  it("formats avgRating with one decimal and a star when not null", () => {
+    const poi = makePoi();
+    let root: ReturnType<typeof create>;
 
     act(() => {
-      root = create(<PoiListRow poi={poi} avgRating={null} onPress={jest.fn()} />)
-    })
+      root = create(<PoiListRow poi={poi} avgRating={4.567} onPress={jest.fn()} />);
+    });
 
-    expect(findTexts(root!)).toContain(CATEGORY_LABELS['nightlife'])
-  })
+    expect(findTexts(root!)).toContain("★ 4.6");
+  });
 
-  it('calls onPress with the poi when the row is pressed', () => {
-    const onPress = jest.fn()
-    const poi = makePoi({ id: 'poi-press', name: 'Pressed Cafe' })
-    let root: ReturnType<typeof create>
+  it("shows the correct category label from CATEGORY_LABELS", () => {
+    const poi = makePoi({ category: "nightlife" });
+    let root: ReturnType<typeof create>;
 
     act(() => {
-      root = create(<PoiListRow poi={poi} avgRating={null} onPress={onPress} />)
-    })
+      root = create(<PoiListRow poi={poi} avgRating={null} onPress={jest.fn()} />);
+    });
+
+    expect(findTexts(root!)).toContain(CATEGORY_LABELS["nightlife"]);
+  });
+
+  it("calls onPress with the poi when the row is pressed", () => {
+    const onPress = jest.fn();
+    const poi = makePoi({ id: "poi-press", name: "Pressed Cafe" });
+    let root: ReturnType<typeof create>;
+
+    act(() => {
+      root = create(<PoiListRow poi={poi} avgRating={null} onPress={onPress} />);
+    });
 
     const pressable = root!.root.findAll(
-      (n: ReactTestInstance) => n.props.testID === 'poi-list-row' && typeof n.props.onPress === 'function'
-    )[0]
+      (n: ReactTestInstance) =>
+        n.props.testID === "poi-list-row" && typeof n.props.onPress === "function",
+    )[0];
 
     act(() => {
-      pressable.props.onPress()
-    })
+      pressable.props.onPress();
+    });
 
-    expect(onPress).toHaveBeenCalledTimes(1)
-    expect(onPress).toHaveBeenCalledWith(poi)
-  })
-})
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onPress).toHaveBeenCalledWith(poi);
+  });
+});

--- a/components/map/__tests__/PoiListView.test.tsx
+++ b/components/map/__tests__/PoiListView.test.tsx
@@ -5,111 +5,105 @@
  * No @testing-library/react-native required.
  */
 
-import React from 'react'
-import { act, create, ReactTestInstance } from 'react-test-renderer'
-import { PoiListView } from '../PoiListView'
-import { PoiListRow } from '../PoiListRow'
-import { Tables } from '@/types/supabase'
+import React from "react";
+import { act, create, ReactTestInstance } from "react-test-renderer";
+import { PoiListView } from "../PoiListView";
+import { PoiListRow } from "../PoiListRow";
+import { Tables } from "@/types/supabase";
 
-type Poi = Tables<'pois'>
+type Poi = Tables<"pois">;
 
 function makePoi(overrides: Partial<Poi> = {}): Poi {
   return {
-    id: 'poi-1',
-    name: 'Test Cafe',
-    category: 'food_drink',
+    id: "poi-1",
+    name: "Test Cafe",
+    category: "food_drink",
     lat: 55.6761,
     lng: 12.5683,
     description: null,
-    created_by: 'user-1',
-    created_at: '2025-01-01T00:00:00Z',
+    created_by: "user-1",
+    created_at: "2025-01-01T00:00:00Z",
     ...overrides,
-  } as Poi
+  } as Poi;
 }
 
-describe('PoiListView', () => {
-  it('renders the empty state when pois array is empty', () => {
-    let root: ReturnType<typeof create>
+describe("PoiListView", () => {
+  it("renders the empty state when pois array is empty", () => {
+    let root: ReturnType<typeof create>;
 
     act(() => {
-      root = create(
-        <PoiListView pois={[]} avgRatings={{}} onPoiPress={jest.fn()} />
-      )
-    })
+      root = create(<PoiListView pois={[]} avgRatings={{}} onPoiPress={jest.fn()} />);
+    });
 
     // Verify the empty container is present by testID.
     // findAll returns both the React component node and the host node, so check > 0.
-    const emptyNodes = root!.root.findAll((n: ReactTestInstance) => n.props.testID === 'poi-list-empty')
-    expect(emptyNodes.length).toBeGreaterThan(0)
-  })
+    const emptyNodes = root!.root.findAll(
+      (n: ReactTestInstance) => n.props.testID === "poi-list-empty",
+    );
+    expect(emptyNodes.length).toBeGreaterThan(0);
+  });
 
-  it('wires onPoiPress and poi to each PoiListRow', () => {
-    const onPress = jest.fn()
-    const poi = makePoi({ id: 'poi-abc', name: 'Paludan Bogcafé' })
+  it("wires onPoiPress and poi to each PoiListRow", () => {
+    const onPress = jest.fn();
+    const poi = makePoi({ id: "poi-abc", name: "Paludan Bogcafé" });
 
-    let root: ReturnType<typeof create>
+    let root: ReturnType<typeof create>;
 
     act(() => {
-      root = create(
-        <PoiListView pois={[poi]} avgRatings={{}} onPoiPress={onPress} />
-      )
-    })
+      root = create(<PoiListView pois={[poi]} avgRatings={{}} onPoiPress={onPress} />);
+    });
 
     // Assert prop wiring directly on the React component instance.
     // PoiListView is responsible for passing the right props to PoiListRow;
     // PoiListRow's own Pressable behaviour is its own concern.
-    const row = root!.root.findByType(PoiListRow)
-    expect(row.props.onPress).toBe(onPress)
-    expect(row.props.poi).toEqual(poi)
-  })
+    const row = root!.root.findByType(PoiListRow);
+    expect(row.props.onPress).toBe(onPress);
+    expect(row.props.poi).toEqual(poi);
+  });
 
-  it('forwards the correct avgRating from avgRatings map to each row', () => {
-    const poi = makePoi({ id: 'poi-abc', name: 'Test Cafe' })
+  it("forwards the correct avgRating from avgRatings map to each row", () => {
+    const poi = makePoi({ id: "poi-abc", name: "Test Cafe" });
 
-    let root: ReturnType<typeof create>
-
-    act(() => {
-      root = create(
-        <PoiListView pois={[poi]} avgRatings={{ 'poi-abc': 4.5 }} onPoiPress={jest.fn()} />
-      )
-    })
-
-    const row = root!.root.findByType(PoiListRow)
-    expect(row.props.avgRating).toBe(4.5)
-  })
-
-  it('passes null avgRating when POI has no entry in avgRatings', () => {
-    const poi = makePoi({ id: 'poi-xyz' })
-
-    let root: ReturnType<typeof create>
+    let root: ReturnType<typeof create>;
 
     act(() => {
       root = create(
-        <PoiListView pois={[poi]} avgRatings={{}} onPoiPress={jest.fn()} />
-      )
-    })
+        <PoiListView pois={[poi]} avgRatings={{ "poi-abc": 4.5 }} onPoiPress={jest.fn()} />,
+      );
+    });
 
-    const row = root!.root.findByType(PoiListRow)
-    expect(row.props.avgRating).toBeNull()
-  })
+    const row = root!.root.findByType(PoiListRow);
+    expect(row.props.avgRating).toBe(4.5);
+  });
 
-  it('renders one row per POI', () => {
+  it("passes null avgRating when POI has no entry in avgRatings", () => {
+    const poi = makePoi({ id: "poi-xyz" });
+
+    let root: ReturnType<typeof create>;
+
+    act(() => {
+      root = create(<PoiListView pois={[poi]} avgRatings={{}} onPoiPress={jest.fn()} />);
+    });
+
+    const row = root!.root.findByType(PoiListRow);
+    expect(row.props.avgRating).toBeNull();
+  });
+
+  it("renders one row per POI", () => {
     const pois = [
-      makePoi({ id: 'poi-1', name: 'Cafe 1' }),
-      makePoi({ id: 'poi-2', name: 'Cafe 2' }),
-      makePoi({ id: 'poi-3', name: 'Cafe 3' }),
-    ]
+      makePoi({ id: "poi-1", name: "Cafe 1" }),
+      makePoi({ id: "poi-2", name: "Cafe 2" }),
+      makePoi({ id: "poi-3", name: "Cafe 3" }),
+    ];
 
-    let root: ReturnType<typeof create>
+    let root: ReturnType<typeof create>;
 
     act(() => {
-      root = create(
-        <PoiListView pois={pois} avgRatings={{}} onPoiPress={jest.fn()} />
-      )
-    })
+      root = create(<PoiListView pois={pois} avgRatings={{}} onPoiPress={jest.fn()} />);
+    });
 
     // findAllByType counts React component instances, not host nodes — one per row.
-    const rows = root!.root.findAllByType(PoiListRow)
-    expect(rows.length).toBe(3)
-  })
-})
+    const rows = root!.root.findAllByType(PoiListRow);
+    expect(rows.length).toBe(3);
+  });
+});

--- a/components/map/__tests__/PresenceBubble.test.tsx
+++ b/components/map/__tests__/PresenceBubble.test.tsx
@@ -1,86 +1,106 @@
-import React from 'react'
-import { Image } from 'react-native'
-import { act, create, ReactTestInstance } from 'react-test-renderer'
-import { PresenceBubble } from '../PresenceBubble'
+import React from "react";
+import { Image } from "react-native";
+import { act, create, ReactTestInstance } from "react-test-renderer";
+import { PresenceBubble } from "../PresenceBubble";
 
-describe('PresenceBubble', () => {
-  it('renders two-letter initials for a two-word name', () => {
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<PresenceBubble displayName="Jane Doe" avatarUrl={null} />) })
+describe("PresenceBubble", () => {
+  it("renders two-letter initials for a two-word name", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<PresenceBubble displayName="Jane Doe" avatarUrl={null} />);
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    const initialsNode = texts.find((n) => String(n.props.children).match(/^[A-Z]{1,2}$/))
-    expect(initialsNode?.props.children).toBe('JD')
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    const initialsNode = texts.find((n) => String(n.props.children).match(/^[A-Z]{1,2}$/));
+    expect(initialsNode?.props.children).toBe("JD");
+  });
 
-  it('renders a single initial for a single-word name', () => {
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<PresenceBubble displayName="Jane" avatarUrl={null} />) })
+  it("renders a single initial for a single-word name", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<PresenceBubble displayName="Jane" avatarUrl={null} />);
+    });
 
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    const initialsNode = texts.find((n) => String(n.props.children).match(/^[A-Z]{1,2}$/))
-    expect(initialsNode?.props.children).toBe('J')
-  })
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    const initialsNode = texts.find((n) => String(n.props.children).match(/^[A-Z]{1,2}$/));
+    expect(initialsNode?.props.children).toBe("J");
+  });
 
-  it('renders an Image when avatarUrl is provided', () => {
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<PresenceBubble displayName="Jane Doe" avatarUrl="https://example.com/avatar.png" />) })
+  it("renders an Image when avatarUrl is provided", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(
+        <PresenceBubble displayName="Jane Doe" avatarUrl="https://example.com/avatar.png" />,
+      );
+    });
 
-    const images = root!.root.findAllByType(Image)
-    expect(images.length).toBeGreaterThan(0)
-    expect(images[0].props.source.uri).toBe('https://example.com/avatar.png')
-  })
+    const images = root!.root.findAllByType(Image);
+    expect(images.length).toBeGreaterThan(0);
+    expect(images[0].props.source.uri).toBe("https://example.com/avatar.png");
+  });
 
-  it('renders initials (no Image) when avatarUrl is null', () => {
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<PresenceBubble displayName="Jane Doe" avatarUrl={null} />) })
+  it("renders initials (no Image) when avatarUrl is null", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<PresenceBubble displayName="Jane Doe" avatarUrl={null} />);
+    });
 
-    const images = root!.root.findAllByType(Image)
-    expect(images.length).toBe(0)
-  })
+    const images = root!.root.findAllByType(Image);
+    expect(images.length).toBe(0);
+  });
 
-  it('falls back to initials when the avatar image fails to load', () => {
-    let root: ReturnType<typeof create>
-    act(() => { root = create(<PresenceBubble displayName="Jane Doe" avatarUrl="https://example.com/avatar.png" />) })
+  it("falls back to initials when the avatar image fails to load", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(
+        <PresenceBubble displayName="Jane Doe" avatarUrl="https://example.com/avatar.png" />,
+      );
+    });
 
     // Initially renders an Image
-    expect(root!.root.findAllByType(Image).length).toBeGreaterThan(0)
+    expect(root!.root.findAllByType(Image).length).toBeGreaterThan(0);
 
     // Simulate image load error
-    act(() => { root!.root.findAllByType(Image)[0].props.onError() })
+    act(() => {
+      root!.root.findAllByType(Image)[0].props.onError();
+    });
 
     // Image gone; initials rendered
-    expect(root!.root.findAllByType(Image).length).toBe(0)
-    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    const initialsNode = texts.find((n) => String(n.props.children).match(/^[A-Z]{1,2}$/))
-    expect(initialsNode?.props.children).toBe('JD')
-  })
+    expect(root!.root.findAllByType(Image).length).toBe(0);
+    const texts = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === "Text");
+    const initialsNode = texts.find((n) => String(n.props.children).match(/^[A-Z]{1,2}$/));
+    expect(initialsNode?.props.children).toBe("JD");
+  });
 
-  it('produces the same background color for the same display name', () => {
-    let root1: ReturnType<typeof create>
-    let root2: ReturnType<typeof create>
-    act(() => { root1 = create(<PresenceBubble displayName="Jane Doe" avatarUrl={null} />) })
-    act(() => { root2 = create(<PresenceBubble displayName="Jane Doe" avatarUrl={null} />) })
+  it("produces the same background color for the same display name", () => {
+    let root1: ReturnType<typeof create>;
+    let root2: ReturnType<typeof create>;
+    act(() => {
+      root1 = create(<PresenceBubble displayName="Jane Doe" avatarUrl={null} />);
+    });
+    act(() => {
+      root2 = create(<PresenceBubble displayName="Jane Doe" avatarUrl={null} />);
+    });
 
     // style may be an array — flatten to find backgroundColor across all style objects
     const getBgColor = (style: unknown): string | undefined => {
       if (Array.isArray(style)) {
         for (const s of style) {
-          const c = getBgColor(s)
-          if (c) return c
+          const c = getBgColor(s);
+          if (c) return c;
         }
-        return undefined
+        return undefined;
       }
-      return (style as Record<string, unknown> | null)?.backgroundColor as string | undefined
-    }
+      return (style as Record<string, unknown> | null)?.backgroundColor as string | undefined;
+    };
 
     const getColor = (root: ReturnType<typeof create>) =>
       root.root
-        .findAll((n: ReactTestInstance) => (n.type as string) === 'View')
+        .findAll((n: ReactTestInstance) => (n.type as string) === "View")
         .map((n) => getBgColor(n.props.style))
-        .find((c) => c !== undefined)
+        .find((c) => c !== undefined);
 
-    expect(getColor(root1!)).toBe(getColor(root2!))
-    expect(getColor(root1!)).toBeDefined()
-  })
-})
+    expect(getColor(root1!)).toBe(getColor(root2!));
+    expect(getColor(root1!)).toBeDefined();
+  });
+});

--- a/components/map/__tests__/PresenceCard.test.tsx
+++ b/components/map/__tests__/PresenceCard.test.tsx
@@ -1,43 +1,43 @@
-import React from 'react'
-import { ActivityIndicator, Text, TouchableOpacity } from 'react-native'
-import { act, create, ReactTestInstance } from 'react-test-renderer'
-import { PresenceCard } from '../PresenceCard'
-import { LivePresenceEntry } from '@/hooks/useLivePresences'
-import { PresenceJoin } from '@/lib/presenceJoins'
+import React from "react";
+import { ActivityIndicator, Text, TouchableOpacity } from "react-native";
+import { act, create, ReactTestInstance } from "react-test-renderer";
+import { PresenceCard } from "../PresenceCard";
+import { LivePresenceEntry } from "@/hooks/useLivePresences";
+import { PresenceJoin } from "@/lib/presenceJoins";
 
 // PresenceBubble renders a native View+Text or Image — no mock needed
 
 const MOCK_PRESENCE: LivePresenceEntry = {
-  id: 'p-1',
-  userId: 'u-2',
-  poiId: 'poi-1',
-  displayName: 'Jane Doe',
+  id: "p-1",
+  userId: "u-2",
+  poiId: "poi-1",
+  displayName: "Jane Doe",
   avatarUrl: null,
-  message: 'grabbing coffee',
-}
+  message: "grabbing coffee",
+};
 
 const MOCK_JOIN: PresenceJoin = {
-  id: 'j-1',
-  presence_id: 'p-1',
-  joiner_user_id: 'u-1',
-  joined_at: '2026-01-01T00:00:00Z',
+  id: "j-1",
+  presence_id: "p-1",
+  joiner_user_id: "u-1",
+  joined_at: "2026-01-01T00:00:00Z",
   confirmed: false,
-}
+};
 
 const MOCK_JOIN_CONFIRMED: PresenceJoin = {
   ...MOCK_JOIN,
   confirmed: true,
-}
+};
 
 function findTexts(root: ReturnType<typeof create>): string[] {
   return root.root
-    .findAll((n: ReactTestInstance) => (n.type as string) === 'Text')
-    .map((n) => String(n.props.children))
+    .findAll((n: ReactTestInstance) => (n.type as string) === "Text")
+    .map((n) => String(n.props.children));
 }
 
-describe('PresenceCard', () => {
-  it('renders display name and message', () => {
-    let root: ReturnType<typeof create>
+describe("PresenceCard", () => {
+  it("renders display name and message", () => {
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -46,17 +46,17 @@ describe('PresenceCard', () => {
           onJoin={jest.fn()}
           onCancel={jest.fn()}
           isOwnPresence={false}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const texts = findTexts(root!)
-    expect(texts).toContain('Jane Doe')
-    expect(texts).toContain('grabbing coffee')
-  })
+    const texts = findTexts(root!);
+    expect(texts).toContain("Jane Doe");
+    expect(texts).toContain("grabbing coffee");
+  });
 
-  it('renders Join [firstName] button when not joined', () => {
-    let root: ReturnType<typeof create>
+  it("renders Join [firstName] button when not joined", () => {
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -65,16 +65,16 @@ describe('PresenceCard', () => {
           onJoin={jest.fn()}
           onCancel={jest.fn()}
           isOwnPresence={false}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const texts = findTexts(root!)
-    expect(texts.some((t) => t.includes('Join Jane'))).toBe(true)
-  })
+    const texts = findTexts(root!);
+    expect(texts.some((t) => t.includes("Join Jane"))).toBe(true);
+  });
 
-  it('renders On my way and Cancel when existingJoin is provided', () => {
-    let root: ReturnType<typeof create>
+  it("renders On my way and Cancel when existingJoin is provided", () => {
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -83,19 +83,19 @@ describe('PresenceCard', () => {
           onJoin={jest.fn()}
           onCancel={jest.fn()}
           isOwnPresence={false}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const texts = findTexts(root!)
-    expect(texts).toContain('On my way')
-    expect(texts).toContain('Cancel')
-  })
+    const texts = findTexts(root!);
+    expect(texts).toContain("On my way");
+    expect(texts).toContain("Cancel");
+  });
 
-  it('calls onJoin with presenceId when Join button is pressed', async () => {
-    const onJoin = jest.fn().mockResolvedValue(undefined)
+  it("calls onJoin with presenceId when Join button is pressed", async () => {
+    const onJoin = jest.fn().mockResolvedValue(undefined);
 
-    let root: ReturnType<typeof create>
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -104,25 +104,27 @@ describe('PresenceCard', () => {
           onJoin={onJoin}
           onCancel={jest.fn()}
           isOwnPresence={false}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const touchables = root!.root.findAllByType(TouchableOpacity);
     const joinButton = touchables.find((n) => {
-      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
-      return texts.some((t) => String(t.props.children).includes('Join'))
-    })
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === "Text");
+      return texts.some((t) => String(t.props.children).includes("Join"));
+    });
 
-    await act(async () => { joinButton!.props.onPress() })
+    await act(async () => {
+      joinButton!.props.onPress();
+    });
 
-    expect(onJoin).toHaveBeenCalledWith('p-1')
-  })
+    expect(onJoin).toHaveBeenCalledWith("p-1");
+  });
 
-  it('calls onCancel with joinId when Cancel button is pressed', async () => {
-    const onCancel = jest.fn().mockResolvedValue(undefined)
+  it("calls onCancel with joinId when Cancel button is pressed", async () => {
+    const onCancel = jest.fn().mockResolvedValue(undefined);
 
-    let root: ReturnType<typeof create>
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -131,23 +133,25 @@ describe('PresenceCard', () => {
           onJoin={jest.fn()}
           onCancel={onCancel}
           isOwnPresence={false}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const touchables = root!.root.findAllByType(TouchableOpacity);
     const cancelButton = touchables.find((n) => {
-      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
-      return texts.some((t) => String(t.props.children) === 'Cancel')
-    })
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === "Text");
+      return texts.some((t) => String(t.props.children) === "Cancel");
+    });
 
-    await act(async () => { cancelButton!.props.onPress() })
+    await act(async () => {
+      cancelButton!.props.onPress();
+    });
 
-    expect(onCancel).toHaveBeenCalledWith('j-1')
-  })
+    expect(onCancel).toHaveBeenCalledWith("j-1");
+  });
 
-  it('does not render action button when isOwnPresence is true', () => {
-    let root: ReturnType<typeof create>
+  it("does not render action button when isOwnPresence is true", () => {
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -156,21 +160,25 @@ describe('PresenceCard', () => {
           onJoin={jest.fn()}
           onCancel={jest.fn()}
           isOwnPresence={true}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const texts = findTexts(root!)
-    expect(texts.some((t) => t.includes('Join'))).toBe(false)
-    expect(texts).not.toContain('Cancel')
-    expect(texts).not.toContain('On my way')
-  })
+    const texts = findTexts(root!);
+    expect(texts.some((t) => t.includes("Join"))).toBe(false);
+    expect(texts).not.toContain("Cancel");
+    expect(texts).not.toContain("On my way");
+  });
 
-  it('shows ActivityIndicator while operation is in progress', async () => {
-    let resolveJoin!: () => void
-    const onJoin = jest.fn().mockReturnValue(new Promise<void>((r) => { resolveJoin = r }))
+  it("shows ActivityIndicator while operation is in progress", async () => {
+    let resolveJoin!: () => void;
+    const onJoin = jest.fn().mockReturnValue(
+      new Promise<void>((r) => {
+        resolveJoin = r;
+      }),
+    );
 
-    let root: ReturnType<typeof create>
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -179,29 +187,37 @@ describe('PresenceCard', () => {
           onJoin={onJoin}
           onCancel={jest.fn()}
           isOwnPresence={false}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const touchables = root!.root.findAllByType(TouchableOpacity);
     const joinButton = touchables.find((n) => {
-      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
-      return texts.some((t) => String(t.props.children).includes('Join'))
-    })
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === "Text");
+      return texts.some((t) => String(t.props.children).includes("Join"));
+    });
 
-    act(() => { joinButton!.props.onPress() })
+    act(() => {
+      joinButton!.props.onPress();
+    });
 
-    expect(root!.root.findAllByType(ActivityIndicator).length).toBeGreaterThan(0)
+    expect(root!.root.findAllByType(ActivityIndicator).length).toBeGreaterThan(0);
 
     // Clean up
-    await act(async () => { resolveJoin() })
-  })
+    await act(async () => {
+      resolveJoin();
+    });
+  });
 
-  it('shows ActivityIndicator while cancel is in progress', async () => {
-    let resolveCancel!: () => void
-    const onCancel = jest.fn().mockReturnValue(new Promise<void>((r) => { resolveCancel = r }))
+  it("shows ActivityIndicator while cancel is in progress", async () => {
+    let resolveCancel!: () => void;
+    const onCancel = jest.fn().mockReturnValue(
+      new Promise<void>((r) => {
+        resolveCancel = r;
+      }),
+    );
 
-    let root: ReturnType<typeof create>
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -210,28 +226,32 @@ describe('PresenceCard', () => {
           onJoin={jest.fn()}
           onCancel={onCancel}
           isOwnPresence={false}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const touchables = root!.root.findAllByType(TouchableOpacity);
     const cancelButton = touchables.find((n) => {
-      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
-      return texts.some((t) => String(t.props.children) === 'Cancel')
-    })
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === "Text");
+      return texts.some((t) => String(t.props.children) === "Cancel");
+    });
 
-    act(() => { cancelButton!.props.onPress() })
+    act(() => {
+      cancelButton!.props.onPress();
+    });
 
-    expect(root!.root.findAllByType(ActivityIndicator).length).toBeGreaterThan(0)
+    expect(root!.root.findAllByType(ActivityIndicator).length).toBeGreaterThan(0);
 
     // Clean up
-    await act(async () => { resolveCancel() })
-  })
+    await act(async () => {
+      resolveCancel();
+    });
+  });
 
-  it('does not render message text when message is null', () => {
-    const presence: LivePresenceEntry = { ...MOCK_PRESENCE, message: null }
+  it("does not render message text when message is null", () => {
+    const presence: LivePresenceEntry = { ...MOCK_PRESENCE, message: null };
 
-    let root: ReturnType<typeof create>
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -240,20 +260,20 @@ describe('PresenceCard', () => {
           onJoin={jest.fn()}
           onCancel={jest.fn()}
           isOwnPresence={false}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const texts = findTexts(root!)
+    const texts = findTexts(root!);
     // displayName is still shown, but no message line
-    expect(texts).toContain('Jane Doe')
-    expect(texts.filter((t) => t === 'grabbing coffee').length).toBe(0)
-  })
+    expect(texts).toContain("Jane Doe");
+    expect(texts.filter((t) => t === "grabbing coffee").length).toBe(0);
+  });
 
-  it('shows inline error and resets busy when onJoin rejects', async () => {
-    const onJoin = jest.fn().mockRejectedValue(new Error('network failure'))
+  it("shows inline error and resets busy when onJoin rejects", async () => {
+    const onJoin = jest.fn().mockRejectedValue(new Error("network failure"));
 
-    let root: ReturnType<typeof create>
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -262,31 +282,33 @@ describe('PresenceCard', () => {
           onJoin={onJoin}
           onCancel={jest.fn()}
           isOwnPresence={false}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const touchables = root!.root.findAllByType(TouchableOpacity);
     const joinButton = touchables.find((n) => {
-      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
-      return texts.some((t) => String(t.props.children).includes('Join'))
-    })
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === "Text");
+      return texts.some((t) => String(t.props.children).includes("Join"));
+    });
 
-    await act(async () => { joinButton!.props.onPress() })
+    await act(async () => {
+      joinButton!.props.onPress();
+    });
 
     // busy resets to false — ActivityIndicator should be gone
-    expect(root!.root.findAllByType(ActivityIndicator).length).toBe(0)
+    expect(root!.root.findAllByType(ActivityIndicator).length).toBe(0);
     // error shown inline
     const errorNode = root!.root
       .findAllByType(Text)
-      .find((n: ReactTestInstance) => String(n.props.children).includes('Could not join'))
-    expect(errorNode).toBeDefined()
-  })
+      .find((n: ReactTestInstance) => String(n.props.children).includes("Could not join"));
+    expect(errorNode).toBeDefined();
+  });
 
   it('shows already-joined message inline when error includes "already joined"', async () => {
-    const onJoin = jest.fn().mockRejectedValue(new Error('You have already joined this person.'))
+    const onJoin = jest.fn().mockRejectedValue(new Error("You have already joined this person."));
 
-    let root: ReturnType<typeof create>
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -295,26 +317,31 @@ describe('PresenceCard', () => {
           onJoin={onJoin}
           onCancel={jest.fn()}
           isOwnPresence={false}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const touchables = root!.root.findAllByType(TouchableOpacity)
+    const touchables = root!.root.findAllByType(TouchableOpacity);
     const joinButton = touchables.find((n) => {
-      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === 'Text')
-      return texts.some((t) => String(t.props.children).includes('Join'))
-    })
+      const texts = n.findAll((c: ReactTestInstance) => (c.type as string) === "Text");
+      return texts.some((t) => String(t.props.children).includes("Join"));
+    });
 
-    await act(async () => { joinButton!.props.onPress() })
+    await act(async () => {
+      joinButton!.props.onPress();
+    });
 
     const errorNode = root!.root
       .findAllByType(Text)
-      .find((n: ReactTestInstance) => String(n.props.children) === 'You have already joined this person.')
-    expect(errorNode).toBeDefined()
-  })
+      .find(
+        (n: ReactTestInstance) =>
+          String(n.props.children) === "You have already joined this person.",
+      );
+    expect(errorNode).toBeDefined();
+  });
 
-  it('renders Arrived when existingJoin is confirmed', () => {
-    let root: ReturnType<typeof create>
+  it("renders Arrived when existingJoin is confirmed", () => {
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -323,19 +350,19 @@ describe('PresenceCard', () => {
           onJoin={jest.fn()}
           onCancel={jest.fn()}
           isOwnPresence={false}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const texts = findTexts(root!)
-    expect(texts).toContain('Arrived')
-    expect(texts).not.toContain('On my way')
-    expect(texts).not.toContain('Cancel')
-    expect(texts.some((t) => t.includes('Join'))).toBe(false)
-  })
+    const texts = findTexts(root!);
+    expect(texts).toContain("Arrived");
+    expect(texts).not.toContain("On my way");
+    expect(texts).not.toContain("Cancel");
+    expect(texts.some((t) => t.includes("Join"))).toBe(false);
+  });
 
-  it('renders no action buttons when confirmed join exists', () => {
-    let root: ReturnType<typeof create>
+  it("renders no action buttons when confirmed join exists", () => {
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -344,18 +371,18 @@ describe('PresenceCard', () => {
           onJoin={jest.fn()}
           onCancel={jest.fn()}
           isOwnPresence={false}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const texts = findTexts(root!)
-    expect(texts.some((t) => t.includes('Join'))).toBe(false)
-    expect(texts).not.toContain('Cancel')
-    expect(texts).not.toContain('On my way')
-  })
+    const texts = findTexts(root!);
+    expect(texts.some((t) => t.includes("Join"))).toBe(false);
+    expect(texts).not.toContain("Cancel");
+    expect(texts).not.toContain("On my way");
+  });
 
-  it('still renders On my way state when existingJoin is unconfirmed', () => {
-    let root: ReturnType<typeof create>
+  it("still renders On my way state when existingJoin is unconfirmed", () => {
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -364,23 +391,23 @@ describe('PresenceCard', () => {
           onJoin={jest.fn()}
           onCancel={jest.fn()}
           isOwnPresence={false}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const texts = findTexts(root!)
-    expect(texts).toContain('On my way')
-    expect(texts).toContain('Cancel')
-    expect(texts).not.toContain('Arrived')
-  })
+    const texts = findTexts(root!);
+    expect(texts).toContain("On my way");
+    expect(texts).toContain("Cancel");
+    expect(texts).not.toContain("Arrived");
+  });
 
-  it('extracts first name for Join button label', () => {
+  it("extracts first name for Join button label", () => {
     const presence: LivePresenceEntry = {
       ...MOCK_PRESENCE,
-      displayName: 'Alice Bob Carol',
-    }
+      displayName: "Alice Bob Carol",
+    };
 
-    let root: ReturnType<typeof create>
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
         <PresenceCard
@@ -389,11 +416,11 @@ describe('PresenceCard', () => {
           onJoin={jest.fn()}
           onCancel={jest.fn()}
           isOwnPresence={false}
-        />
-      )
-    })
+        />,
+      );
+    });
 
-    const texts = findTexts(root!)
-    expect(texts.some((t) => t === 'Join Alice')).toBe(true)
-  })
-})
+    const texts = findTexts(root!);
+    expect(texts.some((t) => t === "Join Alice")).toBe(true);
+  });
+});

--- a/components/map/__tests__/PresenceLayer.test.tsx
+++ b/components/map/__tests__/PresenceLayer.test.tsx
@@ -5,204 +5,239 @@
  * so we can inspect children without a native Mapbox context.
  */
 
-import React from 'react'
-import { act, create, ReactTestInstance } from 'react-test-renderer'
-import { PresenceLayer } from '../PresenceLayer'
-import { PresenceBubble } from '../PresenceBubble'
-import { Tables } from '@/types/supabase'
-import { LivePresenceEntry } from '@/hooks/useLivePresences'
+import React from "react";
+import { act, create, ReactTestInstance } from "react-test-renderer";
+import { PresenceLayer } from "../PresenceLayer";
+import { PresenceBubble } from "../PresenceBubble";
+import { Tables } from "@/types/supabase";
+import { LivePresenceEntry } from "@/hooks/useLivePresences";
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
-jest.mock('@rnmapbox/maps', () => {
-  const React = require('react')
+jest.mock("@rnmapbox/maps", () => {
+  const React = require("react");
   return {
     __esModule: true,
     default: {
-      MarkerView: function MockMarkerView({ children, id, coordinate, allowOverlap }: { children: React.ReactNode; id: string; coordinate: number[]; allowOverlap?: boolean }) {
-        return React.createElement('MarkerView', { id, coordinate, allowOverlap }, children)
+      MarkerView: function MockMarkerView({
+        children,
+        id,
+        coordinate,
+        allowOverlap,
+      }: {
+        children: React.ReactNode;
+        id: string;
+        coordinate: number[];
+        allowOverlap?: boolean;
+      }) {
+        return React.createElement("MarkerView", { id, coordinate, allowOverlap }, children);
       },
     },
-  }
-})
+  };
+});
 
-jest.mock('../PresenceBubble', () => ({
+jest.mock("../PresenceBubble", () => ({
   PresenceBubble: (props: { displayName: string; avatarUrl: string | null }) =>
-    require('react').createElement('PresenceBubble', props),
-}))
+    require("react").createElement("PresenceBubble", props),
+}));
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-type Poi = Tables<'pois'>
+type Poi = Tables<"pois">;
 
 function makePoi(overrides: Partial<Poi> = {}): Poi {
   return {
-    id: 'poi-1',
-    name: 'Test Cafe',
-    category: 'food_drink',
+    id: "poi-1",
+    name: "Test Cafe",
+    category: "food_drink",
     lat: 55.6761,
     lng: 12.5683,
     description: null,
-    created_by: 'user-1',
-    created_at: '2025-01-01T00:00:00Z',
+    created_by: "user-1",
+    created_at: "2025-01-01T00:00:00Z",
     ...overrides,
-  } as Poi
+  } as Poi;
 }
 
 function makePresence(overrides: Partial<LivePresenceEntry> = {}): LivePresenceEntry {
   return {
-    id: 'presence-1',
-    userId: 'user-2',
-    poiId: 'poi-1',
-    displayName: 'Jane Doe',
+    id: "presence-1",
+    userId: "user-2",
+    poiId: "poi-1",
+    displayName: "Jane Doe",
     avatarUrl: null,
     message: null,
     ...overrides,
-  }
+  };
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-describe('PresenceLayer', () => {
-  it('renders nothing when presences is empty', () => {
-    let root: ReturnType<typeof create>
+describe("PresenceLayer", () => {
+  it("renders nothing when presences is empty", () => {
+    let root: ReturnType<typeof create>;
     act(() => {
-      root = create(<PresenceLayer presences={[]} pois={[makePoi()]} onPoiPress={jest.fn()} />)
-    })
+      root = create(<PresenceLayer presences={[]} pois={[makePoi()]} onPoiPress={jest.fn()} />);
+    });
 
-    const markers = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'MarkerView')
-    expect(markers.length).toBe(0)
-  })
+    const markers = root!.root.findAll(
+      (n: ReactTestInstance) => (n.type as string) === "MarkerView",
+    );
+    expect(markers.length).toBe(0);
+  });
 
-  it('renders a MarkerView at the correct POI coordinates', () => {
-    const poi = makePoi({ id: 'poi-1', lng: 12.5683, lat: 55.6761 })
-    let root: ReturnType<typeof create>
-    act(() => {
-      root = create(
-        <PresenceLayer presences={[makePresence()]} pois={[poi]} onPoiPress={jest.fn()} />
-      )
-    })
-
-    const markers = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'MarkerView')
-    expect(markers.length).toBe(1)
-    expect(markers[0].props.coordinate).toEqual([12.5683, 55.6761])
-  })
-
-  it('renders one PresenceBubble for a single presence at a POI', () => {
-    let root: ReturnType<typeof create>
+  it("renders a MarkerView at the correct POI coordinates", () => {
+    const poi = makePoi({ id: "poi-1", lng: 12.5683, lat: 55.6761 });
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
-        <PresenceLayer presences={[makePresence()]} pois={[makePoi()]} onPoiPress={jest.fn()} />
-      )
-    })
+        <PresenceLayer presences={[makePresence()]} pois={[poi]} onPoiPress={jest.fn()} />,
+      );
+    });
 
-    const bubbles = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'PresenceBubble')
-    expect(bubbles.length).toBe(1)
-    expect(bubbles[0].props.displayName).toBe('Jane Doe')
-  })
+    const markers = root!.root.findAll(
+      (n: ReactTestInstance) => (n.type as string) === "MarkerView",
+    );
+    expect(markers.length).toBe(1);
+    expect(markers[0].props.coordinate).toEqual([12.5683, 55.6761]);
+  });
 
-  it('renders multiple bubbles in one MarkerView when several users are at the same POI', () => {
+  it("renders one PresenceBubble for a single presence at a POI", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(
+        <PresenceLayer presences={[makePresence()]} pois={[makePoi()]} onPoiPress={jest.fn()} />,
+      );
+    });
+
+    const bubbles = root!.root.findAll(
+      (n: ReactTestInstance) => (n.type as string) === "PresenceBubble",
+    );
+    expect(bubbles.length).toBe(1);
+    expect(bubbles[0].props.displayName).toBe("Jane Doe");
+  });
+
+  it("renders multiple bubbles in one MarkerView when several users are at the same POI", () => {
     const presences = [
-      makePresence({ id: 'p-1', displayName: 'Jane Doe' }),
-      makePresence({ id: 'p-2', userId: 'user-3', displayName: 'Bob Smith' }),
-    ]
-    let root: ReturnType<typeof create>
+      makePresence({ id: "p-1", displayName: "Jane Doe" }),
+      makePresence({ id: "p-2", userId: "user-3", displayName: "Bob Smith" }),
+    ];
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
-        <PresenceLayer presences={presences} pois={[makePoi()]} onPoiPress={jest.fn()} />
-      )
-    })
+        <PresenceLayer presences={presences} pois={[makePoi()]} onPoiPress={jest.fn()} />,
+      );
+    });
 
-    const markers = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'MarkerView')
-    expect(markers.length).toBe(1)
+    const markers = root!.root.findAll(
+      (n: ReactTestInstance) => (n.type as string) === "MarkerView",
+    );
+    expect(markers.length).toBe(1);
 
-    const bubbles = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'PresenceBubble')
-    expect(bubbles.length).toBe(2)
-  })
+    const bubbles = root!.root.findAll(
+      (n: ReactTestInstance) => (n.type as string) === "PresenceBubble",
+    );
+    expect(bubbles.length).toBe(2);
+  });
 
-  it('caps visible bubbles at 3 and shows an overflow pill for extras', () => {
+  it("caps visible bubbles at 3 and shows an overflow pill for extras", () => {
     const presences = Array.from({ length: 5 }, (_, i) =>
-      makePresence({ id: `p-${i}`, userId: `user-${i + 2}`, displayName: `User ${i}` })
-    )
-    let root: ReturnType<typeof create>
+      makePresence({ id: `p-${i}`, userId: `user-${i + 2}`, displayName: `User ${i}` }),
+    );
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
-        <PresenceLayer presences={presences} pois={[makePoi()]} onPoiPress={jest.fn()} />
-      )
-    })
+        <PresenceLayer presences={presences} pois={[makePoi()]} onPoiPress={jest.fn()} />,
+      );
+    });
 
-    const bubbles = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'PresenceBubble')
-    expect(bubbles.length).toBe(3)
+    const bubbles = root!.root.findAll(
+      (n: ReactTestInstance) => (n.type as string) === "PresenceBubble",
+    );
+    expect(bubbles.length).toBe(3);
 
     const texts = root!.root.findAll(
-      (n: ReactTestInstance) => (n.type as string) === 'Text' && String(n.props.children).startsWith('+')
-    )
-    expect(texts.length).toBe(1)
-    expect(texts[0].props.children).toBe('+2')
-  })
+      (n: ReactTestInstance) =>
+        (n.type as string) === "Text" && String(n.props.children).startsWith("+"),
+    );
+    expect(texts.length).toBe(1);
+    expect(texts[0].props.children).toBe("+2");
+  });
 
-  it('calls onPoiPress with the correct POI when a bubble is tapped', () => {
-    const poi = makePoi()
-    const onPoiPress = jest.fn()
-    let root: ReturnType<typeof create>
+  it("calls onPoiPress with the correct POI when a bubble is tapped", () => {
+    const poi = makePoi();
+    const onPoiPress = jest.fn();
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
-        <PresenceLayer presences={[makePresence()]} pois={[poi]} onPoiPress={onPoiPress} />
-      )
-    })
+        <PresenceLayer presences={[makePresence()]} pois={[poi]} onPoiPress={onPoiPress} />,
+      );
+    });
 
     const pressable = root!.root.findAll(
-      (n: ReactTestInstance) => typeof n.props.onPress === 'function'
-    )[0]
-    act(() => { pressable.props.onPress() })
+      (n: ReactTestInstance) => typeof n.props.onPress === "function",
+    )[0];
+    act(() => {
+      pressable.props.onPress();
+    });
 
-    expect(onPoiPress).toHaveBeenCalledWith(poi)
-  })
+    expect(onPoiPress).toHaveBeenCalledWith(poi);
+  });
 
-  it('gives separate MarkerViews to presences at different POIs', () => {
-    const poi1 = makePoi({ id: 'poi-1' })
-    const poi2 = makePoi({ id: 'poi-2', lng: 12.57, lat: 55.68 })
+  it("gives separate MarkerViews to presences at different POIs", () => {
+    const poi1 = makePoi({ id: "poi-1" });
+    const poi2 = makePoi({ id: "poi-2", lng: 12.57, lat: 55.68 });
     const presences = [
-      makePresence({ id: 'p-1', poiId: 'poi-1' }),
-      makePresence({ id: 'p-2', userId: 'user-3', poiId: 'poi-2' }),
-    ]
-    let root: ReturnType<typeof create>
+      makePresence({ id: "p-1", poiId: "poi-1" }),
+      makePresence({ id: "p-2", userId: "user-3", poiId: "poi-2" }),
+    ];
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
-        <PresenceLayer presences={presences} pois={[poi1, poi2]} onPoiPress={jest.fn()} />
-      )
-    })
+        <PresenceLayer presences={presences} pois={[poi1, poi2]} onPoiPress={jest.fn()} />,
+      );
+    });
 
-    const markers = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'MarkerView')
-    expect(markers.length).toBe(2)
-  })
+    const markers = root!.root.findAll(
+      (n: ReactTestInstance) => (n.type as string) === "MarkerView",
+    );
+    expect(markers.length).toBe(2);
+  });
 
-  it('renders MarkerView with allowOverlap so bubbles are visible at all zoom levels', () => {
-    const presence = makePresence()
-    let root: ReturnType<typeof create>
+  it("renders MarkerView with allowOverlap so bubbles are visible at all zoom levels", () => {
+    const presence = makePresence();
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
-        <PresenceLayer presences={[presence]} pois={[makePoi()]} onPoiPress={jest.fn()} />
-      )
-    })
+        <PresenceLayer presences={[presence]} pois={[makePoi()]} onPoiPress={jest.fn()} />,
+      );
+    });
 
-    const marker = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'MarkerView')[0]
-    expect(marker.props.allowOverlap).toBe(true)
-  })
+    const marker = root!.root.findAll(
+      (n: ReactTestInstance) => (n.type as string) === "MarkerView",
+    )[0];
+    expect(marker.props.allowOverlap).toBe(true);
+  });
 
-  it('skips a presence whose POI is not in the pois array', () => {
-    const presence = makePresence({ poiId: 'poi-unknown' })
-    let root: ReturnType<typeof create>
+  it("skips a presence whose POI is not in the pois array", () => {
+    const presence = makePresence({ poiId: "poi-unknown" });
+    let root: ReturnType<typeof create>;
     act(() => {
       root = create(
-        <PresenceLayer presences={[presence]} pois={[makePoi({ id: 'poi-1' })]} onPoiPress={jest.fn()} />
-      )
-    })
+        <PresenceLayer
+          presences={[presence]}
+          pois={[makePoi({ id: "poi-1" })]}
+          onPoiPress={jest.fn()}
+        />,
+      );
+    });
 
-    const markers = root!.root.findAll((n: ReactTestInstance) => (n.type as string) === 'MarkerView')
-    expect(markers.length).toBe(0)
-  })
-})
+    const markers = root!.root.findAll(
+      (n: ReactTestInstance) => (n.type as string) === "MarkerView",
+    );
+    expect(markers.length).toBe(0);
+  });
+});

--- a/hooks/__tests__/useActivePresence.test.ts
+++ b/hooks/__tests__/useActivePresence.test.ts
@@ -5,13 +5,13 @@
  * mock @/lib/supabase and @/hooks/useAuth, render with react-test-renderer.
  */
 
-import React from 'react'
-import { act, create } from 'react-test-renderer'
+import React from "react";
+import { act, create } from "react-test-renderer";
 
-const mockLimitFn = jest.fn()
-const mockUseAuth = jest.fn()
+const mockLimitFn = jest.fn();
+const mockUseAuth = jest.fn();
 
-jest.mock('@/lib/supabase', () => ({
+jest.mock("@/lib/supabase", () => ({
   supabase: {
     from: jest.fn(() => ({
       select: jest.fn(() => ({
@@ -25,148 +25,152 @@ jest.mock('@/lib/supabase', () => ({
       })),
     })),
   },
-}))
+}));
 
-jest.mock('@/hooks/useAuth', () => ({
+jest.mock("@/hooks/useAuth", () => ({
   useAuth: () => mockUseAuth(),
-}))
+}));
 
-import { useActivePresence } from '../useActivePresence'
+import { useActivePresence } from "../useActivePresence";
 
-type HookResult<T> = { current: T }
+type HookResult<T> = { current: T };
 
 function renderHook<T>(useHook: () => T): HookResult<T> {
-  const result: HookResult<T> = { current: undefined as unknown as T }
+  const result: HookResult<T> = { current: undefined as unknown as T };
 
   function TestComponent() {
-    result.current = useHook()
-    return null
+    result.current = useHook();
+    return null;
   }
 
   act(() => {
-    create(React.createElement(TestComponent))
-  })
+    create(React.createElement(TestComponent));
+  });
 
-  return result
+  return result;
 }
 
 async function flush() {
   await act(async () => {
-    await Promise.resolve()
-  })
+    await Promise.resolve();
+  });
 }
 
 const MOCK_PRESENCE_ROW = {
-  id: 'presence-1',
-  poi_id: 'poi-1',
-  message: 'grabbing coffee',
-  visible_to: 'friends' as const,
-}
+  id: "presence-1",
+  poi_id: "poi-1",
+  message: "grabbing coffee",
+  visible_to: "friends" as const,
+};
 
 beforeEach(() => {
-  jest.clearAllMocks()
-  mockUseAuth.mockReturnValue({ session: { user: { id: 'user-1' } } })
-})
+  jest.clearAllMocks();
+  mockUseAuth.mockReturnValue({ session: { user: { id: "user-1" } } });
+});
 
-describe('useActivePresence', () => {
-  it('activePresence is null when query returns no rows', async () => {
-    mockLimitFn.mockResolvedValue({ data: [], error: null })
+describe("useActivePresence", () => {
+  it("activePresence is null when query returns no rows", async () => {
+    mockLimitFn.mockResolvedValue({ data: [], error: null });
 
-    const result = renderHook(() => useActivePresence())
-    await flush()
+    const result = renderHook(() => useActivePresence());
+    await flush();
 
-    expect(result.current.activePresence).toBeNull()
-    expect(result.current.loading).toBe(false)
-  })
+    expect(result.current.activePresence).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
 
-  it('activePresence is populated when query returns a row', async () => {
-    mockLimitFn.mockResolvedValue({ data: [MOCK_PRESENCE_ROW], error: null })
+  it("activePresence is populated when query returns a row", async () => {
+    mockLimitFn.mockResolvedValue({ data: [MOCK_PRESENCE_ROW], error: null });
 
-    const result = renderHook(() => useActivePresence())
-    await flush()
+    const result = renderHook(() => useActivePresence());
+    await flush();
 
-    expect(result.current.activePresence).toEqual(MOCK_PRESENCE_ROW)
+    expect(result.current.activePresence).toEqual(MOCK_PRESENCE_ROW);
     // Fix 6: loading is false after query settles on success
-    expect(result.current.loading).toBe(false)
-  })
+    expect(result.current.loading).toBe(false);
+  });
 
-  it('setBroadcast updates activePresence locally', async () => {
-    mockLimitFn.mockResolvedValue({ data: [], error: null })
+  it("setBroadcast updates activePresence locally", async () => {
+    mockLimitFn.mockResolvedValue({ data: [], error: null });
 
-    const result = renderHook(() => useActivePresence())
-    await flush()
+    const result = renderHook(() => useActivePresence());
+    await flush();
 
-    expect(result.current.activePresence).toBeNull()
-
-    act(() => {
-      result.current.setBroadcast(MOCK_PRESENCE_ROW)
-    })
-
-    expect(result.current.activePresence).toEqual(MOCK_PRESENCE_ROW)
-  })
-
-  it('clearBroadcast sets activePresence to null', async () => {
-    mockLimitFn.mockResolvedValue({ data: [MOCK_PRESENCE_ROW], error: null })
-
-    const result = renderHook(() => useActivePresence())
-    await flush()
-
-    expect(result.current.activePresence).toEqual(MOCK_PRESENCE_ROW)
+    expect(result.current.activePresence).toBeNull();
 
     act(() => {
-      result.current.clearBroadcast()
-    })
+      result.current.setBroadcast(MOCK_PRESENCE_ROW);
+    });
 
-    expect(result.current.activePresence).toBeNull()
-  })
+    expect(result.current.activePresence).toEqual(MOCK_PRESENCE_ROW);
+  });
 
-  it('sets error state when query fails', async () => {
-    mockLimitFn.mockResolvedValue({ data: null, error: { message: 'network error' } })
+  it("clearBroadcast sets activePresence to null", async () => {
+    mockLimitFn.mockResolvedValue({ data: [MOCK_PRESENCE_ROW], error: null });
 
-    const result = renderHook(() => useActivePresence())
-    await flush()
+    const result = renderHook(() => useActivePresence());
+    await flush();
 
-    expect(result.current.error).toBe('network error')
-    expect(result.current.activePresence).toBeNull()
+    expect(result.current.activePresence).toEqual(MOCK_PRESENCE_ROW);
+
+    act(() => {
+      result.current.clearBroadcast();
+    });
+
+    expect(result.current.activePresence).toBeNull();
+  });
+
+  it("sets error state when query fails", async () => {
+    mockLimitFn.mockResolvedValue({ data: null, error: { message: "network error" } });
+
+    const result = renderHook(() => useActivePresence());
+    await flush();
+
+    expect(result.current.error).toBe("network error");
+    expect(result.current.activePresence).toBeNull();
     // Fix 6: loading is false after error path settles
-    expect(result.current.loading).toBe(false)
-  })
+    expect(result.current.loading).toBe(false);
+  });
 
-  it('activePresence is null when user is not authenticated', async () => {
-    mockUseAuth.mockReturnValue({ session: null })
+  it("activePresence is null when user is not authenticated", async () => {
+    mockUseAuth.mockReturnValue({ session: null });
 
-    const result = renderHook(() => useActivePresence())
-    await flush()
+    const result = renderHook(() => useActivePresence());
+    await flush();
 
-    expect(result.current.activePresence).toBeNull()
-    expect(result.current.loading).toBe(false)
-    expect(mockLimitFn).not.toHaveBeenCalled()
-  })
+    expect(result.current.activePresence).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(mockLimitFn).not.toHaveBeenCalled();
+  });
 
   // Fix 6: loading is true before the fetch resolves (pending promise)
-  it('loading is true before the fetch resolves', async () => {
-    let resolveQuery!: (value: { data: typeof MOCK_PRESENCE_ROW[]; error: null }) => void
+  it("loading is true before the fetch resolves", async () => {
+    let resolveQuery!: (value: { data: (typeof MOCK_PRESENCE_ROW)[]; error: null }) => void;
     mockLimitFn.mockReturnValue(
-      new Promise((resolve) => { resolveQuery = resolve })
-    )
+      new Promise((resolve) => {
+        resolveQuery = resolve;
+      }),
+    );
 
-    const result = renderHook(() => useActivePresence())
+    const result = renderHook(() => useActivePresence());
     // Do NOT flush — query is still pending
-    expect(result.current.loading).toBe(true)
+    expect(result.current.loading).toBe(true);
 
     // Resolve and clean up to avoid open handles
-    await act(async () => { resolveQuery({ data: [], error: null }) })
-    expect(result.current.loading).toBe(false)
-  })
+    await act(async () => {
+      resolveQuery({ data: [], error: null });
+    });
+    expect(result.current.loading).toBe(false);
+  });
 
   // Fix 9: data: null without an error is treated as "no active presence", not an error state
-  it('activePresence is null and error is null when data is null but no error returned', async () => {
-    mockLimitFn.mockResolvedValue({ data: null, error: null })
+  it("activePresence is null and error is null when data is null but no error returned", async () => {
+    mockLimitFn.mockResolvedValue({ data: null, error: null });
 
-    const result = renderHook(() => useActivePresence())
-    await flush()
+    const result = renderHook(() => useActivePresence());
+    await flush();
 
-    expect(result.current.activePresence).toBeNull()
-    expect(result.current.error).toBeNull()
-  })
-})
+    expect(result.current.activePresence).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/hooks/__tests__/useAllPoiRatings.test.ts
+++ b/hooks/__tests__/useAllPoiRatings.test.ts
@@ -6,137 +6,135 @@
  * (no @testing-library/react-hooks needed).
  */
 
-import React from 'react'
-import { act, create } from 'react-test-renderer'
+import React from "react";
+import { act, create } from "react-test-renderer";
 
-const mockSelectFn = jest.fn()
+const mockSelectFn = jest.fn();
 
 // jest.mock() is hoisted automatically by Jest regardless of file position,
 // so this mock applies even though useAllPoiRatings is imported below.
-jest.mock('@/lib/supabase', () => ({
+jest.mock("@/lib/supabase", () => ({
   supabase: {
     from: jest.fn(() => ({
       select: mockSelectFn,
     })),
   },
-}))
+}));
 
-import { useAllPoiRatings } from '../useAllPoiRatings'
+import { useAllPoiRatings } from "../useAllPoiRatings";
 
-type HookResult<T> = { current: T }
+type HookResult<T> = { current: T };
 
 function renderHook<T>(useHook: () => T): HookResult<T> {
-  const result: HookResult<T> = { current: undefined as unknown as T }
+  const result: HookResult<T> = { current: undefined as unknown as T };
 
   function TestComponent() {
-    result.current = useHook()
-    return null
+    result.current = useHook();
+    return null;
   }
 
   act(() => {
-    create(React.createElement(TestComponent))
-  })
+    create(React.createElement(TestComponent));
+  });
 
-  return result
+  return result;
 }
 
 async function flush() {
   await act(async () => {
-    await Promise.resolve()
-  })
+    await Promise.resolve();
+  });
 }
 
 beforeEach(() => {
-  jest.clearAllMocks()
-})
+  jest.clearAllMocks();
+});
 
-describe('useAllPoiRatings', () => {
-  it('avgRatings is empty when query returns no rows', async () => {
-    mockSelectFn.mockResolvedValue({ data: [], error: null })
+describe("useAllPoiRatings", () => {
+  it("avgRatings is empty when query returns no rows", async () => {
+    mockSelectFn.mockResolvedValue({ data: [], error: null });
 
-    const result = renderHook(() => useAllPoiRatings())
-    await flush()
+    const result = renderHook(() => useAllPoiRatings());
+    await flush();
 
-    expect(result.current.avgRatings).toEqual({})
-    expect(result.current.error).toBeNull()
-    expect(result.current.loading).toBe(false)
-  })
+    expect(result.current.avgRatings).toEqual({});
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
 
-  it('maps a pre-aggregated avg_rating row into the avgRatings record', async () => {
+  it("maps a pre-aggregated avg_rating row into the avgRatings record", async () => {
+    mockSelectFn.mockResolvedValue({
+      data: [{ poi_id: "poi-1", avg_rating: 4 }],
+      error: null,
+    });
+
+    const result = renderHook(() => useAllPoiRatings());
+    await flush();
+
+    expect(result.current.avgRatings["poi-1"]).toBe(4);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("maps pre-aggregated rows for two POIs into independent avgRatings entries", async () => {
     mockSelectFn.mockResolvedValue({
       data: [
-        { poi_id: 'poi-1', avg_rating: 4 },
+        { poi_id: "poi-1", avg_rating: 2 },
+        { poi_id: "poi-2", avg_rating: 4.5 },
       ],
       error: null,
-    })
+    });
 
-    const result = renderHook(() => useAllPoiRatings())
-    await flush()
+    const result = renderHook(() => useAllPoiRatings());
+    await flush();
 
-    expect(result.current.avgRatings['poi-1']).toBe(4)
-    expect(result.current.loading).toBe(false)
-  })
+    expect(result.current.avgRatings["poi-1"]).toBe(2);
+    expect(result.current.avgRatings["poi-2"]).toBe(4.5);
+    expect(result.current.loading).toBe(false);
+  });
 
-  it('maps pre-aggregated rows for two POIs into independent avgRatings entries', async () => {
+  it("excludes rows where avg_rating is null", async () => {
     mockSelectFn.mockResolvedValue({
       data: [
-        { poi_id: 'poi-1', avg_rating: 2 },
-        { poi_id: 'poi-2', avg_rating: 4.5 },
+        { poi_id: "poi-1", avg_rating: null },
+        { poi_id: "poi-2", avg_rating: 3.5 },
       ],
       error: null,
-    })
+    });
 
-    const result = renderHook(() => useAllPoiRatings())
-    await flush()
+    const result = renderHook(() => useAllPoiRatings());
+    await flush();
 
-    expect(result.current.avgRatings['poi-1']).toBe(2)
-    expect(result.current.avgRatings['poi-2']).toBe(4.5)
-    expect(result.current.loading).toBe(false)
-  })
+    expect(result.current.avgRatings["poi-1"]).toBeUndefined();
+    expect(result.current.avgRatings["poi-2"]).toBe(3.5);
+    expect(result.current.loading).toBe(false);
+  });
 
-  it('excludes rows where avg_rating is null', async () => {
-    mockSelectFn.mockResolvedValue({
-      data: [
-        { poi_id: 'poi-1', avg_rating: null },
-        { poi_id: 'poi-2', avg_rating: 3.5 },
-      ],
-      error: null,
-    })
-
-    const result = renderHook(() => useAllPoiRatings())
-    await flush()
-
-    expect(result.current.avgRatings['poi-1']).toBeUndefined()
-    expect(result.current.avgRatings['poi-2']).toBe(3.5)
-    expect(result.current.loading).toBe(false)
-  })
-
-  it('refetch triggers a new query and updates avgRatings', async () => {
+  it("refetch triggers a new query and updates avgRatings", async () => {
     mockSelectFn
-      .mockResolvedValueOnce({ data: [{ poi_id: 'poi-1', avg_rating: 3 }], error: null })
-      .mockResolvedValueOnce({ data: [{ poi_id: 'poi-1', avg_rating: 5 }], error: null })
+      .mockResolvedValueOnce({ data: [{ poi_id: "poi-1", avg_rating: 3 }], error: null })
+      .mockResolvedValueOnce({ data: [{ poi_id: "poi-1", avg_rating: 5 }], error: null });
 
-    const result = renderHook(() => useAllPoiRatings())
-    await flush()
+    const result = renderHook(() => useAllPoiRatings());
+    await flush();
 
-    expect(result.current.avgRatings['poi-1']).toBe(3)
+    expect(result.current.avgRatings["poi-1"]).toBe(3);
 
     await act(async () => {
-      await result.current.refetch()
-    })
+      await result.current.refetch();
+    });
 
-    expect(result.current.avgRatings['poi-1']).toBe(5)
-    expect(mockSelectFn).toHaveBeenCalledTimes(2)
-  })
+    expect(result.current.avgRatings["poi-1"]).toBe(5);
+    expect(mockSelectFn).toHaveBeenCalledTimes(2);
+  });
 
-  it('sets error and leaves avgRatings empty when query fails', async () => {
-    mockSelectFn.mockResolvedValue({ data: null, error: { message: 'network error' } })
+  it("sets error and leaves avgRatings empty when query fails", async () => {
+    mockSelectFn.mockResolvedValue({ data: null, error: { message: "network error" } });
 
-    const result = renderHook(() => useAllPoiRatings())
-    await flush()
+    const result = renderHook(() => useAllPoiRatings());
+    await flush();
 
-    expect(result.current.error).toBe('network error')
-    expect(result.current.avgRatings).toEqual({})
-    expect(result.current.loading).toBe(false)
-  })
-})
+    expect(result.current.error).toBe("network error");
+    expect(result.current.avgRatings).toEqual({});
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/hooks/__tests__/useFriendships.test.ts
+++ b/hooks/__tests__/useFriendships.test.ts
@@ -1,364 +1,417 @@
-import React from 'react'
-import { act, create } from 'react-test-renderer'
+import React from "react";
+import { act, create } from "react-test-renderer";
 
-const mockUseAuth = jest.fn()
-const mockFetchFriendships = jest.fn()
-const mockLibSendRequest = jest.fn()
-const mockLibCancelRequest = jest.fn()
-const mockLibAcceptRequest = jest.fn()
-const mockLibDeclineRequest = jest.fn()
-const mockLibUnfriend = jest.fn()
+const mockUseAuth = jest.fn();
+const mockFetchFriendships = jest.fn();
+const mockLibSendRequest = jest.fn();
+const mockLibCancelRequest = jest.fn();
+const mockLibAcceptRequest = jest.fn();
+const mockLibDeclineRequest = jest.fn();
+const mockLibUnfriend = jest.fn();
 
 const mockChannel = {
   on: jest.fn().mockReturnThis(),
   subscribe: jest.fn(),
-}
-jest.mock('@/lib/supabase', () => ({
+};
+jest.mock("@/lib/supabase", () => ({
   supabase: {
     channel: jest.fn(() => mockChannel),
     removeChannel: jest.fn(),
   },
-}))
+}));
 
-jest.mock('@/hooks/useAuth', () => ({
+jest.mock("@/hooks/useAuth", () => ({
   useAuth: () => mockUseAuth(),
-}))
+}));
 
-jest.mock('@/lib/friendships', () => ({
+jest.mock("@/lib/friendships", () => ({
   fetchFriendships: (...args: unknown[]) => mockFetchFriendships(...args),
   sendRequest: (...args: unknown[]) => mockLibSendRequest(...args),
   cancelRequest: (...args: unknown[]) => mockLibCancelRequest(...args),
   acceptRequest: (...args: unknown[]) => mockLibAcceptRequest(...args),
   declineRequest: (...args: unknown[]) => mockLibDeclineRequest(...args),
   unfriend: (...args: unknown[]) => mockLibUnfriend(...args),
-}))
+}));
 
-import { useFriendships } from '../useFriendships'
+import { useFriendships } from "../useFriendships";
 
-type HookResult<T> = { current: T }
+type HookResult<T> = { current: T };
 
 function renderHook<T>(useHook: () => T): { result: HookResult<T>; unmount: () => void } {
-  const result: HookResult<T> = { current: undefined as unknown as T }
-  let root: ReturnType<typeof create>
+  const result: HookResult<T> = { current: undefined as unknown as T };
+  let root: ReturnType<typeof create>;
   function TestComponent() {
-    result.current = useHook()
-    return null
+    result.current = useHook();
+    return null;
   }
-  act(() => { root = create(React.createElement(TestComponent)) })
-  return { result, unmount: () => act(() => { root.unmount() }) }
+  act(() => {
+    root = create(React.createElement(TestComponent));
+  });
+  return {
+    result,
+    unmount: () =>
+      act(() => {
+        root.unmount();
+      }),
+  };
 }
 
 async function flush() {
-  await act(async () => { await Promise.resolve() })
+  await act(async () => {
+    await Promise.resolve();
+  });
 }
 
-const USER_ID = 'user-me'
-const OTHER_ID = 'user-other'
-const FRIEND_ID = 'user-friend'
+const USER_ID = "user-me";
+const OTHER_ID = "user-other";
+const FRIEND_ID = "user-friend";
 
 const PENDING_SENT_ROW = {
-  id: 'fs-pending-sent',
+  id: "fs-pending-sent",
   requester_id: USER_ID,
   addressee_id: OTHER_ID,
-  status: 'pending',
-  created_at: '2026-01-01T00:00:00Z',
-  requester: { id: USER_ID, display_name: 'Me', avatar_url: null },
-  addressee: { id: OTHER_ID, display_name: 'Other', avatar_url: null },
-}
+  status: "pending",
+  created_at: "2026-01-01T00:00:00Z",
+  requester: { id: USER_ID, display_name: "Me", avatar_url: null },
+  addressee: { id: OTHER_ID, display_name: "Other", avatar_url: null },
+};
 
 const PENDING_RECEIVED_ROW = {
-  id: 'fs-pending-received',
+  id: "fs-pending-received",
   requester_id: OTHER_ID,
   addressee_id: USER_ID,
-  status: 'pending',
-  created_at: '2026-01-01T00:00:00Z',
-  requester: { id: OTHER_ID, display_name: 'Other', avatar_url: null },
-  addressee: { id: USER_ID, display_name: 'Me', avatar_url: null },
-}
+  status: "pending",
+  created_at: "2026-01-01T00:00:00Z",
+  requester: { id: OTHER_ID, display_name: "Other", avatar_url: null },
+  addressee: { id: USER_ID, display_name: "Me", avatar_url: null },
+};
 
 const ACCEPTED_ROW = {
-  id: 'fs-accepted',
+  id: "fs-accepted",
   requester_id: USER_ID,
   addressee_id: FRIEND_ID,
-  status: 'accepted',
-  created_at: '2026-01-01T00:00:00Z',
-  requester: { id: USER_ID, display_name: 'Me', avatar_url: null },
-  addressee: { id: FRIEND_ID, display_name: 'Friend', avatar_url: null },
-}
+  status: "accepted",
+  created_at: "2026-01-01T00:00:00Z",
+  requester: { id: USER_ID, display_name: "Me", avatar_url: null },
+  addressee: { id: FRIEND_ID, display_name: "Friend", avatar_url: null },
+};
 
 beforeEach(() => {
-  jest.clearAllMocks()
-  mockUseAuth.mockReturnValue({ session: { user: { id: USER_ID } } })
-})
+  jest.clearAllMocks();
+  mockUseAuth.mockReturnValue({ session: { user: { id: USER_ID } } });
+});
 
-describe('useFriendships', () => {
-  it('returns empty state when no friendships exist', async () => {
-    mockFetchFriendships.mockResolvedValue([])
-    const { result } = renderHook(() => useFriendships())
-    await flush()
+describe("useFriendships", () => {
+  it("returns empty state when no friendships exist", async () => {
+    mockFetchFriendships.mockResolvedValue([]);
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
-    expect(result.current.friends).toEqual([])
-    expect(result.current.incomingRequests).toEqual([])
-    expect(result.current.outgoingRequestMap.size).toBe(0)
-    expect(result.current.pendingCount).toBe(0)
-    expect(result.current.loading).toBe(false)
-  })
+    expect(result.current.friends).toEqual([]);
+    expect(result.current.incomingRequests).toEqual([]);
+    expect(result.current.outgoingRequestMap.size).toBe(0);
+    expect(result.current.pendingCount).toBe(0);
+    expect(result.current.loading).toBe(false);
+  });
 
-  it('correctly derives friends from accepted rows', async () => {
-    mockFetchFriendships.mockResolvedValue([ACCEPTED_ROW])
-    const { result } = renderHook(() => useFriendships())
-    await flush()
+  it("correctly derives friends from accepted rows", async () => {
+    mockFetchFriendships.mockResolvedValue([ACCEPTED_ROW]);
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
-    expect(result.current.friends).toHaveLength(1)
-    expect(result.current.friends[0].userId).toBe(FRIEND_ID)
-    expect(result.current.friends[0].displayName).toBe('Friend')
-    expect(result.current.friends[0].friendshipId).toBe('fs-accepted')
-  })
+    expect(result.current.friends).toHaveLength(1);
+    expect(result.current.friends[0].userId).toBe(FRIEND_ID);
+    expect(result.current.friends[0].displayName).toBe("Friend");
+    expect(result.current.friends[0].friendshipId).toBe("fs-accepted");
+  });
 
-  it('correctly derives incomingRequests from pending-received rows', async () => {
-    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
-    const { result } = renderHook(() => useFriendships())
-    await flush()
+  it("correctly derives incomingRequests from pending-received rows", async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW]);
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
-    expect(result.current.incomingRequests).toHaveLength(1)
-    expect(result.current.incomingRequests[0].requesterId).toBe(OTHER_ID)
-    expect(result.current.incomingRequests[0].displayName).toBe('Other')
-    expect(result.current.pendingCount).toBe(1)
-  })
+    expect(result.current.incomingRequests).toHaveLength(1);
+    expect(result.current.incomingRequests[0].requesterId).toBe(OTHER_ID);
+    expect(result.current.incomingRequests[0].displayName).toBe("Other");
+    expect(result.current.pendingCount).toBe(1);
+  });
 
-  it('correctly populates outgoingRequestMap from pending-sent rows', async () => {
-    mockFetchFriendships.mockResolvedValue([PENDING_SENT_ROW])
-    const { result } = renderHook(() => useFriendships())
-    await flush()
+  it("correctly populates outgoingRequestMap from pending-sent rows", async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_SENT_ROW]);
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
-    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(true)
-    expect(result.current.outgoingRequestMap.get(OTHER_ID)).toBe('fs-pending-sent')
-    expect(result.current.incomingRequests).toHaveLength(0)
-  })
+    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(true);
+    expect(result.current.outgoingRequestMap.get(OTHER_ID)).toBe("fs-pending-sent");
+    expect(result.current.incomingRequests).toHaveLength(0);
+  });
 
-  it('sets error state when fetchFriendships throws', async () => {
-    mockFetchFriendships.mockRejectedValue(new Error('network error'))
-    const { result } = renderHook(() => useFriendships())
-    await flush()
+  it("sets error state when fetchFriendships throws", async () => {
+    mockFetchFriendships.mockRejectedValue(new Error("network error"));
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
-    expect(result.current.error).toBe('network error')
-    expect(result.current.loading).toBe(false)
-  })
+    expect(result.current.error).toBe("network error");
+    expect(result.current.loading).toBe(false);
+  });
 
-  it('returns empty state when not authenticated', async () => {
-    mockUseAuth.mockReturnValue({ session: null })
-    const { result } = renderHook(() => useFriendships())
-    await flush()
+  it("returns empty state when not authenticated", async () => {
+    mockUseAuth.mockReturnValue({ session: null });
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
-    expect(result.current.friends).toEqual([])
-    expect(result.current.loading).toBe(false)
-    expect(mockFetchFriendships).not.toHaveBeenCalled()
-  })
+    expect(result.current.friends).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(mockFetchFriendships).not.toHaveBeenCalled();
+  });
 
-  it('sendRequest: optimistically adds to outgoingRequestMap and confirms on success', async () => {
-    mockFetchFriendships.mockResolvedValue([])
-    mockLibSendRequest.mockResolvedValue({ ...PENDING_SENT_ROW, id: 'fs-new' })
+  it("sendRequest: optimistically adds to outgoingRequestMap and confirms on success", async () => {
+    mockFetchFriendships.mockResolvedValue([]);
+    mockLibSendRequest.mockResolvedValue({ ...PENDING_SENT_ROW, id: "fs-new" });
 
-    const { result } = renderHook(() => useFriendships())
-    await flush()
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
-    await act(async () => { await result.current.sendRequest(OTHER_ID) })
+    await act(async () => {
+      await result.current.sendRequest(OTHER_ID);
+    });
 
-    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(true)
-  })
+    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(true);
+  });
 
-  it('sendRequest: rolls back optimistic add on error', async () => {
-    mockFetchFriendships.mockResolvedValue([])
-    mockLibSendRequest.mockRejectedValue(new Error('Friend request already exists'))
+  it("sendRequest: rolls back optimistic add on error", async () => {
+    mockFetchFriendships.mockResolvedValue([]);
+    mockLibSendRequest.mockRejectedValue(new Error("Friend request already exists"));
 
-    const { result } = renderHook(() => useFriendships())
-    await flush()
-
-    await expect(
-      act(async () => { await result.current.sendRequest(OTHER_ID) })
-    ).rejects.toThrow('Friend request already exists')
-
-    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(false)
-  })
-
-  it('cancelRequest: removes from outgoingRequestMap on success', async () => {
-    mockFetchFriendships.mockResolvedValue([PENDING_SENT_ROW])
-    mockLibCancelRequest.mockResolvedValue(undefined)
-
-    const { result } = renderHook(() => useFriendships())
-    await flush()
-
-    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(true)
-
-    await act(async () => { await result.current.cancelRequest('fs-pending-sent') })
-
-    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(false)
-  })
-
-  it('cancelRequest: rolls back on error', async () => {
-    mockFetchFriendships.mockResolvedValue([PENDING_SENT_ROW])
-    mockLibCancelRequest.mockRejectedValue(new Error('Request not found or already cancelled'))
-
-    const { result } = renderHook(() => useFriendships())
-    await flush()
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
     await expect(
-      act(async () => { await result.current.cancelRequest('fs-pending-sent') })
-    ).rejects.toThrow()
+      act(async () => {
+        await result.current.sendRequest(OTHER_ID);
+      }),
+    ).rejects.toThrow("Friend request already exists");
 
-    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(true)
-  })
+    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(false);
+  });
 
-  it('acceptRequest: moves row from incomingRequests to friends', async () => {
-    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
-    mockLibAcceptRequest.mockResolvedValue(undefined)
+  it("cancelRequest: removes from outgoingRequestMap on success", async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_SENT_ROW]);
+    mockLibCancelRequest.mockResolvedValue(undefined);
 
-    const { result } = renderHook(() => useFriendships())
-    await flush()
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
-    expect(result.current.incomingRequests).toHaveLength(1)
-    expect(result.current.friends).toHaveLength(0)
+    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(true);
 
-    await act(async () => { await result.current.acceptRequest('fs-pending-received') })
+    await act(async () => {
+      await result.current.cancelRequest("fs-pending-sent");
+    });
 
-    expect(result.current.incomingRequests).toHaveLength(0)
-    expect(result.current.friends).toHaveLength(1)
-    expect(result.current.pendingCount).toBe(0)
-  })
+    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(false);
+  });
 
-  it('acceptRequest: rolls back on error', async () => {
-    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
-    mockLibAcceptRequest.mockRejectedValue(new Error('update failed'))
+  it("cancelRequest: rolls back on error", async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_SENT_ROW]);
+    mockLibCancelRequest.mockRejectedValue(new Error("Request not found or already cancelled"));
 
-    const { result } = renderHook(() => useFriendships())
-    await flush()
-
-    await expect(
-      act(async () => { await result.current.acceptRequest('fs-pending-received') })
-    ).rejects.toThrow()
-
-    expect(result.current.incomingRequests).toHaveLength(1)
-  })
-
-  it('declineRequest: removes from incomingRequests on success', async () => {
-    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
-    mockLibDeclineRequest.mockResolvedValue(undefined)
-
-    const { result } = renderHook(() => useFriendships())
-    await flush()
-
-    await act(async () => { await result.current.declineRequest('fs-pending-received') })
-
-    expect(result.current.incomingRequests).toHaveLength(0)
-  })
-
-  it('declineRequest: rolls back on error', async () => {
-    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW])
-    mockLibDeclineRequest.mockRejectedValue(new Error('not found'))
-
-    const { result } = renderHook(() => useFriendships())
-    await flush()
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
     await expect(
-      act(async () => { await result.current.declineRequest('fs-pending-received') })
-    ).rejects.toThrow()
+      act(async () => {
+        await result.current.cancelRequest("fs-pending-sent");
+      }),
+    ).rejects.toThrow();
 
-    expect(result.current.incomingRequests).toHaveLength(1)
-  })
+    expect(result.current.outgoingRequestMap.has(OTHER_ID)).toBe(true);
+  });
 
-  it('unfriend: removes from friends on success', async () => {
-    mockFetchFriendships.mockResolvedValue([ACCEPTED_ROW])
-    mockLibUnfriend.mockResolvedValue(undefined)
+  it("acceptRequest: moves row from incomingRequests to friends", async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW]);
+    mockLibAcceptRequest.mockResolvedValue(undefined);
 
-    const { result } = renderHook(() => useFriendships())
-    await flush()
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
-    expect(result.current.friends).toHaveLength(1)
+    expect(result.current.incomingRequests).toHaveLength(1);
+    expect(result.current.friends).toHaveLength(0);
 
-    await act(async () => { await result.current.unfriend('fs-accepted') })
+    await act(async () => {
+      await result.current.acceptRequest("fs-pending-received");
+    });
 
-    expect(result.current.friends).toHaveLength(0)
-  })
+    expect(result.current.incomingRequests).toHaveLength(0);
+    expect(result.current.friends).toHaveLength(1);
+    expect(result.current.pendingCount).toBe(0);
+  });
 
-  it('unfriend: rolls back on error', async () => {
-    mockFetchFriendships.mockResolvedValue([ACCEPTED_ROW])
-    mockLibUnfriend.mockRejectedValue(new Error('Friendship not found'))
+  it("acceptRequest: rolls back on error", async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW]);
+    mockLibAcceptRequest.mockRejectedValue(new Error("update failed"));
 
-    const { result } = renderHook(() => useFriendships())
-    await flush()
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
     await expect(
-      act(async () => { await result.current.unfriend('fs-accepted') })
-    ).rejects.toThrow()
+      act(async () => {
+        await result.current.acceptRequest("fs-pending-received");
+      }),
+    ).rejects.toThrow();
 
-    expect(result.current.friends).toHaveLength(1)
-  })
+    expect(result.current.incomingRequests).toHaveLength(1);
+  });
 
-  it('does not log or set error when CLOSED fires after cleanup (unmount)', async () => {
-    mockFetchFriendships.mockResolvedValue([])
+  it("declineRequest: removes from incomingRequests on success", async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW]);
+    mockLibDeclineRequest.mockResolvedValue(undefined);
 
-    const { result, unmount } = renderHook(() => useFriendships())
-    await flush()
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
-    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (status: string, err?: Error) => void
-    act(() => { statusHandler('SUBSCRIBED') })
+    await act(async () => {
+      await result.current.declineRequest("fs-pending-received");
+    });
 
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-    unmount()
-    act(() => { statusHandler('CLOSED') })
+    expect(result.current.incomingRequests).toHaveLength(0);
+  });
 
-    expect(consoleSpy).not.toHaveBeenCalled()
-    expect(result.current.error).toBeNull()
-    consoleSpy.mockRestore()
-  })
+  it("declineRequest: rolls back on error", async () => {
+    mockFetchFriendships.mockResolvedValue([PENDING_RECEIVED_ROW]);
+    mockLibDeclineRequest.mockRejectedValue(new Error("not found"));
 
-  it('suppresses error when CHANNEL_ERROR fires while app is backgrounded', async () => {
-    const { AppState } = require('react-native')
-    const original = AppState.currentState
-    mockFetchFriendships.mockResolvedValue([])
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
-    const { result } = renderHook(() => useFriendships())
-    await flush()
+    await expect(
+      act(async () => {
+        await result.current.declineRequest("fs-pending-received");
+      }),
+    ).rejects.toThrow();
 
-    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (status: string, err?: Error) => void
-    act(() => { statusHandler('SUBSCRIBED') })
+    expect(result.current.incomingRequests).toHaveLength(1);
+  });
 
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-    AppState.currentState = 'background'
-    act(() => { statusHandler('CHANNEL_ERROR') })
+  it("unfriend: removes from friends on success", async () => {
+    mockFetchFriendships.mockResolvedValue([ACCEPTED_ROW]);
+    mockLibUnfriend.mockResolvedValue(undefined);
 
-    expect(consoleSpy).not.toHaveBeenCalled()
-    expect(result.current.error).toBeNull()
-    consoleSpy.mockRestore()
-    AppState.currentState = original
-  })
+    const { result } = renderHook(() => useFriendships());
+    await flush();
 
-  it('refetches and clears error after CHANNEL_ERROR + SUBSCRIBED reconnect', async () => {
-    mockFetchFriendships.mockResolvedValue([])
+    expect(result.current.friends).toHaveLength(1);
 
-    const { result } = renderHook(() => useFriendships())
-    await flush()
+    await act(async () => {
+      await result.current.unfriend("fs-accepted");
+    });
 
-    expect(mockFetchFriendships).toHaveBeenCalledTimes(1)
+    expect(result.current.friends).toHaveLength(0);
+  });
 
-    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (status: string, err?: Error) => void
+  it("unfriend: rolls back on error", async () => {
+    mockFetchFriendships.mockResolvedValue([ACCEPTED_ROW]);
+    mockLibUnfriend.mockRejectedValue(new Error("Friendship not found"));
+
+    const { result } = renderHook(() => useFriendships());
+    await flush();
+
+    await expect(
+      act(async () => {
+        await result.current.unfriend("fs-accepted");
+      }),
+    ).rejects.toThrow();
+
+    expect(result.current.friends).toHaveLength(1);
+  });
+
+  it("does not log or set error when CLOSED fires after cleanup (unmount)", async () => {
+    mockFetchFriendships.mockResolvedValue([]);
+
+    const { result, unmount } = renderHook(() => useFriendships());
+    await flush();
+
+    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (
+      status: string,
+      err?: Error,
+    ) => void;
+    act(() => {
+      statusHandler("SUBSCRIBED");
+    });
+
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    unmount();
+    act(() => {
+      statusHandler("CLOSED");
+    });
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+    expect(result.current.error).toBeNull();
+    consoleSpy.mockRestore();
+  });
+
+  it("suppresses error when CHANNEL_ERROR fires while app is backgrounded", async () => {
+    const { AppState } = require("react-native");
+    const original = AppState.currentState;
+    mockFetchFriendships.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useFriendships());
+    await flush();
+
+    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (
+      status: string,
+      err?: Error,
+    ) => void;
+    act(() => {
+      statusHandler("SUBSCRIBED");
+    });
+
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    AppState.currentState = "background";
+    act(() => {
+      statusHandler("CHANNEL_ERROR");
+    });
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+    expect(result.current.error).toBeNull();
+    consoleSpy.mockRestore();
+    AppState.currentState = original;
+  });
+
+  it("refetches and clears error after CHANNEL_ERROR + SUBSCRIBED reconnect", async () => {
+    mockFetchFriendships.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useFriendships());
+    await flush();
+
+    expect(mockFetchFriendships).toHaveBeenCalledTimes(1);
+
+    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (
+      status: string,
+      err?: Error,
+    ) => void;
 
     // Initial SUBSCRIBED — marks channel as subscribed-once, no refetch
-    act(() => { statusHandler('SUBSCRIBED') })
-    expect(mockFetchFriendships).toHaveBeenCalledTimes(1)
-    expect(result.current.error).toBeNull()
+    act(() => {
+      statusHandler("SUBSCRIBED");
+    });
+    expect(mockFetchFriendships).toHaveBeenCalledTimes(1);
+    expect(result.current.error).toBeNull();
 
     // Channel error — sets sticky error state
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-    act(() => { statusHandler('CHANNEL_ERROR') })
-    expect(result.current.error).not.toBeNull()
-    consoleSpy.mockRestore()
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    act(() => {
+      statusHandler("CHANNEL_ERROR");
+    });
+    expect(result.current.error).not.toBeNull();
+    consoleSpy.mockRestore();
 
     // Reconnect — should re-fetch and clear error
-    await act(async () => { statusHandler('SUBSCRIBED') })
-    await flush()
+    await act(async () => {
+      statusHandler("SUBSCRIBED");
+    });
+    await flush();
 
-    expect(mockFetchFriendships).toHaveBeenCalledTimes(2)
-    expect(result.current.error).toBeNull()
-  })
-})
+    expect(mockFetchFriendships).toHaveBeenCalledTimes(2);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/hooks/__tests__/useGeofenceNotifications.test.ts
+++ b/hooks/__tests__/useGeofenceNotifications.test.ts
@@ -1,59 +1,59 @@
-const React = require('react')
+const React = require("react");
 
 // Track the registered listener so tests can invoke it
-let notificationResponseListener: ((response: unknown) => void) | null = null
+let notificationResponseListener: ((response: unknown) => void) | null = null;
 
-jest.mock('expo-notifications', () => ({
+jest.mock("expo-notifications", () => ({
   addNotificationResponseReceivedListener: jest.fn((cb) => {
-    notificationResponseListener = cb
-    return { remove: jest.fn() }
+    notificationResponseListener = cb;
+    return { remove: jest.fn() };
   }),
   dismissNotificationAsync: jest.fn().mockResolvedValue(undefined),
-  DEFAULT_ACTION_IDENTIFIER: 'expo.modules.notifications.actions.DEFAULT',
-}))
+  DEFAULT_ACTION_IDENTIFIER: "expo.modules.notifications.actions.DEFAULT",
+}));
 
-jest.mock('../../lib/checkIns', () => ({
+jest.mock("../../lib/checkIns", () => ({
   insertCheckIn: jest.fn().mockResolvedValue(undefined),
-}))
+}));
 
-jest.mock('../../lib/presenceJoins', () => ({
+jest.mock("../../lib/presenceJoins", () => ({
   confirmJoins: jest.fn().mockResolvedValue(undefined),
-}))
+}));
 
-jest.mock('../../lib/supabase', () => ({
+jest.mock("../../lib/supabase", () => ({
   supabase: { __mock: true },
-}))
+}));
 
-jest.mock('../../lib/notifications', () => ({
-  CHECKIN_CATEGORY: 'geofence-checkin',
-  ACTION_CONFIRM: 'confirm-checkin',
-  ACTION_DISMISS: 'dismiss-checkin',
-}))
+jest.mock("../../lib/notifications", () => ({
+  CHECKIN_CATEGORY: "geofence-checkin",
+  ACTION_CONFIRM: "confirm-checkin",
+  ACTION_DISMISS: "dismiss-checkin",
+}));
 
-import { useGeofenceNotifications } from '../useGeofenceNotifications'
-import { insertCheckIn } from '../../lib/checkIns'
-import { confirmJoins } from '../../lib/presenceJoins'
+import { useGeofenceNotifications } from "../useGeofenceNotifications";
+import { insertCheckIn } from "../../lib/checkIns";
+import { confirmJoins } from "../../lib/presenceJoins";
 
 // Minimal renderHook using react-test-renderer (project convention)
-const { create, act } = require('react-test-renderer')
+const { create, act } = require("react-test-renderer");
 
 function renderHook<T>(hook: () => T): { result: { current: T }; unmount: () => void } {
-  const result = { current: undefined as T }
-  let renderer: ReturnType<typeof create>
+  const result = { current: undefined as T };
+  let renderer: ReturnType<typeof create>;
 
   function TestComponent() {
-    result.current = hook()
-    return null
+    result.current = hook();
+    return null;
   }
 
   act(() => {
-    renderer = create(React.createElement(TestComponent))
-  })
+    renderer = create(React.createElement(TestComponent));
+  });
 
   return {
     result,
     unmount: () => act(() => renderer.unmount()),
-  }
+  };
 }
 
 function makeNotificationResponse(actionIdentifier: string, poiId?: string, poiName?: string) {
@@ -61,357 +61,350 @@ function makeNotificationResponse(actionIdentifier: string, poiId?: string, poiN
     actionIdentifier,
     notification: {
       request: {
-        identifier: 'notif-123',
+        identifier: "notif-123",
         content: {
-          categoryIdentifier: 'geofence-checkin',
+          categoryIdentifier: "geofence-checkin",
           data: { poiId, poiName },
         },
       },
     },
-  }
+  };
 }
 
-describe('useGeofenceNotifications', () => {
+describe("useGeofenceNotifications", () => {
   beforeEach(() => {
-    jest.clearAllMocks()
-    notificationResponseListener = null
-  })
+    jest.clearAllMocks();
+    notificationResponseListener = null;
+  });
 
-  it('registers a notification response listener on mount', () => {
-    const Notifications = require('expo-notifications')
-    renderHook(() => useGeofenceNotifications())
-    expect(Notifications.addNotificationResponseReceivedListener).toHaveBeenCalled()
-  })
+  it("registers a notification response listener on mount", () => {
+    const Notifications = require("expo-notifications");
+    renderHook(() => useGeofenceNotifications());
+    expect(Notifications.addNotificationResponseReceivedListener).toHaveBeenCalled();
+  });
 
-  it('calls insertCheckIn on confirm action', async () => {
-    renderHook(() => useGeofenceNotifications())
-
-    await act(async () => {
-      await notificationResponseListener!(
-        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
-      )
-    })
-
-    expect(insertCheckIn).toHaveBeenCalledWith(
-      expect.objectContaining({ __mock: true }),
-      { poiId: 'poi-1' }
-    )
-  })
-
-  it('calls insertCheckIn on default action (body tap)', async () => {
-    renderHook(() => useGeofenceNotifications())
+  it("calls insertCheckIn on confirm action", async () => {
+    renderHook(() => useGeofenceNotifications());
 
     await act(async () => {
       await notificationResponseListener!(
-        makeNotificationResponse(
-          'expo.modules.notifications.actions.DEFAULT',
-          'poi-2',
-          'Nørrebro'
-        )
-      )
-    })
+        makeNotificationResponse("confirm-checkin", "poi-1", "Paludan"),
+      );
+    });
 
-    expect(insertCheckIn).toHaveBeenCalledWith(
-      expect.anything(),
-      { poiId: 'poi-2' }
-    )
-  })
+    expect(insertCheckIn).toHaveBeenCalledWith(expect.objectContaining({ __mock: true }), {
+      poiId: "poi-1",
+    });
+  });
 
-  it('does not call insertCheckIn on dismiss action', async () => {
-    renderHook(() => useGeofenceNotifications())
+  it("calls insertCheckIn on default action (body tap)", async () => {
+    renderHook(() => useGeofenceNotifications());
 
     await act(async () => {
       await notificationResponseListener!(
-        makeNotificationResponse('dismiss-checkin', 'poi-1', 'Paludan')
-      )
-    })
+        makeNotificationResponse("expo.modules.notifications.actions.DEFAULT", "poi-2", "Nørrebro"),
+      );
+    });
 
-    expect(insertCheckIn).not.toHaveBeenCalled()
-  })
+    expect(insertCheckIn).toHaveBeenCalledWith(expect.anything(), { poiId: "poi-2" });
+  });
 
-  it('dismisses notification on dismiss action', async () => {
-    const Notifications = require('expo-notifications')
-    renderHook(() => useGeofenceNotifications())
+  it("does not call insertCheckIn on dismiss action", async () => {
+    renderHook(() => useGeofenceNotifications());
 
     await act(async () => {
       await notificationResponseListener!(
-        makeNotificationResponse('dismiss-checkin', 'poi-1', 'Paludan')
-      )
-    })
+        makeNotificationResponse("dismiss-checkin", "poi-1", "Paludan"),
+      );
+    });
 
-    expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('notif-123')
-  })
+    expect(insertCheckIn).not.toHaveBeenCalled();
+  });
 
-  it('does not call insertCheckIn for non-geofence notification', async () => {
-    renderHook(() => useGeofenceNotifications())
+  it("dismisses notification on dismiss action", async () => {
+    const Notifications = require("expo-notifications");
+    renderHook(() => useGeofenceNotifications());
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse("dismiss-checkin", "poi-1", "Paludan"),
+      );
+    });
+
+    expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith("notif-123");
+  });
+
+  it("does not call insertCheckIn for non-geofence notification", async () => {
+    renderHook(() => useGeofenceNotifications());
 
     await act(async () => {
       await notificationResponseListener!({
-        actionIdentifier: 'confirm-checkin',
+        actionIdentifier: "confirm-checkin",
         notification: {
           request: {
             content: {
-              categoryIdentifier: 'some-other-category',
-              data: { poiId: 'poi-1', poiName: 'Paludan' },
+              categoryIdentifier: "some-other-category",
+              data: { poiId: "poi-1", poiName: "Paludan" },
             },
           },
         },
-      })
-    })
+      });
+    });
 
-    expect(insertCheckIn).not.toHaveBeenCalled()
-  })
+    expect(insertCheckIn).not.toHaveBeenCalled();
+  });
 
-  it('sets toast visible on successful check-in', async () => {
-    const { result } = renderHook(() => useGeofenceNotifications())
-
-    await act(async () => {
-      await notificationResponseListener!(
-        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
-      )
-    })
-
-    expect(result.current.toast.visible).toBe(true)
-    expect(result.current.toast.message).toBe('Checked in at Paludan')
-  })
-
-  it('shows error toast when insertCheckIn fails', async () => {
-    ;(insertCheckIn as jest.Mock).mockRejectedValueOnce(new Error('Not authenticated'))
-
-    const { result } = renderHook(() => useGeofenceNotifications())
+  it("sets toast visible on successful check-in", async () => {
+    const { result } = renderHook(() => useGeofenceNotifications());
 
     await act(async () => {
       await notificationResponseListener!(
-        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
-      )
-    })
+        makeNotificationResponse("confirm-checkin", "poi-1", "Paludan"),
+      );
+    });
 
-    expect(result.current.toast.visible).toBe(true)
-    expect(result.current.toast.message).toBe('Check-in failed — please try again')
-  })
+    expect(result.current.toast.visible).toBe(true);
+    expect(result.current.toast.message).toBe("Checked in at Paludan");
+  });
 
-  it('does not call insertCheckIn when poiId is missing', async () => {
-    renderHook(() => useGeofenceNotifications())
+  it("shows error toast when insertCheckIn fails", async () => {
+    (insertCheckIn as jest.Mock).mockRejectedValueOnce(new Error("Not authenticated"));
 
-    await act(async () => {
-      await notificationResponseListener!(
-        makeNotificationResponse('confirm-checkin', undefined, 'Paludan')
-      )
-    })
-
-    expect(insertCheckIn).not.toHaveBeenCalled()
-  })
-
-  it('does not call insertCheckIn when poiName is missing', async () => {
-    renderHook(() => useGeofenceNotifications())
+    const { result } = renderHook(() => useGeofenceNotifications());
 
     await act(async () => {
       await notificationResponseListener!(
-        makeNotificationResponse('confirm-checkin', 'poi-1', undefined)
-      )
-    })
+        makeNotificationResponse("confirm-checkin", "poi-1", "Paludan"),
+      );
+    });
 
-    expect(insertCheckIn).not.toHaveBeenCalled()
-  })
+    expect(result.current.toast.visible).toBe(true);
+    expect(result.current.toast.message).toBe("Check-in failed — please try again");
+  });
 
-  it('dismisses notification before attempting check-in', async () => {
-    const Notifications = require('expo-notifications')
-    renderHook(() => useGeofenceNotifications())
+  it("does not call insertCheckIn when poiId is missing", async () => {
+    renderHook(() => useGeofenceNotifications());
 
     await act(async () => {
       await notificationResponseListener!(
-        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
-      )
-    })
+        makeNotificationResponse("confirm-checkin", undefined, "Paludan"),
+      );
+    });
 
-    expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith('notif-123')
-  })
+    expect(insertCheckIn).not.toHaveBeenCalled();
+  });
 
-  it('removes listener on unmount', () => {
-    const Notifications = require('expo-notifications')
-    const { unmount } = renderHook(() => useGeofenceNotifications())
-    const removeMock = Notifications.addNotificationResponseReceivedListener.mock.results[0].value.remove
+  it("does not call insertCheckIn when poiName is missing", async () => {
+    renderHook(() => useGeofenceNotifications());
 
-    unmount()
-    expect(removeMock).toHaveBeenCalled()
-  })
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse("confirm-checkin", "poi-1", undefined),
+      );
+    });
 
-  it('ignores duplicate notification with same identifier', async () => {
-    renderHook(() => useGeofenceNotifications())
+    expect(insertCheckIn).not.toHaveBeenCalled();
+  });
+
+  it("dismisses notification before attempting check-in", async () => {
+    const Notifications = require("expo-notifications");
+    renderHook(() => useGeofenceNotifications());
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse("confirm-checkin", "poi-1", "Paludan"),
+      );
+    });
+
+    expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith("notif-123");
+  });
+
+  it("removes listener on unmount", () => {
+    const Notifications = require("expo-notifications");
+    const { unmount } = renderHook(() => useGeofenceNotifications());
+    const removeMock =
+      Notifications.addNotificationResponseReceivedListener.mock.results[0].value.remove;
+
+    unmount();
+    expect(removeMock).toHaveBeenCalled();
+  });
+
+  it("ignores duplicate notification with same identifier", async () => {
+    renderHook(() => useGeofenceNotifications());
 
     // First response — should insert check-in
     await act(async () => {
       await notificationResponseListener!(
-        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
-      )
-    })
+        makeNotificationResponse("confirm-checkin", "poi-1", "Paludan"),
+      );
+    });
 
-    expect(insertCheckIn).toHaveBeenCalledTimes(1)
+    expect(insertCheckIn).toHaveBeenCalledTimes(1);
 
     // Second response with same notification identifier — should be skipped
     await act(async () => {
       await notificationResponseListener!(
-        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
-      )
-    })
+        makeNotificationResponse("confirm-checkin", "poi-1", "Paludan"),
+      );
+    });
 
     // insertCheckIn should still have been called only once
-    expect(insertCheckIn).toHaveBeenCalledTimes(1)
-  })
+    expect(insertCheckIn).toHaveBeenCalledTimes(1);
+  });
 
-  it('processes notifications with different identifiers independently', async () => {
-    renderHook(() => useGeofenceNotifications())
+  it("processes notifications with different identifiers independently", async () => {
+    renderHook(() => useGeofenceNotifications());
 
     await act(async () => {
       await notificationResponseListener!(
-        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
-      )
-    })
+        makeNotificationResponse("confirm-checkin", "poi-1", "Paludan"),
+      );
+    });
 
     await act(async () => {
       await notificationResponseListener!({
-        actionIdentifier: 'confirm-checkin',
+        actionIdentifier: "confirm-checkin",
         notification: {
           request: {
-            identifier: 'notif-456',
+            identifier: "notif-456",
             content: {
-              categoryIdentifier: 'geofence-checkin',
-              data: { poiId: 'poi-2', poiName: 'Nørrebro' },
+              categoryIdentifier: "geofence-checkin",
+              data: { poiId: "poi-2", poiName: "Nørrebro" },
             },
           },
         },
-      })
-    })
+      });
+    });
 
-    expect(insertCheckIn).toHaveBeenCalledTimes(2)
-  })
+    expect(insertCheckIn).toHaveBeenCalledTimes(2);
+  });
 
-  it('calls confirmJoins after successful check-in', async () => {
-    renderHook(() => useGeofenceNotifications())
-
-    await act(async () => {
-      await notificationResponseListener!(
-        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
-      )
-    })
-
-    expect(confirmJoins).toHaveBeenCalledWith(
-      expect.objectContaining({ __mock: true }),
-      { poiId: 'poi-1' }
-    )
-  })
-
-  it('does not call confirmJoins when check-in fails', async () => {
-    ;(insertCheckIn as jest.Mock).mockRejectedValueOnce(new Error('auth error'))
-
-    renderHook(() => useGeofenceNotifications())
+  it("calls confirmJoins after successful check-in", async () => {
+    renderHook(() => useGeofenceNotifications());
 
     await act(async () => {
       await notificationResponseListener!(
-        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
-      )
-    })
+        makeNotificationResponse("confirm-checkin", "poi-1", "Paludan"),
+      );
+    });
 
-    expect(confirmJoins).not.toHaveBeenCalled()
-  })
+    expect(confirmJoins).toHaveBeenCalledWith(expect.objectContaining({ __mock: true }), {
+      poiId: "poi-1",
+    });
+  });
 
-  it('retries confirmJoins once on failure and shows toast on success', async () => {
+  it("does not call confirmJoins when check-in fails", async () => {
+    (insertCheckIn as jest.Mock).mockRejectedValueOnce(new Error("auth error"));
+
+    renderHook(() => useGeofenceNotifications());
+
+    await act(async () => {
+      await notificationResponseListener!(
+        makeNotificationResponse("confirm-checkin", "poi-1", "Paludan"),
+      );
+    });
+
+    expect(confirmJoins).not.toHaveBeenCalled();
+  });
+
+  it("retries confirmJoins once on failure and shows toast on success", async () => {
     // Mock setTimeout to fire the first 2000ms timer (retry delay) immediately.
     // Subsequent 2000ms timers (toast cleanup) are registered but not called,
     // so toast.visible stays true when we check. React's internal 0ms timers
     // are not affected by the 2000ms guard.
-    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout')
-    let retryFired = false
+    const setTimeoutSpy = jest.spyOn(globalThis, "setTimeout");
+    let retryFired = false;
     setTimeoutSpy.mockImplementation((fn, delay) => {
       if (!retryFired && delay === 2000) {
-        retryFired = true
-        if (typeof fn === 'function') (fn as () => void)()
+        retryFired = true;
+        if (typeof fn === "function") (fn as () => void)();
       }
-      return 0 as unknown as ReturnType<typeof setTimeout>
-    })
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+    (confirmJoins as jest.Mock)
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce(undefined);
 
-    ;(confirmJoins as jest.Mock)
-      .mockRejectedValueOnce(new Error('transient'))
-      .mockResolvedValueOnce(undefined)
-
-    const { result } = renderHook(() => useGeofenceNotifications())
+    const { result } = renderHook(() => useGeofenceNotifications());
 
     await act(async () => {
       await notificationResponseListener!(
-        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
-      )
-    })
+        makeNotificationResponse("confirm-checkin", "poi-1", "Paludan"),
+      );
+    });
 
-    expect(confirmJoins).toHaveBeenCalledTimes(2)
-    expect(result.current.toast.visible).toBe(true)
-    expect(result.current.toast.message).toBe('Checked in at Paludan')
+    expect(confirmJoins).toHaveBeenCalledTimes(2);
+    expect(result.current.toast.visible).toBe(true);
+    expect(result.current.toast.message).toBe("Checked in at Paludan");
 
-    setTimeoutSpy.mockRestore()
-  })
+    setTimeoutSpy.mockRestore();
+  });
 
-  it('logs error and still shows toast when confirmJoins fails both attempts', async () => {
-    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout')
-    let retryFired = false
+  it("logs error and still shows toast when confirmJoins fails both attempts", async () => {
+    const setTimeoutSpy = jest.spyOn(globalThis, "setTimeout");
+    let retryFired = false;
     setTimeoutSpy.mockImplementation((fn, delay) => {
       if (!retryFired && delay === 2000) {
-        retryFired = true
-        if (typeof fn === 'function') (fn as () => void)()
+        retryFired = true;
+        if (typeof fn === "function") (fn as () => void)();
       }
-      return 0 as unknown as ReturnType<typeof setTimeout>
-    })
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
 
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
-    ;(confirmJoins as jest.Mock).mockRejectedValue(new Error('persistent error'))
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    (confirmJoins as jest.Mock).mockRejectedValue(new Error("persistent error"));
 
-    const { result } = renderHook(() => useGeofenceNotifications())
+    const { result } = renderHook(() => useGeofenceNotifications());
 
     await act(async () => {
       await notificationResponseListener!(
-        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
-      )
-    })
+        makeNotificationResponse("confirm-checkin", "poi-1", "Paludan"),
+      );
+    });
 
-    expect(confirmJoins).toHaveBeenCalledTimes(2)
+    expect(confirmJoins).toHaveBeenCalledTimes(2);
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Join confirmation failed after retry'),
-      expect.any(Error)
-    )
-    expect(result.current.toast.visible).toBe(true)
-    expect(result.current.toast.message).toBe('Checked in at Paludan')
+      expect.stringContaining("Join confirmation failed after retry"),
+      expect.any(Error),
+    );
+    expect(result.current.toast.visible).toBe(true);
+    expect(result.current.toast.message).toBe("Checked in at Paludan");
 
-    consoleSpy.mockRestore()
-    setTimeoutSpy.mockRestore()
-  })
+    consoleSpy.mockRestore();
+    setTimeoutSpy.mockRestore();
+  });
 
-  it('hides toast after 2 seconds', async () => {
+  it("hides toast after 2 seconds", async () => {
     // Ensure confirmJoins resolves so the retry timer is never scheduled
-    ;(confirmJoins as jest.Mock).mockResolvedValue(undefined)
-    const { result } = renderHook(() => useGeofenceNotifications())
+    (confirmJoins as jest.Mock).mockResolvedValue(undefined);
+    const { result } = renderHook(() => useGeofenceNotifications());
     // Set up the spy AFTER renderHook so React initialisation timers are unaffected.
     // The spy intercepts the toast cleanup setTimeout (2000 ms) and captures the fn.
-    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout')
-    let cleanupFn: (() => void) | null = null
+    const setTimeoutSpy = jest.spyOn(globalThis, "setTimeout");
+    let cleanupFn: (() => void) | null = null;
     setTimeoutSpy.mockImplementation((fn, delay) => {
-      if (delay === 2000 && typeof fn === 'function') {
-        cleanupFn = fn as () => void
+      if (delay === 2000 && typeof fn === "function") {
+        cleanupFn = fn as () => void;
       }
-      return 0 as unknown as ReturnType<typeof setTimeout>
-    })
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
 
     await act(async () => {
       await notificationResponseListener!(
-        makeNotificationResponse('confirm-checkin', 'poi-1', 'Paludan')
-      )
-    })
+        makeNotificationResponse("confirm-checkin", "poi-1", "Paludan"),
+      );
+    });
 
     // Toast should be visible immediately after the notification is handled
-    expect(result.current.toast.visible).toBe(true)
-    expect(cleanupFn).not.toBeNull()
+    expect(result.current.toast.visible).toBe(true);
+    expect(cleanupFn).not.toBeNull();
 
     // Fire the cleanup timer to hide the toast
-    await act(async () => { cleanupFn!() })
+    await act(async () => {
+      cleanupFn!();
+    });
 
-    expect(result.current.toast.visible).toBe(false)
-    setTimeoutSpy.mockRestore()
-  })
-})
+    expect(result.current.toast.visible).toBe(false);
+    setTimeoutSpy.mockRestore();
+  });
+});

--- a/hooks/__tests__/useLivePresences.test.ts
+++ b/hooks/__tests__/useLivePresences.test.ts
@@ -5,54 +5,58 @@
  * Mocks @/lib/supabase (initial fetch + Realtime channel) and @/hooks/useAuth.
  */
 
-import React from 'react'
-import { act, create } from 'react-test-renderer'
+import React from "react";
+import { act, create } from "react-test-renderer";
 
 // ---------------------------------------------------------------------------
 // Mock leaf fns — prefixed with "mock" so Jest hoisting allows use in factory
 // ---------------------------------------------------------------------------
-const mockNeqFn = jest.fn()
-const mockSingleFn = jest.fn()
-const mockSubscribeFn = jest.fn()
-const mockChannelOnFn = jest.fn()
-const mockUseAuth = jest.fn()
+const mockNeqFn = jest.fn();
+const mockSingleFn = jest.fn();
+const mockSubscribeFn = jest.fn();
+const mockChannelOnFn = jest.fn();
+const mockUseAuth = jest.fn();
 
 // removeChannel is declared as jest.fn() directly in the factory so it is always
 // a function at factory-run time (avoids TDZ issues with eagerly-evaluated references).
 // Tests access it via the imported supabase mock.
-jest.mock('@/lib/supabase', () => ({
+jest.mock("@/lib/supabase", () => ({
   supabase: {
     from: jest.fn((table: string) => {
-      if (table === 'profiles') {
-        return { select: jest.fn(() => ({ eq: jest.fn(() => ({ single: mockSingleFn })) })) }
+      if (table === "profiles") {
+        return { select: jest.fn(() => ({ eq: jest.fn(() => ({ single: mockSingleFn })) })) };
       }
       // live_presence
-      return { select: jest.fn(() => ({ is: jest.fn(() => ({ neq: mockNeqFn })) })) }
+      return { select: jest.fn(() => ({ is: jest.fn(() => ({ neq: mockNeqFn })) })) };
     }),
     channel: jest.fn(() => ({ on: mockChannelOnFn, subscribe: mockSubscribeFn })),
     removeChannel: jest.fn(),
   },
-}))
+}));
 
-jest.mock('@/hooks/useAuth', () => ({ useAuth: () => mockUseAuth() }))
+jest.mock("@/hooks/useAuth", () => ({ useAuth: () => mockUseAuth() }));
 
-import { supabase } from '@/lib/supabase'
-import { useLivePresences } from '../useLivePresences'
+import { supabase } from "@/lib/supabase";
+import { useLivePresences } from "../useLivePresences";
 
-type HookResult<T> = { current: T }
+type HookResult<T> = { current: T };
 
 function renderHook<T>(useHook: () => T): HookResult<T> {
-  const result: HookResult<T> = { current: undefined as unknown as T }
+  const result: HookResult<T> = { current: undefined as unknown as T };
   function TestComponent() {
-    result.current = useHook()
-    return null
+    result.current = useHook();
+    return null;
   }
-  act(() => { create(React.createElement(TestComponent)) })
-  return result
+  act(() => {
+    create(React.createElement(TestComponent));
+  });
+  return result;
 }
 
 async function flush() {
-  await act(async () => { await Promise.resolve() })
+  await act(async () => {
+    await Promise.resolve();
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -60,552 +64,619 @@ async function flush() {
 // ---------------------------------------------------------------------------
 function makeRow(overrides: Record<string, unknown> = {}) {
   return {
-    id: 'presence-1',
-    user_id: 'user-2',
-    poi_id: 'poi-1',
-    message: 'grabbing coffee',
-    profiles: { display_name: 'Jane Doe', avatar_url: null },
+    id: "presence-1",
+    user_id: "user-2",
+    poi_id: "poi-1",
+    message: "grabbing coffee",
+    profiles: { display_name: "Jane Doe", avatar_url: null },
     ...overrides,
-  }
+  };
 }
 
 function makeInsertPayload(overrides: Record<string, unknown> = {}) {
   return {
     new: {
-      id: 'presence-2',
-      user_id: 'user-3',
-      poi_id: 'poi-1',
-      message: 'hey',
+      id: "presence-2",
+      user_id: "user-3",
+      poi_id: "poi-1",
+      message: "hey",
       dismissed_at: null,
-      visible_to: 'community',
-      created_at: '2026-01-01T00:00:00Z',
+      visible_to: "community",
+      created_at: "2026-01-01T00:00:00Z",
       ...overrides,
     },
-  }
+  };
 }
 
 // Capture INSERT/UPDATE handlers after the hook mounts
 function getCapturedHandlers() {
   const insertCall = mockChannelOnFn.mock.calls.find(
-    (c: unknown[]) => (c[1] as { event: string }).event === 'INSERT'
-  )
+    (c: unknown[]) => (c[1] as { event: string }).event === "INSERT",
+  );
   const updateCall = mockChannelOnFn.mock.calls.find(
-    (c: unknown[]) => (c[1] as { event: string }).event === 'UPDATE'
-  )
+    (c: unknown[]) => (c[1] as { event: string }).event === "UPDATE",
+  );
   return {
     insertHandler: insertCall?.[2] as ((p: unknown) => Promise<void>) | undefined,
     updateHandler: updateCall?.[2] as ((p: unknown) => void) | undefined,
-  }
+  };
 }
 
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
 beforeEach(() => {
-  jest.clearAllMocks()
-  mockUseAuth.mockReturnValue({ session: { user: { id: 'user-1' } } })
-  mockNeqFn.mockResolvedValue({ data: [], error: null })
+  jest.clearAllMocks();
+  mockUseAuth.mockReturnValue({ session: { user: { id: "user-1" } } });
+  mockNeqFn.mockResolvedValue({ data: [], error: null });
   // Make .on() chainable and capture event/handler
   mockChannelOnFn.mockImplementation((_event: string, _filter: unknown, _handler: unknown) => ({
     on: mockChannelOnFn,
     subscribe: mockSubscribeFn,
-  }))
-  mockSubscribeFn.mockReturnValue('mock-channel-ref')
-})
+  }));
+  mockSubscribeFn.mockReturnValue("mock-channel-ref");
+});
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-describe('useLivePresences', () => {
-  it('returns empty presences when initial fetch returns no rows', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+describe("useLivePresences", () => {
+  it("returns empty presences when initial fetch returns no rows", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
 
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
-    expect(result.current.presences).toEqual([])
-    expect(result.current.loading).toBe(false)
-  })
+    expect(result.current.presences).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
 
-  it('maps initial fetch rows to LivePresenceEntry correctly', async () => {
-    mockNeqFn.mockResolvedValue({ data: [makeRow()], error: null })
+  it("maps initial fetch rows to LivePresenceEntry correctly", async () => {
+    mockNeqFn.mockResolvedValue({ data: [makeRow()], error: null });
 
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
     expect(result.current.presences).toEqual([
       {
-        id: 'presence-1',
-        userId: 'user-2',
-        poiId: 'poi-1',
-        displayName: 'Jane Doe',
+        id: "presence-1",
+        userId: "user-2",
+        poiId: "poi-1",
+        displayName: "Jane Doe",
         avatarUrl: null,
-        message: 'grabbing coffee',
+        message: "grabbing coffee",
       },
-    ])
-  })
+    ]);
+  });
 
-  it('does not include current user in initial fetch results', async () => {
+  it("does not include current user in initial fetch results", async () => {
     // The neq filter is applied by the DB; confirm the hook passes the right userId
-    const { supabase } = require('@/lib/supabase')
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+    const { supabase } = require("@/lib/supabase");
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
 
-    renderHook(() => useLivePresences([]))
-    await flush()
+    renderHook(() => useLivePresences([]));
+    await flush();
 
     // find the neq call on the live_presence chain
     const fromCall = (supabase.from as jest.Mock).mock.calls.find(
-      (c: string[]) => c[0] === 'live_presence'
-    )
-    expect(fromCall).toBeDefined()
+      (c: string[]) => c[0] === "live_presence",
+    );
+    expect(fromCall).toBeDefined();
     // neq is the last call in the chain — it should have been called with ('user_id', 'user-1')
-    expect(mockNeqFn).toHaveBeenCalledWith('user_id', 'user-1')
-  })
+    expect(mockNeqFn).toHaveBeenCalledWith("user_id", "user-1");
+  });
 
-  it('adds a presence on INSERT and always fetches fresh profile', async () => {
+  it("adds a presence on INSERT and always fetches fresh profile", async () => {
     // Seed via initial fetch (user-2 is cached with "Jane Doe")
-    mockNeqFn.mockResolvedValue({ data: [makeRow()], error: null })
+    mockNeqFn.mockResolvedValue({ data: [makeRow()], error: null });
     mockSingleFn.mockResolvedValue({
-      data: { display_name: 'Jane Doe Updated', avatar_url: 'https://example.com/new.jpg' },
+      data: { display_name: "Jane Doe Updated", avatar_url: "https://example.com/new.jpg" },
       error: null,
-    })
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+    });
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
-    const { insertHandler } = getCapturedHandlers()
-    expect(insertHandler).toBeDefined()
+    const { insertHandler } = getCapturedHandlers();
+    expect(insertHandler).toBeDefined();
 
     // Fire INSERT for same user — should fetch fresh profile, not use cache
     await act(async () => {
-      await insertHandler!(makeInsertPayload({ user_id: 'user-2', id: 'presence-3' }))
-    })
+      await insertHandler!(makeInsertPayload({ user_id: "user-2", id: "presence-3" }));
+    });
 
-    expect(result.current.presences).toHaveLength(2)
-    expect(result.current.presences[1].id).toBe('presence-3')
-    expect(result.current.presences[1].displayName).toBe('Jane Doe Updated')
-    expect(result.current.presences[1].avatarUrl).toBe('https://example.com/new.jpg')
-    expect(mockSingleFn).toHaveBeenCalledTimes(1) // always fetches fresh
-  })
+    expect(result.current.presences).toHaveLength(2);
+    expect(result.current.presences[1].id).toBe("presence-3");
+    expect(result.current.presences[1].displayName).toBe("Jane Doe Updated");
+    expect(result.current.presences[1].avatarUrl).toBe("https://example.com/new.jpg");
+    expect(mockSingleFn).toHaveBeenCalledTimes(1); // always fetches fresh
+  });
 
-  it('fetches fresh profile on INSERT when user has no prior cache entry', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+  it("fetches fresh profile on INSERT when user has no prior cache entry", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
     mockSingleFn.mockResolvedValue({
-      data: { display_name: 'Bob Smith', avatar_url: 'https://example.com/bob.jpg' },
+      data: { display_name: "Bob Smith", avatar_url: "https://example.com/bob.jpg" },
       error: null,
-    })
+    });
 
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
-    const { insertHandler } = getCapturedHandlers()
-    await act(async () => { await insertHandler!(makeInsertPayload()) })
+    const { insertHandler } = getCapturedHandlers();
+    await act(async () => {
+      await insertHandler!(makeInsertPayload());
+    });
 
-    expect(mockSingleFn).toHaveBeenCalledTimes(1)
-    expect(result.current.presences).toHaveLength(1)
-    expect(result.current.presences[0].displayName).toBe('Bob Smith')
-    expect(result.current.presences[0].avatarUrl).toBe('https://example.com/bob.jpg')
-  })
+    expect(mockSingleFn).toHaveBeenCalledTimes(1);
+    expect(result.current.presences).toHaveLength(1);
+    expect(result.current.presences[0].displayName).toBe("Bob Smith");
+    expect(result.current.presences[0].avatarUrl).toBe("https://example.com/bob.jpg");
+  });
 
-  it('removes a presence on UPDATE when dismissed_at is set', async () => {
-    mockNeqFn.mockResolvedValue({ data: [makeRow()], error: null })
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+  it("removes a presence on UPDATE when dismissed_at is set", async () => {
+    mockNeqFn.mockResolvedValue({ data: [makeRow()], error: null });
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
-    expect(result.current.presences).toHaveLength(1)
+    expect(result.current.presences).toHaveLength(1);
 
-    const { updateHandler } = getCapturedHandlers()
+    const { updateHandler } = getCapturedHandlers();
     act(() => {
       updateHandler!({
-        new: { id: 'presence-1', user_id: 'user-2', dismissed_at: '2026-01-01T01:00:00Z' },
-      })
-    })
+        new: { id: "presence-1", user_id: "user-2", dismissed_at: "2026-01-01T01:00:00Z" },
+      });
+    });
 
-    expect(result.current.presences).toHaveLength(0)
-  })
+    expect(result.current.presences).toHaveLength(0);
+  });
 
-  it('ignores INSERT from the current user', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+  it("ignores INSERT from the current user", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
-    const { insertHandler } = getCapturedHandlers()
+    const { insertHandler } = getCapturedHandlers();
     await act(async () => {
-      await insertHandler!(makeInsertPayload({ user_id: 'user-1' })) // own user
-    })
+      await insertHandler!(makeInsertPayload({ user_id: "user-1" })); // own user
+    });
 
-    expect(result.current.presences).toHaveLength(0)
-  })
+    expect(result.current.presences).toHaveLength(0);
+  });
 
-  it('ignores INSERT when dismissed_at is already set', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+  it("ignores INSERT when dismissed_at is already set", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
-    const { insertHandler } = getCapturedHandlers()
+    const { insertHandler } = getCapturedHandlers();
     await act(async () => {
-      await insertHandler!(makeInsertPayload({ dismissed_at: '2026-01-01T00:00:00Z' }))
-    })
+      await insertHandler!(makeInsertPayload({ dismissed_at: "2026-01-01T00:00:00Z" }));
+    });
 
-    expect(result.current.presences).toHaveLength(0)
-  })
+    expect(result.current.presences).toHaveLength(0);
+  });
 
-  it('loading is true before the fetch resolves', () => {
-    let resolve!: (v: { data: unknown[]; error: null }) => void
-    mockNeqFn.mockReturnValue(new Promise((r) => { resolve = r }))
+  it("loading is true before the fetch resolves", () => {
+    let resolve!: (v: { data: unknown[]; error: null }) => void;
+    mockNeqFn.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
 
-    const result = renderHook(() => useLivePresences([]))
-    expect(result.current.loading).toBe(true)
+    const result = renderHook(() => useLivePresences([]));
+    expect(result.current.loading).toBe(true);
 
-    act(() => { resolve({ data: [], error: null }) })
-  })
+    act(() => {
+      resolve({ data: [], error: null });
+    });
+  });
 
-  it('sets error state when initial fetch fails', async () => {
-    mockNeqFn.mockResolvedValue({ data: null, error: { message: 'network failure' } })
+  it("sets error state when initial fetch fails", async () => {
+    mockNeqFn.mockResolvedValue({ data: null, error: { message: "network failure" } });
 
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
-    expect(result.current.error).toBe('network failure')
-    expect(result.current.loading).toBe(false)
-  })
+    expect(result.current.error).toBe("network failure");
+    expect(result.current.loading).toBe(false);
+  });
 
-  it('falls back to Unknown when profile fetch fails and no cached entry exists', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
-    mockSingleFn.mockResolvedValue({ data: null, error: { message: 'not found' } })
+  it("falls back to Unknown when profile fetch fails and no cached entry exists", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
+    mockSingleFn.mockResolvedValue({ data: null, error: { message: "not found" } });
 
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
-    const { insertHandler } = getCapturedHandlers()
-    await act(async () => { await insertHandler!(makeInsertPayload()) })
+    const { insertHandler } = getCapturedHandlers();
+    await act(async () => {
+      await insertHandler!(makeInsertPayload());
+    });
 
-    expect(result.current.presences).toHaveLength(1)
-    expect(result.current.presences[0].displayName).toBe('Unknown')
-    expect(result.current.presences[0].avatarUrl).toBeNull()
-  })
+    expect(result.current.presences).toHaveLength(1);
+    expect(result.current.presences[0].displayName).toBe("Unknown");
+    expect(result.current.presences[0].avatarUrl).toBeNull();
+  });
 
-  it('updates the message field on a non-dismissal UPDATE', async () => {
-    mockNeqFn.mockResolvedValue({ data: [makeRow({ message: 'original' })], error: null })
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+  it("updates the message field on a non-dismissal UPDATE", async () => {
+    mockNeqFn.mockResolvedValue({ data: [makeRow({ message: "original" })], error: null });
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
-    expect(result.current.presences[0].message).toBe('original')
+    expect(result.current.presences[0].message).toBe("original");
 
-    const { updateHandler } = getCapturedHandlers()
+    const { updateHandler } = getCapturedHandlers();
     act(() => {
       updateHandler!({
-        new: { id: 'presence-1', user_id: 'user-2', dismissed_at: null, message: 'updated' },
-      })
-    })
+        new: { id: "presence-1", user_id: "user-2", dismissed_at: null, message: "updated" },
+      });
+    });
 
-    expect(result.current.presences).toHaveLength(1)
-    expect(result.current.presences[0].message).toBe('updated')
-  })
+    expect(result.current.presences).toHaveLength(1);
+    expect(result.current.presences[0].message).toBe("updated");
+  });
 
-  it('does not deduplicate unrelated presences on successive INSERTs', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+  it("does not deduplicate unrelated presences on successive INSERTs", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
     mockSingleFn.mockResolvedValue({
-      data: { display_name: 'Bob', avatar_url: null },
+      data: { display_name: "Bob", avatar_url: null },
       error: null,
-    })
+    });
 
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
-    const { insertHandler } = getCapturedHandlers()
-    await act(async () => { await insertHandler!(makeInsertPayload({ id: 'p-a' })) })
-    await act(async () => { await insertHandler!(makeInsertPayload({ id: 'p-b' })) })
+    const { insertHandler } = getCapturedHandlers();
+    await act(async () => {
+      await insertHandler!(makeInsertPayload({ id: "p-a" }));
+    });
+    await act(async () => {
+      await insertHandler!(makeInsertPayload({ id: "p-b" }));
+    });
 
-    expect(result.current.presences).toHaveLength(2)
-  })
+    expect(result.current.presences).toHaveLength(2);
+  });
 
-  it('does not add the same presence twice on duplicate INSERTs', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+  it("does not add the same presence twice on duplicate INSERTs", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
     mockSingleFn.mockResolvedValue({
-      data: { display_name: 'Bob', avatar_url: null },
+      data: { display_name: "Bob", avatar_url: null },
       error: null,
-    })
+    });
 
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
-    const { insertHandler } = getCapturedHandlers()
-    const payload = makeInsertPayload({ id: 'presence-dup' })
-    await act(async () => { await insertHandler!(payload) })
-    await act(async () => { await insertHandler!(payload) })
+    const { insertHandler } = getCapturedHandlers();
+    const payload = makeInsertPayload({ id: "presence-dup" });
+    await act(async () => {
+      await insertHandler!(payload);
+    });
+    await act(async () => {
+      await insertHandler!(payload);
+    });
 
-    expect(result.current.presences).toHaveLength(1)
-  })
+    expect(result.current.presences).toHaveLength(1);
+  });
 
-  it('calls removeChannel on unmount', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+  it("calls removeChannel on unmount", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
 
-    let unmount!: () => void
+    let unmount!: () => void;
     act(() => {
       const renderer = create(
         React.createElement(function TestComponent() {
-          useLivePresences([])
-          return null
-        })
-      )
-      unmount = () => renderer.unmount()
-    })
-    await flush()
+          useLivePresences([]);
+          return null;
+        }),
+      );
+      unmount = () => renderer.unmount();
+    });
+    await flush();
 
-    act(() => { unmount() })
+    act(() => {
+      unmount();
+    });
 
-    expect((supabase as any).removeChannel).toHaveBeenCalledTimes(1)
-  })
+    expect((supabase as any).removeChannel).toHaveBeenCalledTimes(1);
+  });
 
-  it('returns empty presences when user is not authenticated', async () => {
-    mockUseAuth.mockReturnValue({ session: null })
+  it("returns empty presences when user is not authenticated", async () => {
+    mockUseAuth.mockReturnValue({ session: null });
 
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
-    expect(result.current.presences).toEqual([])
-    expect(result.current.loading).toBe(false)
-    expect(mockNeqFn).not.toHaveBeenCalled()
-  })
+    expect(result.current.presences).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(mockNeqFn).not.toHaveBeenCalled();
+  });
 
-  it('creates only one channel when friendIds is empty', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+  it("creates only one channel when friendIds is empty", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
 
-    renderHook(() => useLivePresences([]))
-    await flush()
+    renderHook(() => useLivePresences([]));
+    await flush();
 
-    expect((supabase as any).channel).toHaveBeenCalledTimes(1)
-  })
+    expect((supabase as any).channel).toHaveBeenCalledTimes(1);
+  });
 
-  it('creates two channels when friendIds is non-empty', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+  it("creates two channels when friendIds is non-empty", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
 
-    renderHook(() => useLivePresences(['user-5', 'user-6']))
-    await flush()
+    renderHook(() => useLivePresences(["user-5", "user-6"]));
+    await flush();
 
-    expect((supabase as any).channel).toHaveBeenCalledTimes(2)
-  })
+    expect((supabase as any).channel).toHaveBeenCalledTimes(2);
+  });
 
-  it('friends channel INSERT fires for friends-only broadcasts', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+  it("friends channel INSERT fires for friends-only broadcasts", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
     mockSingleFn.mockResolvedValue({
-      data: { display_name: 'Friend User', avatar_url: null },
+      data: { display_name: "Friend User", avatar_url: null },
       error: null,
-    })
+    });
 
-    const result = renderHook(() => useLivePresences(['user-5']))
-    await flush()
+    const result = renderHook(() => useLivePresences(["user-5"]));
+    await flush();
 
     // Friends channel INSERT handler is the second INSERT .on() call
     const friendsInsertHandler = mockChannelOnFn.mock.calls.filter(
-      (c: unknown[]) => (c[1] as { event: string }).event === 'INSERT'
-    )[1]?.[2] as ((p: unknown) => Promise<void>) | undefined
-    expect(friendsInsertHandler).toBeDefined()
+      (c: unknown[]) => (c[1] as { event: string }).event === "INSERT",
+    )[1]?.[2] as ((p: unknown) => Promise<void>) | undefined;
+    expect(friendsInsertHandler).toBeDefined();
 
     await act(async () => {
-      await friendsInsertHandler!(makeInsertPayload({ user_id: 'user-5', id: 'p-friends', visible_to: 'friends' }))
-    })
+      await friendsInsertHandler!(
+        makeInsertPayload({ user_id: "user-5", id: "p-friends", visible_to: "friends" }),
+      );
+    });
 
-    expect(result.current.presences).toHaveLength(1)
-    expect(result.current.presences[0].id).toBe('p-friends')
-  })
+    expect(result.current.presences).toHaveLength(1);
+    expect(result.current.presences[0].id).toBe("p-friends");
+  });
 
-  it('friends channel skips community broadcasts from friends', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+  it("friends channel skips community broadcasts from friends", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
     mockSingleFn.mockResolvedValue({
-      data: { display_name: 'Friend User', avatar_url: null },
+      data: { display_name: "Friend User", avatar_url: null },
       error: null,
-    })
+    });
 
-    const result = renderHook(() => useLivePresences(['user-5']))
-    await flush()
+    const result = renderHook(() => useLivePresences(["user-5"]));
+    await flush();
 
     // Friends channel INSERT handler is the second INSERT .on() call
     const friendsInsertHandler = mockChannelOnFn.mock.calls.filter(
-      (c: unknown[]) => (c[1] as { event: string }).event === 'INSERT'
-    )[1]?.[2] as ((p: unknown) => Promise<void>) | undefined
-    expect(friendsInsertHandler).toBeDefined()
+      (c: unknown[]) => (c[1] as { event: string }).event === "INSERT",
+    )[1]?.[2] as ((p: unknown) => Promise<void>) | undefined;
+    expect(friendsInsertHandler).toBeDefined();
 
     // visible_to === 'community' — should be skipped by the friends handler guard
     await act(async () => {
-      await friendsInsertHandler!(makeInsertPayload({ user_id: 'user-5', id: 'p-community', visible_to: 'community' }))
-    })
+      await friendsInsertHandler!(
+        makeInsertPayload({ user_id: "user-5", id: "p-community", visible_to: "community" }),
+      );
+    });
 
-    expect(result.current.presences).toHaveLength(0)
-    expect(mockSingleFn).not.toHaveBeenCalled()
-  })
+    expect(result.current.presences).toHaveLength(0);
+    expect(mockSingleFn).not.toHaveBeenCalled();
+  });
 
-  it('calls removeChannel for both channels on unmount when friendIds is non-empty', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+  it("calls removeChannel for both channels on unmount when friendIds is non-empty", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
 
-    let unmount!: () => void
+    let unmount!: () => void;
     act(() => {
       const renderer = create(
         React.createElement(function TestComponent() {
-          useLivePresences(['user-5', 'user-6'])
-          return null
-        })
-      )
-      unmount = () => renderer.unmount()
-    })
-    await flush()
+          useLivePresences(["user-5", "user-6"]);
+          return null;
+        }),
+      );
+      unmount = () => renderer.unmount();
+    });
+    await flush();
 
-    act(() => { unmount() })
+    act(() => {
+      unmount();
+    });
 
-    expect((supabase as any).removeChannel).toHaveBeenCalledTimes(2)
-  })
+    expect((supabase as any).removeChannel).toHaveBeenCalledTimes(2);
+  });
 
-  it('re-subscribes and creates friends channel when friendIds changes', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+  it("re-subscribes and creates friends channel when friendIds changes", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
 
-    let setFriendIds!: (ids: string[]) => void
+    let setFriendIds!: (ids: string[]) => void;
     function TestWrapper() {
-      const [ids, setIds] = React.useState<string[]>([])
-      setFriendIds = setIds
-      useLivePresences(ids)
-      return null
+      const [ids, setIds] = React.useState<string[]>([]);
+      setFriendIds = setIds;
+      useLivePresences(ids);
+      return null;
     }
 
-    act(() => { create(React.createElement(TestWrapper)) })
-    await flush()
+    act(() => {
+      create(React.createElement(TestWrapper));
+    });
+    await flush();
 
     // Initial render with no friends: one community channel
-    expect((supabase as any).channel).toHaveBeenCalledTimes(1)
-    expect((supabase as any).removeChannel).not.toHaveBeenCalled()
+    expect((supabase as any).channel).toHaveBeenCalledTimes(1);
+    expect((supabase as any).removeChannel).not.toHaveBeenCalled();
 
     // Change friendIds — effect should tear down old channel and create two new ones
-    await act(async () => { setFriendIds(['user-5']) })
-    await flush()
+    await act(async () => {
+      setFriendIds(["user-5"]);
+    });
+    await flush();
 
-    expect((supabase as any).removeChannel).toHaveBeenCalledTimes(1)
-    expect((supabase as any).channel).toHaveBeenCalledTimes(3) // 1 original + 2 new
-  })
+    expect((supabase as any).removeChannel).toHaveBeenCalledTimes(1);
+    expect((supabase as any).channel).toHaveBeenCalledTimes(3); // 1 original + 2 new
+  });
 
-  it('does not trigger fetchPresences on second channel initial SUBSCRIBED', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+  it("does not trigger fetchPresences on second channel initial SUBSCRIBED", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
 
-    renderHook(() => useLivePresences(['user-5']))
-    await flush()
+    renderHook(() => useLivePresences(["user-5"]));
+    await flush();
 
     // fetchPresences called exactly once on initial mount
-    expect(mockNeqFn).toHaveBeenCalledTimes(1)
+    expect(mockNeqFn).toHaveBeenCalledTimes(1);
 
     // Capture the two status handlers passed to .subscribe()
     const [communityHandler, friendsHandler] = mockSubscribeFn.mock.calls.map(
-      (c: unknown[]) => c[0] as (status: string) => void
-    )
+      (c: unknown[]) => c[0] as (status: string) => void,
+    );
 
     // Fire initial SUBSCRIBED on community — should NOT trigger a refetch
-    act(() => { communityHandler('SUBSCRIBED') })
-    expect(mockNeqFn).toHaveBeenCalledTimes(1)
+    act(() => {
+      communityHandler("SUBSCRIBED");
+    });
+    expect(mockNeqFn).toHaveBeenCalledTimes(1);
 
     // Fire initial SUBSCRIBED on friends — should NOT trigger a refetch
-    act(() => { friendsHandler('SUBSCRIBED') })
-    expect(mockNeqFn).toHaveBeenCalledTimes(1)
+    act(() => {
+      friendsHandler("SUBSCRIBED");
+    });
+    expect(mockNeqFn).toHaveBeenCalledTimes(1);
 
     // Fire SUBSCRIBED again on community (reconnect) — should refetch
-    await act(async () => { communityHandler('SUBSCRIBED') })
-    await flush()
-    expect(mockNeqFn).toHaveBeenCalledTimes(2)
-  })
+    await act(async () => {
+      communityHandler("SUBSCRIBED");
+    });
+    await flush();
+    expect(mockNeqFn).toHaveBeenCalledTimes(2);
+  });
 
-  it('refetches presences and clears error after CHANNEL_ERROR + SUBSCRIBED reconnect', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+  it("refetches presences and clears error after CHANNEL_ERROR + SUBSCRIBED reconnect", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
 
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
-    expect(mockNeqFn).toHaveBeenCalledTimes(1)
+    expect(mockNeqFn).toHaveBeenCalledTimes(1);
 
-    const communityHandler = mockSubscribeFn.mock.calls[0][0] as (status: string, err?: Error) => void
+    const communityHandler = mockSubscribeFn.mock.calls[0][0] as (
+      status: string,
+      err?: Error,
+    ) => void;
 
     // Initial SUBSCRIBED — marks channel as ever-subscribed, no refetch
-    act(() => { communityHandler('SUBSCRIBED') })
-    expect(mockNeqFn).toHaveBeenCalledTimes(1)
+    act(() => {
+      communityHandler("SUBSCRIBED");
+    });
+    expect(mockNeqFn).toHaveBeenCalledTimes(1);
 
     // Channel error — sets error state
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-    act(() => { communityHandler('CHANNEL_ERROR') })
-    expect(result.current.error).not.toBeNull()
-    consoleSpy.mockRestore()
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    act(() => {
+      communityHandler("CHANNEL_ERROR");
+    });
+    expect(result.current.error).not.toBeNull();
+    consoleSpy.mockRestore();
 
     // Reconnect — should re-fetch; error cleared only after fetchPresences resolves
-    await act(async () => { communityHandler('SUBSCRIBED') })
-    await flush()
+    await act(async () => {
+      communityHandler("SUBSCRIBED");
+    });
+    await flush();
 
-    expect(mockNeqFn).toHaveBeenCalledTimes(2)
-    expect(result.current.error).toBeNull()
-  })
+    expect(mockNeqFn).toHaveBeenCalledTimes(2);
+    expect(result.current.error).toBeNull();
+  });
 
-  it('refetches after TIMED_OUT + SUBSCRIBED reconnect', async () => {
-    mockNeqFn.mockResolvedValue({ data: [], error: null })
+  it("refetches after TIMED_OUT + SUBSCRIBED reconnect", async () => {
+    mockNeqFn.mockResolvedValue({ data: [], error: null });
 
-    const result = renderHook(() => useLivePresences([]))
-    await flush()
+    const result = renderHook(() => useLivePresences([]));
+    await flush();
 
-    expect(mockNeqFn).toHaveBeenCalledTimes(1)
+    expect(mockNeqFn).toHaveBeenCalledTimes(1);
 
-    const communityHandler = mockSubscribeFn.mock.calls[0][0] as (status: string, err?: Error) => void
+    const communityHandler = mockSubscribeFn.mock.calls[0][0] as (
+      status: string,
+      err?: Error,
+    ) => void;
 
-    act(() => { communityHandler('SUBSCRIBED') })
+    act(() => {
+      communityHandler("SUBSCRIBED");
+    });
 
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-    act(() => { communityHandler('TIMED_OUT') })
-    expect(result.current.error).not.toBeNull()
-    consoleSpy.mockRestore()
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    act(() => {
+      communityHandler("TIMED_OUT");
+    });
+    expect(result.current.error).not.toBeNull();
+    consoleSpy.mockRestore();
 
-    await act(async () => { communityHandler('SUBSCRIBED') })
-    await flush()
+    await act(async () => {
+      communityHandler("SUBSCRIBED");
+    });
+    await flush();
 
-    expect(mockNeqFn).toHaveBeenCalledTimes(2)
-    expect(result.current.error).toBeNull()
-  })
+    expect(mockNeqFn).toHaveBeenCalledTimes(2);
+    expect(result.current.error).toBeNull();
+  });
 
-  it('allHealthy gate: error cleared only when both channels have initial SUBSCRIBED', async () => {
+  it("allHealthy gate: error cleared only when both channels have initial SUBSCRIBED", async () => {
     // Initial fetch fails — sets an error
-    mockNeqFn.mockResolvedValue({ data: null, error: { message: 'network down' } })
+    mockNeqFn.mockResolvedValue({ data: null, error: { message: "network down" } });
 
-    const result = renderHook(() => useLivePresences(['user-5']))
-    await flush()
+    const result = renderHook(() => useLivePresences(["user-5"]));
+    await flush();
 
-    expect(result.current.error).toBe('network down')
+    expect(result.current.error).toBe("network down");
 
     const [communityHandler, friendsHandler] = mockSubscribeFn.mock.calls.map(
-      (c: unknown[]) => c[0] as (status: string) => void
-    )
+      (c: unknown[]) => c[0] as (status: string) => void,
+    );
 
     // Community subscribes first (initial connect) — friends not yet healthy
-    act(() => { communityHandler('SUBSCRIBED') })
-    expect(result.current.error).toBe('network down') // error stays — not allHealthy yet
+    act(() => {
+      communityHandler("SUBSCRIBED");
+    });
+    expect(result.current.error).toBe("network down"); // error stays — not allHealthy yet
 
     // Friends channel also subscribes — now allHealthy, error clears
-    act(() => { friendsHandler('SUBSCRIBED') })
-    expect(result.current.error).toBeNull()
-  })
+    act(() => {
+      friendsHandler("SUBSCRIBED");
+    });
+    expect(result.current.error).toBeNull();
+  });
 
-  it('friends channel UPDATE handler skips community-visible updates from friends', async () => {
-    mockNeqFn.mockResolvedValue({ data: [makeRow({ user_id: 'user-5', message: 'original' })], error: null })
+  it("friends channel UPDATE handler skips community-visible updates from friends", async () => {
+    mockNeqFn.mockResolvedValue({
+      data: [makeRow({ user_id: "user-5", message: "original" })],
+      error: null,
+    });
 
-    const result = renderHook(() => useLivePresences(['user-5']))
-    await flush()
+    const result = renderHook(() => useLivePresences(["user-5"]));
+    await flush();
 
-    expect(result.current.presences).toHaveLength(1)
-    expect(result.current.presences[0].message).toBe('original')
+    expect(result.current.presences).toHaveLength(1);
+    expect(result.current.presences[0].message).toBe("original");
 
     // Friends channel UPDATE handler is the second UPDATE .on() call
     const friendsUpdateHandler = mockChannelOnFn.mock.calls.filter(
-      (c: unknown[]) => (c[1] as { event: string }).event === 'UPDATE'
-    )[1]?.[2] as ((p: unknown) => void) | undefined
-    expect(friendsUpdateHandler).toBeDefined()
+      (c: unknown[]) => (c[1] as { event: string }).event === "UPDATE",
+    )[1]?.[2] as ((p: unknown) => void) | undefined;
+    expect(friendsUpdateHandler).toBeDefined();
 
     // community-visible UPDATE from a friend — should be ignored by the friends handler guard
     act(() => {
       friendsUpdateHandler!({
-        new: { id: 'presence-1', user_id: 'user-5', dismissed_at: null, message: 'updated', visible_to: 'community' },
-      })
-    })
+        new: {
+          id: "presence-1",
+          user_id: "user-5",
+          dismissed_at: null,
+          message: "updated",
+          visible_to: "community",
+        },
+      });
+    });
 
     // Message should NOT have changed (community updates travel through the community channel)
-    expect(result.current.presences[0].message).toBe('original')
-  })
-})
+    expect(result.current.presences[0].message).toBe("original");
+  });
+});

--- a/hooks/__tests__/usePendingRequestCount.test.ts
+++ b/hooks/__tests__/usePendingRequestCount.test.ts
@@ -1,210 +1,237 @@
-import React from 'react'
-import { act, create } from 'react-test-renderer'
+import React from "react";
+import { act, create } from "react-test-renderer";
 
-const mockUseAuth = jest.fn()
+const mockUseAuth = jest.fn();
 
-const mockSelect = jest.fn()
+const mockSelect = jest.fn();
 const mockChannel = {
   on: jest.fn().mockReturnThis(),
   subscribe: jest.fn(),
-}
+};
 
-jest.mock('@/lib/supabase', () => ({
+jest.mock("@/lib/supabase", () => ({
   supabase: {
     from: jest.fn(() => ({ select: mockSelect })),
     channel: jest.fn(() => mockChannel),
     removeChannel: jest.fn(),
   },
-}))
+}));
 
-jest.mock('@/hooks/useAuth', () => ({
+jest.mock("@/hooks/useAuth", () => ({
   useAuth: () => mockUseAuth(),
-}))
+}));
 
-import { usePendingRequestCount } from '../usePendingRequestCount'
-import { supabase } from '@/lib/supabase'
+import { usePendingRequestCount } from "../usePendingRequestCount";
+import { supabase } from "@/lib/supabase";
 
-type HookResult<T> = { current: T }
+type HookResult<T> = { current: T };
 
 function renderHook<T>(useHook: () => T): { result: HookResult<T>; unmount: () => void } {
-  const result: HookResult<T> = { current: undefined as unknown as T }
-  let root: ReturnType<typeof create>
+  const result: HookResult<T> = { current: undefined as unknown as T };
+  let root: ReturnType<typeof create>;
   function TestComponent() {
-    result.current = useHook()
-    return null
+    result.current = useHook();
+    return null;
   }
-  act(() => { root = create(React.createElement(TestComponent)) })
-  return { result, unmount: () => act(() => { root.unmount() }) }
+  act(() => {
+    root = create(React.createElement(TestComponent));
+  });
+  return {
+    result,
+    unmount: () =>
+      act(() => {
+        root.unmount();
+      }),
+  };
 }
 
 async function flush() {
-  await act(async () => { await Promise.resolve() })
+  await act(async () => {
+    await Promise.resolve();
+  });
 }
 
-const USER_ID = 'user-me'
+const USER_ID = "user-me";
 
 beforeEach(() => {
-  jest.clearAllMocks()
-  mockUseAuth.mockReturnValue({ session: { user: { id: USER_ID } } })
-  mockChannel.on.mockReturnThis()
-})
+  jest.clearAllMocks();
+  mockUseAuth.mockReturnValue({ session: { user: { id: USER_ID } } });
+  mockChannel.on.mockReturnThis();
+});
 
-describe('usePendingRequestCount', () => {
-  it('returns 0 when unauthenticated', async () => {
-    mockUseAuth.mockReturnValue({ session: null })
-    const { result } = renderHook(() => usePendingRequestCount())
-    await flush()
+describe("usePendingRequestCount", () => {
+  it("returns 0 when unauthenticated", async () => {
+    mockUseAuth.mockReturnValue({ session: null });
+    const { result } = renderHook(() => usePendingRequestCount());
+    await flush();
 
-    expect(result.current).toBe(0)
-  })
+    expect(result.current).toBe(0);
+  });
 
-  it('returns the correct count from a successful query', async () => {
-    const eq2 = jest.fn().mockResolvedValue({ count: 3, error: null })
-    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
-    mockSelect.mockReturnValue({ eq: eq1 })
+  it("returns the correct count from a successful query", async () => {
+    const eq2 = jest.fn().mockResolvedValue({ count: 3, error: null });
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 });
+    mockSelect.mockReturnValue({ eq: eq1 });
 
-    const { result } = renderHook(() => usePendingRequestCount())
-    await flush()
+    const { result } = renderHook(() => usePendingRequestCount());
+    await flush();
 
-    expect(result.current).toBe(3)
-    expect(eq1).toHaveBeenCalledWith('addressee_id', USER_ID)
-    expect(eq2).toHaveBeenCalledWith('status', 'pending')
-  })
+    expect(result.current).toBe(3);
+    expect(eq1).toHaveBeenCalledWith("addressee_id", USER_ID);
+    expect(eq2).toHaveBeenCalledWith("status", "pending");
+  });
 
-  it('returns 0 when the query returns null count', async () => {
-    const eq2 = jest.fn().mockResolvedValue({ count: null, error: null })
-    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
-    mockSelect.mockReturnValue({ eq: eq1 })
+  it("returns 0 when the query returns null count", async () => {
+    const eq2 = jest.fn().mockResolvedValue({ count: null, error: null });
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 });
+    mockSelect.mockReturnValue({ eq: eq1 });
 
-    const { result } = renderHook(() => usePendingRequestCount())
-    await flush()
+    const { result } = renderHook(() => usePendingRequestCount());
+    await flush();
 
-    expect(result.current).toBe(0)
-  })
+    expect(result.current).toBe(0);
+  });
 
-  it('keeps previous count on query error and logs the error', async () => {
-    const eq2 = jest.fn().mockResolvedValue({ count: null, error: { message: 'RLS denied' } })
-    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
-    mockSelect.mockReturnValue({ eq: eq1 })
+  it("keeps previous count on query error and logs the error", async () => {
+    const eq2 = jest.fn().mockResolvedValue({ count: null, error: { message: "RLS denied" } });
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 });
+    mockSelect.mockReturnValue({ eq: eq1 });
 
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-    const { result } = renderHook(() => usePendingRequestCount())
-    await flush()
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    const { result } = renderHook(() => usePendingRequestCount());
+    await flush();
 
-    expect(result.current).toBe(0)
-    expect(consoleSpy).toHaveBeenCalledWith('usePendingRequestCount: query error', 'RLS denied')
-    consoleSpy.mockRestore()
-  })
+    expect(result.current).toBe(0);
+    expect(consoleSpy).toHaveBeenCalledWith("usePendingRequestCount: query error", "RLS denied");
+    consoleSpy.mockRestore();
+  });
 
-  it('logs error on fetch exception', async () => {
-    const eq2 = jest.fn().mockRejectedValue(new Error('network down'))
-    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
-    mockSelect.mockReturnValue({ eq: eq1 })
+  it("logs error on fetch exception", async () => {
+    const eq2 = jest.fn().mockRejectedValue(new Error("network down"));
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 });
+    mockSelect.mockReturnValue({ eq: eq1 });
 
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-    const { result } = renderHook(() => usePendingRequestCount())
-    await flush()
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    const { result } = renderHook(() => usePendingRequestCount());
+    await flush();
 
-    expect(result.current).toBe(0)
+    expect(result.current).toBe(0);
     expect(consoleSpy).toHaveBeenCalledWith(
-      'usePendingRequestCount: failed to fetch count',
-      expect.any(Error)
-    )
-    consoleSpy.mockRestore()
-  })
+      "usePendingRequestCount: failed to fetch count",
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+  });
 
-  it('calls removeChannel on cleanup', async () => {
-    const eq2 = jest.fn().mockResolvedValue({ count: 0, error: null })
-    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
-    mockSelect.mockReturnValue({ eq: eq1 })
+  it("calls removeChannel on cleanup", async () => {
+    const eq2 = jest.fn().mockResolvedValue({ count: 0, error: null });
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 });
+    mockSelect.mockReturnValue({ eq: eq1 });
 
-    const { unmount } = renderHook(() => usePendingRequestCount())
-    await flush()
+    const { unmount } = renderHook(() => usePendingRequestCount());
+    await flush();
 
-    unmount()
-    expect(supabase.removeChannel).toHaveBeenCalled()
-  })
+    unmount();
+    expect(supabase.removeChannel).toHaveBeenCalled();
+  });
 
-  it('subscribes with a status callback for Realtime errors', async () => {
-    const eq2 = jest.fn().mockResolvedValue({ count: 0, error: null })
-    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
-    mockSelect.mockReturnValue({ eq: eq1 })
+  it("subscribes with a status callback for Realtime errors", async () => {
+    const eq2 = jest.fn().mockResolvedValue({ count: 0, error: null });
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 });
+    mockSelect.mockReturnValue({ eq: eq1 });
 
-    renderHook(() => usePendingRequestCount())
-    await flush()
+    renderHook(() => usePendingRequestCount());
+    await flush();
 
-    expect(mockChannel.subscribe).toHaveBeenCalledWith(expect.any(Function))
-  })
+    expect(mockChannel.subscribe).toHaveBeenCalledWith(expect.any(Function));
+  });
 
-  it('does not log an error when CLOSED fires after cleanup (unmount)', async () => {
-    const eq2 = jest.fn().mockResolvedValue({ count: 0, error: null })
-    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
-    mockSelect.mockReturnValue({ eq: eq1 })
+  it("does not log an error when CLOSED fires after cleanup (unmount)", async () => {
+    const eq2 = jest.fn().mockResolvedValue({ count: 0, error: null });
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 });
+    mockSelect.mockReturnValue({ eq: eq1 });
 
-    const { unmount } = renderHook(() => usePendingRequestCount())
-    await flush()
+    const { unmount } = renderHook(() => usePendingRequestCount());
+    await flush();
 
-    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (status: string) => void
-    act(() => { statusHandler('SUBSCRIBED') })
+    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (status: string) => void;
+    act(() => {
+      statusHandler("SUBSCRIBED");
+    });
 
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-    unmount()
-    act(() => { statusHandler('CLOSED') })
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    unmount();
+    act(() => {
+      statusHandler("CLOSED");
+    });
 
-    expect(consoleSpy).not.toHaveBeenCalled()
-    consoleSpy.mockRestore()
-  })
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
 
-  it('suppresses error when CHANNEL_ERROR fires while app is backgrounded', async () => {
-    const { AppState } = require('react-native')
-    const original = AppState.currentState
-    const eq2 = jest.fn().mockResolvedValue({ count: 0, error: null })
-    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
-    mockSelect.mockReturnValue({ eq: eq1 })
+  it("suppresses error when CHANNEL_ERROR fires while app is backgrounded", async () => {
+    const { AppState } = require("react-native");
+    const original = AppState.currentState;
+    const eq2 = jest.fn().mockResolvedValue({ count: 0, error: null });
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 });
+    mockSelect.mockReturnValue({ eq: eq1 });
 
-    renderHook(() => usePendingRequestCount())
-    await flush()
+    renderHook(() => usePendingRequestCount());
+    await flush();
 
-    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (status: string) => void
-    act(() => { statusHandler('SUBSCRIBED') })
+    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (status: string) => void;
+    act(() => {
+      statusHandler("SUBSCRIBED");
+    });
 
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-    AppState.currentState = 'background'
-    act(() => { statusHandler('CHANNEL_ERROR') })
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    AppState.currentState = "background";
+    act(() => {
+      statusHandler("CHANNEL_ERROR");
+    });
 
-    expect(consoleSpy).not.toHaveBeenCalled()
-    consoleSpy.mockRestore()
-    AppState.currentState = original
-  })
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+    AppState.currentState = original;
+  });
 
-  it('refetches count after CHANNEL_ERROR + SUBSCRIBED reconnect', async () => {
-    const eq2 = jest.fn().mockResolvedValue({ count: 3, error: null })
-    const eq1 = jest.fn().mockReturnValue({ eq: eq2 })
-    mockSelect.mockReturnValue({ eq: eq1 })
+  it("refetches count after CHANNEL_ERROR + SUBSCRIBED reconnect", async () => {
+    const eq2 = jest.fn().mockResolvedValue({ count: 3, error: null });
+    const eq1 = jest.fn().mockReturnValue({ eq: eq2 });
+    mockSelect.mockReturnValue({ eq: eq1 });
 
-    const { result } = renderHook(() => usePendingRequestCount())
-    await flush()
+    const { result } = renderHook(() => usePendingRequestCount());
+    await flush();
 
-    expect(eq2).toHaveBeenCalledTimes(1)
-    expect(result.current).toBe(3)
+    expect(eq2).toHaveBeenCalledTimes(1);
+    expect(result.current).toBe(3);
 
-    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (status: string, err?: Error) => void
+    const statusHandler = mockChannel.subscribe.mock.calls[0][0] as (
+      status: string,
+      err?: Error,
+    ) => void;
 
     // Initial SUBSCRIBED — marks as subscribed-once, no refetch
-    act(() => { statusHandler('SUBSCRIBED') })
-    expect(eq2).toHaveBeenCalledTimes(1)
+    act(() => {
+      statusHandler("SUBSCRIBED");
+    });
+    expect(eq2).toHaveBeenCalledTimes(1);
 
     // Channel error
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
-    act(() => { statusHandler('CHANNEL_ERROR') })
-    consoleSpy.mockRestore()
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    act(() => {
+      statusHandler("CHANNEL_ERROR");
+    });
+    consoleSpy.mockRestore();
 
     // Reconnect — should re-fetch with updated count
-    eq2.mockResolvedValue({ count: 5, error: null })
-    await act(async () => { statusHandler('SUBSCRIBED') })
-    await flush()
+    eq2.mockResolvedValue({ count: 5, error: null });
+    await act(async () => {
+      statusHandler("SUBSCRIBED");
+    });
+    await flush();
 
-    expect(eq2).toHaveBeenCalledTimes(2)
-    expect(result.current).toBe(5)
-  })
-})
+    expect(eq2).toHaveBeenCalledTimes(2);
+    expect(result.current).toBe(5);
+  });
+});

--- a/hooks/__tests__/usePoiRatings.test.ts
+++ b/hooks/__tests__/usePoiRatings.test.ts
@@ -11,24 +11,24 @@
  * out-of-scope references.
  */
 
-import React from 'react'
-import { act, create } from 'react-test-renderer'
+import React from "react";
+import { act, create } from "react-test-renderer";
 
 // ---------------------------------------------------------------------------
 // Variables that the jest.mock() factories reference must be mock-prefixed.
 // ---------------------------------------------------------------------------
 
 // The terminal `.order()` call is what resolves with test data.
-const mockOrderFn = jest.fn()
+const mockOrderFn = jest.fn();
 
 // useAuth return value — replaced per-test in beforeEach.
-const mockUseAuth = jest.fn()
+const mockUseAuth = jest.fn();
 
 // ---------------------------------------------------------------------------
 // Module mocks — hoisted before any imports that trigger the modules.
 // ---------------------------------------------------------------------------
 
-jest.mock('@/lib/supabase', () => ({
+jest.mock("@/lib/supabase", () => ({
   supabase: {
     from: jest.fn(() => ({
       select: jest.fn(() => ({
@@ -38,67 +38,69 @@ jest.mock('@/lib/supabase', () => ({
       })),
     })),
   },
-}))
+}));
 
-jest.mock('@/hooks/useAuth', () => ({
+jest.mock("@/hooks/useAuth", () => ({
   useAuth: () => mockUseAuth(),
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Import hook AFTER mocks are registered.
 // ---------------------------------------------------------------------------
-import { usePoiRatings } from '../usePoiRatings'
+import { usePoiRatings } from "../usePoiRatings";
 
 // ---------------------------------------------------------------------------
 // Minimal renderHook helper (no @testing-library dependency required).
 // ---------------------------------------------------------------------------
-type HookResult<T> = { current: T }
+type HookResult<T> = { current: T };
 
 function renderHook<T>(useHook: () => T): HookResult<T> {
-  const result: HookResult<T> = { current: undefined as unknown as T }
+  const result: HookResult<T> = { current: undefined as unknown as T };
 
   function TestComponent() {
-    result.current = useHook()
-    return null
+    result.current = useHook();
+    return null;
   }
 
   act(() => {
-    create(React.createElement(TestComponent))
-  })
+    create(React.createElement(TestComponent));
+  });
 
-  return result
+  return result;
 }
 
 // Flush all pending microtasks + React state updates.
 async function flush() {
   await act(async () => {
-    await Promise.resolve()
-  })
+    await Promise.resolve();
+  });
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-const POI_ID = 'poi-abc'
+const POI_ID = "poi-abc";
 
-function makeRow(overrides: Partial<{
-  id: string
-  rating: number
-  comment: string | null
-  created_at: string
-  user_id: string
-  profiles: { display_name: string }
-}> = {}) {
+function makeRow(
+  overrides: Partial<{
+    id: string;
+    rating: number;
+    comment: string | null;
+    created_at: string;
+    user_id: string;
+    profiles: { display_name: string };
+  }> = {},
+) {
   return {
-    id: 'row-1',
+    id: "row-1",
     rating: 4,
-    comment: 'Nice place',
-    created_at: '2025-01-01T00:00:00Z',
-    user_id: 'user-1',
-    profiles: { display_name: 'Alice' },
+    comment: "Nice place",
+    created_at: "2025-01-01T00:00:00Z",
+    user_id: "user-1",
+    profiles: { display_name: "Alice" },
     ...overrides,
-  }
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -106,67 +108,67 @@ function makeRow(overrides: Partial<{
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-  jest.clearAllMocks()
+  jest.clearAllMocks();
   // Default: authenticated user
-  mockUseAuth.mockReturnValue({ session: { user: { id: 'user-1' } } })
-})
+  mockUseAuth.mockReturnValue({ session: { user: { id: "user-1" } } });
+});
 
-describe('usePoiRatings', () => {
-  it('avgRating is null and ratingCount is 0 when query returns zero rows', async () => {
-    mockOrderFn.mockResolvedValue({ data: [], error: null })
+describe("usePoiRatings", () => {
+  it("avgRating is null and ratingCount is 0 when query returns zero rows", async () => {
+    mockOrderFn.mockResolvedValue({ data: [], error: null });
 
-    const result = renderHook(() => usePoiRatings(POI_ID))
-    await flush()
+    const result = renderHook(() => usePoiRatings(POI_ID));
+    await flush();
 
-    expect(result.current.avgRating).toBeNull()
-    expect(result.current.ratingCount).toBe(0)
-  })
+    expect(result.current.avgRating).toBeNull();
+    expect(result.current.ratingCount).toBe(0);
+  });
 
-  it('avgRating is computed correctly for two rows with ratings 3 and 5', async () => {
+  it("avgRating is computed correctly for two rows with ratings 3 and 5", async () => {
     mockOrderFn.mockResolvedValue({
-      data: [makeRow({ id: 'r1', rating: 3 }), makeRow({ id: 'r2', rating: 5 })],
+      data: [makeRow({ id: "r1", rating: 3 }), makeRow({ id: "r2", rating: 5 })],
       error: null,
-    })
+    });
 
-    const result = renderHook(() => usePoiRatings(POI_ID))
-    await flush()
+    const result = renderHook(() => usePoiRatings(POI_ID));
+    await flush();
 
-    expect(result.current.avgRating).toBe(4)
-    expect(result.current.ratingCount).toBe(2)
-  })
+    expect(result.current.avgRating).toBe(4);
+    expect(result.current.ratingCount).toBe(2);
+  });
 
-  it('comments are capped at 5 even when 7 rows with comments are returned', async () => {
+  it("comments are capped at 5 even when 7 rows with comments are returned", async () => {
     const rows = Array.from({ length: 7 }, (_, i) =>
-      makeRow({ id: `r${i}`, user_id: `user-${i}`, comment: `Comment ${i}` })
-    )
-    mockOrderFn.mockResolvedValue({ data: rows, error: null })
+      makeRow({ id: `r${i}`, user_id: `user-${i}`, comment: `Comment ${i}` }),
+    );
+    mockOrderFn.mockResolvedValue({ data: rows, error: null });
 
-    const result = renderHook(() => usePoiRatings(POI_ID))
-    await flush()
+    const result = renderHook(() => usePoiRatings(POI_ID));
+    await flush();
 
-    expect(result.current.comments.length).toBe(5)
-  })
+    expect(result.current.comments.length).toBe(5);
+  });
 
-  it('sets error state and leaves avgRating null when query returns an error', async () => {
-    mockOrderFn.mockResolvedValue({ data: null, error: { message: 'network error' } })
+  it("sets error state and leaves avgRating null when query returns an error", async () => {
+    mockOrderFn.mockResolvedValue({ data: null, error: { message: "network error" } });
 
-    const result = renderHook(() => usePoiRatings(POI_ID))
-    await flush()
+    const result = renderHook(() => usePoiRatings(POI_ID));
+    await flush();
 
-    expect(result.current.error).toBe('network error')
-    expect(result.current.avgRating).toBeNull()
-  })
+    expect(result.current.error).toBe("network error");
+    expect(result.current.avgRating).toBeNull();
+  });
 
-  it('myRating is null when session has no userId', async () => {
-    mockUseAuth.mockReturnValue({ session: null })
+  it("myRating is null when session has no userId", async () => {
+    mockUseAuth.mockReturnValue({ session: null });
     mockOrderFn.mockResolvedValue({
-      data: [makeRow({ id: 'r1', user_id: 'user-1', rating: 5 })],
+      data: [makeRow({ id: "r1", user_id: "user-1", rating: 5 })],
       error: null,
-    })
+    });
 
-    const result = renderHook(() => usePoiRatings(POI_ID))
-    await flush()
+    const result = renderHook(() => usePoiRatings(POI_ID));
+    await flush();
 
-    expect(result.current.myRating).toBeNull()
-  })
-})
+    expect(result.current.myRating).toBeNull();
+  });
+});

--- a/hooks/__tests__/usePresenceJoins.test.ts
+++ b/hooks/__tests__/usePresenceJoins.test.ts
@@ -1,29 +1,33 @@
-import React from 'react'
-import { act, create } from 'react-test-renderer'
+import React from "react";
+import { act, create } from "react-test-renderer";
 
-const mockEqFn = jest.fn()
-const mockUseAuth = jest.fn()
-const mockJoinPresence = jest.fn()
-const mockCancelJoin = jest.fn()
+const mockEqFn = jest.fn();
+const mockUseAuth = jest.fn();
+const mockJoinPresence = jest.fn();
+const mockCancelJoin = jest.fn();
 
 // Realtime channel mock — captured so tests can invoke callbacks directly
-let mockSubscribeCallback: ((status: string, err?: unknown) => void) | null = null
-let mockUpdateCallback: ((payload: { new: unknown }) => void) | null = null
+let mockSubscribeCallback: ((status: string, err?: unknown) => void) | null = null;
+let mockUpdateCallback: ((payload: { new: unknown }) => void) | null = null;
 
 const mockChannel = {
-  on: jest.fn().mockImplementation((_event: string, _filter: unknown, cb: (payload: { new: unknown }) => void) => {
-    mockUpdateCallback = cb
-    return mockChannel
-  }),
+  on: jest
+    .fn()
+    .mockImplementation(
+      (_event: string, _filter: unknown, cb: (payload: { new: unknown }) => void) => {
+        mockUpdateCallback = cb;
+        return mockChannel;
+      },
+    ),
   subscribe: jest.fn().mockImplementation((cb: (status: string, err?: unknown) => void) => {
-    mockSubscribeCallback = cb
-    return mockChannel
+    mockSubscribeCallback = cb;
+    return mockChannel;
   }),
-}
+};
 
-const mockRemoveChannel = jest.fn()
+const mockRemoveChannel = jest.fn();
 
-jest.mock('@/lib/supabase', () => ({
+jest.mock("@/lib/supabase", () => ({
   supabase: {
     from: jest.fn(() => ({
       select: jest.fn(() => ({
@@ -33,370 +37,392 @@ jest.mock('@/lib/supabase', () => ({
     channel: jest.fn(() => mockChannel),
     removeChannel: jest.fn(),
   },
-}))
+}));
 
-jest.mock('@/hooks/useAuth', () => ({
+jest.mock("@/hooks/useAuth", () => ({
   useAuth: () => mockUseAuth(),
-}))
+}));
 
-jest.mock('@/lib/presenceJoins', () => ({
+jest.mock("@/lib/presenceJoins", () => ({
   joinPresence: (...args: unknown[]) => mockJoinPresence(...args),
   cancelJoin: (...args: unknown[]) => mockCancelJoin(...args),
-}))
+}));
 
-import { usePresenceJoins } from '../usePresenceJoins'
+import { usePresenceJoins } from "../usePresenceJoins";
 
-type HookResult<T> = { current: T }
+type HookResult<T> = { current: T };
 
 function renderHook<T>(useHook: () => T): HookResult<T> {
-  const result: HookResult<T> = { current: undefined as unknown as T }
+  const result: HookResult<T> = { current: undefined as unknown as T };
 
   function TestComponent() {
-    result.current = useHook()
-    return null
+    result.current = useHook();
+    return null;
   }
 
   act(() => {
-    create(React.createElement(TestComponent))
-  })
+    create(React.createElement(TestComponent));
+  });
 
-  return result
+  return result;
 }
 
 async function flush() {
   await act(async () => {
-    await Promise.resolve()
-  })
+    await Promise.resolve();
+  });
 }
 
 const MOCK_JOIN_ROW = {
-  id: 'join-1',
-  presence_id: 'presence-1',
-  joiner_user_id: 'user-1',
-  joined_at: '2026-01-01T00:00:00Z',
+  id: "join-1",
+  presence_id: "presence-1",
+  joiner_user_id: "user-1",
+  joined_at: "2026-01-01T00:00:00Z",
   confirmed: false,
-}
+};
 
 const MOCK_JOIN_ROW_2 = {
-  id: 'join-2',
-  presence_id: 'presence-2',
-  joiner_user_id: 'user-1',
-  joined_at: '2026-01-02T00:00:00Z',
+  id: "join-2",
+  presence_id: "presence-2",
+  joiner_user_id: "user-1",
+  joined_at: "2026-01-02T00:00:00Z",
   confirmed: false,
-}
+};
 
 beforeEach(() => {
-  jest.clearAllMocks()
-  mockUseAuth.mockReturnValue({ session: { user: { id: 'user-1' } } })
-  mockSubscribeCallback = null
-  mockUpdateCallback = null
-  const AppState = require('react-native').AppState
-  AppState.currentState = 'active'
-})
+  jest.clearAllMocks();
+  mockUseAuth.mockReturnValue({ session: { user: { id: "user-1" } } });
+  mockSubscribeCallback = null;
+  mockUpdateCallback = null;
+  const AppState = require("react-native").AppState;
+  AppState.currentState = "active";
+});
 
-describe('usePresenceJoins', () => {
-  it('returns empty joins when query returns no rows', async () => {
-    mockEqFn.mockResolvedValue({ data: [], error: null })
+describe("usePresenceJoins", () => {
+  it("returns empty joins when query returns no rows", async () => {
+    mockEqFn.mockResolvedValue({ data: [], error: null });
 
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
 
-    expect(result.current.joins).toEqual([])
-    expect(result.current.loading).toBe(false)
-  })
+    expect(result.current.joins).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
 
-  it('returns joins when query returns rows', async () => {
-    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null })
+  it("returns joins when query returns rows", async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null });
 
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
 
-    expect(result.current.joins).toEqual([MOCK_JOIN_ROW])
-    expect(result.current.loading).toBe(false)
-  })
+    expect(result.current.joins).toEqual([MOCK_JOIN_ROW]);
+    expect(result.current.loading).toBe(false);
+  });
 
-  it('loading is true before the fetch resolves', async () => {
-    let resolve!: (value: { data: typeof MOCK_JOIN_ROW[]; error: null }) => void
-    mockEqFn.mockReturnValue(new Promise((r) => { resolve = r }))
-
-    const result = renderHook(() => usePresenceJoins())
-    expect(result.current.loading).toBe(true)
-
-    await act(async () => { resolve({ data: [], error: null }) })
-    expect(result.current.loading).toBe(false)
-  })
-
-  it('sets error state when fetch returns a Supabase error', async () => {
-    mockEqFn.mockResolvedValue({ data: null, error: { message: 'network error' } })
-
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
-
-    expect(result.current.error).toBe('network error')
-    expect(result.current.joins).toEqual([])
-    expect(result.current.loading).toBe(false)
-  })
-
-  it('sets error state when fetch throws a JS exception', async () => {
-    mockEqFn.mockRejectedValue(new Error('connection refused'))
-
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
-
-    expect(result.current.error).toBe('connection refused')
-    expect(result.current.joins).toEqual([])
-    expect(result.current.loading).toBe(false)
-  })
-
-  it('returns empty joins when user is not authenticated', async () => {
-    mockUseAuth.mockReturnValue({ session: null })
-
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
-
-    expect(result.current.joins).toEqual([])
-    expect(result.current.loading).toBe(false)
-    expect(mockEqFn).not.toHaveBeenCalled()
-  })
-
-  it('join() calls joinPresence and appends to state', async () => {
-    mockEqFn.mockResolvedValue({ data: [], error: null })
-    mockJoinPresence.mockResolvedValue(MOCK_JOIN_ROW)
-
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
-
-    await act(async () => {
-      await result.current.join('presence-1')
-    })
-
-    expect(mockJoinPresence).toHaveBeenCalled()
-    expect(result.current.joins).toEqual([MOCK_JOIN_ROW])
-  })
-
-  it('join() deduplicates if same row is returned twice', async () => {
-    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null })
-    mockJoinPresence.mockResolvedValue(MOCK_JOIN_ROW)
-
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
-
-    await act(async () => {
-      await result.current.join('presence-1')
-    })
-
-    expect(result.current.joins).toHaveLength(1)
-    expect(result.current.joins[0]).toEqual(MOCK_JOIN_ROW)
-  })
-
-  it('join() propagates error without mutating state', async () => {
-    mockEqFn.mockResolvedValue({ data: [], error: null })
-    mockJoinPresence.mockRejectedValue(new Error('unique violation'))
-
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
-
-    await expect(
-      act(async () => { await result.current.join('presence-1') })
-    ).rejects.toThrow('unique violation')
-
-    expect(result.current.joins).toEqual([])
-  })
-
-  it('cancel() calls cancelJoin and removes from state', async () => {
-    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW, MOCK_JOIN_ROW_2], error: null })
-    mockCancelJoin.mockResolvedValue(undefined)
-
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
-
-    expect(result.current.joins).toHaveLength(2)
-
-    await act(async () => {
-      await result.current.cancel('join-1')
-    })
-
-    expect(mockCancelJoin).toHaveBeenCalled()
-    expect(result.current.joins).toEqual([MOCK_JOIN_ROW_2])
-  })
-
-  it('cancel() propagates error without removing from state', async () => {
-    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null })
-    mockCancelJoin.mockRejectedValue(new Error('Join not found or already cancelled'))
-
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
-
-    await expect(
-      act(async () => { await result.current.cancel('join-1') })
-    ).rejects.toThrow('Join not found or already cancelled')
-
-    expect(result.current.joins).toEqual([MOCK_JOIN_ROW])
-  })
-
-  it('getJoinForPresence returns matching join', async () => {
-    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW, MOCK_JOIN_ROW_2], error: null })
-
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
-
-    expect(result.current.getJoinForPresence('presence-1')).toEqual(MOCK_JOIN_ROW)
-    expect(result.current.getJoinForPresence('presence-2')).toEqual(MOCK_JOIN_ROW_2)
-  })
-
-  it('getJoinForPresence returns undefined when no match', async () => {
-    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null })
-
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
-
-    expect(result.current.getJoinForPresence('presence-999')).toBeUndefined()
-  })
-
-  it('Realtime UPDATE event updates the matching join in state', async () => {
-    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null })
-
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
-
-    expect(result.current.joins[0].confirmed).toBe(false)
-
-    const confirmedRow = { ...MOCK_JOIN_ROW, confirmed: true }
-    await act(async () => {
-      mockUpdateCallback!({ new: confirmedRow })
-    })
-
-    expect(result.current.joins[0].confirmed).toBe(true)
-  })
-
-  it('Realtime UPDATE event does not affect other joins', async () => {
-    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW, MOCK_JOIN_ROW_2], error: null })
-
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
-
-    const confirmedRow = { ...MOCK_JOIN_ROW, confirmed: true }
-    await act(async () => {
-      mockUpdateCallback!({ new: confirmedRow })
-    })
-
-    expect(result.current.joins).toHaveLength(2)
-    expect(result.current.joins.find((j) => j.id === 'join-1')!.confirmed).toBe(true)
-    expect(result.current.joins.find((j) => j.id === 'join-2')!.confirmed).toBe(false)
-  })
-
-  it('subscribes to UPDATE events filtered by joiner_user_id', async () => {
-    mockEqFn.mockResolvedValue({ data: [], error: null })
-    renderHook(() => usePresenceJoins())
-    await flush()
-    expect(mockChannel.on).toHaveBeenCalledWith(
-      'postgres_changes',
-      expect.objectContaining({
-        event: 'UPDATE',
-        schema: 'public',
-        table: 'presence_joins',
-        filter: expect.stringContaining('joiner_user_id=eq.user-1'),
+  it("loading is true before the fetch resolves", async () => {
+    let resolve!: (value: { data: (typeof MOCK_JOIN_ROW)[]; error: null }) => void;
+    mockEqFn.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
       }),
-      expect.any(Function)
-    )
-  })
+    );
 
-  it('Realtime UPDATE event for unknown join id does not mutate state', async () => {
-    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null })
-    const result = renderHook(() => usePresenceJoins())
-    await flush()
-    const unknownRow = { ...MOCK_JOIN_ROW, id: 'join-unknown', confirmed: true }
+    const result = renderHook(() => usePresenceJoins());
+    expect(result.current.loading).toBe(true);
+
     await act(async () => {
-      mockUpdateCallback!({ new: unknownRow })
-    })
-    expect(result.current.joins).toHaveLength(1)
-    expect(result.current.joins[0]).toEqual(MOCK_JOIN_ROW)
-  })
+      resolve({ data: [], error: null });
+    });
+    expect(result.current.loading).toBe(false);
+  });
 
-  it('suppresses Realtime error when app is backgrounded', async () => {
-    const AppState = require('react-native').AppState
-    AppState.currentState = 'background'
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  it("sets error state when fetch returns a Supabase error", async () => {
+    mockEqFn.mockResolvedValue({ data: null, error: { message: "network error" } });
 
-    mockEqFn.mockResolvedValue({ data: [], error: null })
-    renderHook(() => usePresenceJoins())
-    await flush()
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
 
-    act(() => { mockSubscribeCallback!('CHANNEL_ERROR') })
+    expect(result.current.error).toBe("network error");
+    expect(result.current.joins).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
 
-    expect(consoleSpy).not.toHaveBeenCalled()
+  it("sets error state when fetch throws a JS exception", async () => {
+    mockEqFn.mockRejectedValue(new Error("connection refused"));
 
-    AppState.currentState = 'active'
-    consoleSpy.mockRestore()
-  })
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
 
-  it('logs Realtime error when app is active', async () => {
-    const AppState = require('react-native').AppState
-    AppState.currentState = 'active'
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    expect(result.current.error).toBe("connection refused");
+    expect(result.current.joins).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
 
-    mockEqFn.mockResolvedValue({ data: [], error: null })
-    renderHook(() => usePresenceJoins())
-    await flush()
+  it("returns empty joins when user is not authenticated", async () => {
+    mockUseAuth.mockReturnValue({ session: null });
 
-    act(() => { mockSubscribeCallback!('CHANNEL_ERROR', new Error('ws error')) })
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('CHANNEL_ERROR'),
-      expect.any(Error)
-    )
-    consoleSpy.mockRestore()
-  })
+    expect(result.current.joins).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(mockEqFn).not.toHaveBeenCalled();
+  });
 
-  it('suppresses TIMED_OUT status when app is backgrounded', async () => {
-    const AppState = require('react-native').AppState
-    AppState.currentState = 'background'
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  it("join() calls joinPresence and appends to state", async () => {
+    mockEqFn.mockResolvedValue({ data: [], error: null });
+    mockJoinPresence.mockResolvedValue(MOCK_JOIN_ROW);
 
-    mockEqFn.mockResolvedValue({ data: [], error: null })
-    renderHook(() => usePresenceJoins())
-    await flush()
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
 
-    act(() => { mockSubscribeCallback!('TIMED_OUT') })
+    await act(async () => {
+      await result.current.join("presence-1");
+    });
 
-    expect(consoleSpy).not.toHaveBeenCalled()
+    expect(mockJoinPresence).toHaveBeenCalled();
+    expect(result.current.joins).toEqual([MOCK_JOIN_ROW]);
+  });
 
-    consoleSpy.mockRestore()
-  })
+  it("join() deduplicates if same row is returned twice", async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null });
+    mockJoinPresence.mockResolvedValue(MOCK_JOIN_ROW);
 
-  it('logs TIMED_OUT status when app is active', async () => {
-    const AppState = require('react-native').AppState
-    AppState.currentState = 'active'
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
 
-    mockEqFn.mockResolvedValue({ data: [], error: null })
-    renderHook(() => usePresenceJoins())
-    await flush()
+    await act(async () => {
+      await result.current.join("presence-1");
+    });
 
-    act(() => { mockSubscribeCallback!('TIMED_OUT', new Error('timeout')) })
+    expect(result.current.joins).toHaveLength(1);
+    expect(result.current.joins[0]).toEqual(MOCK_JOIN_ROW);
+  });
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('TIMED_OUT'),
-      expect.any(Error)
-    )
-    consoleSpy.mockRestore()
-  })
+  it("join() propagates error without mutating state", async () => {
+    mockEqFn.mockResolvedValue({ data: [], error: null });
+    mockJoinPresence.mockRejectedValue(new Error("unique violation"));
 
-  it('removes Realtime channel on unmount', async () => {
-    mockEqFn.mockResolvedValue({ data: [], error: null })
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
 
-    let renderer: ReturnType<typeof create>
+    await expect(
+      act(async () => {
+        await result.current.join("presence-1");
+      }),
+    ).rejects.toThrow("unique violation");
+
+    expect(result.current.joins).toEqual([]);
+  });
+
+  it("cancel() calls cancelJoin and removes from state", async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW, MOCK_JOIN_ROW_2], error: null });
+    mockCancelJoin.mockResolvedValue(undefined);
+
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
+
+    expect(result.current.joins).toHaveLength(2);
+
+    await act(async () => {
+      await result.current.cancel("join-1");
+    });
+
+    expect(mockCancelJoin).toHaveBeenCalled();
+    expect(result.current.joins).toEqual([MOCK_JOIN_ROW_2]);
+  });
+
+  it("cancel() propagates error without removing from state", async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null });
+    mockCancelJoin.mockRejectedValue(new Error("Join not found or already cancelled"));
+
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
+
+    await expect(
+      act(async () => {
+        await result.current.cancel("join-1");
+      }),
+    ).rejects.toThrow("Join not found or already cancelled");
+
+    expect(result.current.joins).toEqual([MOCK_JOIN_ROW]);
+  });
+
+  it("getJoinForPresence returns matching join", async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW, MOCK_JOIN_ROW_2], error: null });
+
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
+
+    expect(result.current.getJoinForPresence("presence-1")).toEqual(MOCK_JOIN_ROW);
+    expect(result.current.getJoinForPresence("presence-2")).toEqual(MOCK_JOIN_ROW_2);
+  });
+
+  it("getJoinForPresence returns undefined when no match", async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null });
+
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
+
+    expect(result.current.getJoinForPresence("presence-999")).toBeUndefined();
+  });
+
+  it("Realtime UPDATE event updates the matching join in state", async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null });
+
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
+
+    expect(result.current.joins[0].confirmed).toBe(false);
+
+    const confirmedRow = { ...MOCK_JOIN_ROW, confirmed: true };
+    await act(async () => {
+      mockUpdateCallback!({ new: confirmedRow });
+    });
+
+    expect(result.current.joins[0].confirmed).toBe(true);
+  });
+
+  it("Realtime UPDATE event does not affect other joins", async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW, MOCK_JOIN_ROW_2], error: null });
+
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
+
+    const confirmedRow = { ...MOCK_JOIN_ROW, confirmed: true };
+    await act(async () => {
+      mockUpdateCallback!({ new: confirmedRow });
+    });
+
+    expect(result.current.joins).toHaveLength(2);
+    expect(result.current.joins.find((j) => j.id === "join-1")!.confirmed).toBe(true);
+    expect(result.current.joins.find((j) => j.id === "join-2")!.confirmed).toBe(false);
+  });
+
+  it("subscribes to UPDATE events filtered by joiner_user_id", async () => {
+    mockEqFn.mockResolvedValue({ data: [], error: null });
+    renderHook(() => usePresenceJoins());
+    await flush();
+    expect(mockChannel.on).toHaveBeenCalledWith(
+      "postgres_changes",
+      expect.objectContaining({
+        event: "UPDATE",
+        schema: "public",
+        table: "presence_joins",
+        filter: expect.stringContaining("joiner_user_id=eq.user-1"),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it("Realtime UPDATE event for unknown join id does not mutate state", async () => {
+    mockEqFn.mockResolvedValue({ data: [MOCK_JOIN_ROW], error: null });
+    const result = renderHook(() => usePresenceJoins());
+    await flush();
+    const unknownRow = { ...MOCK_JOIN_ROW, id: "join-unknown", confirmed: true };
+    await act(async () => {
+      mockUpdateCallback!({ new: unknownRow });
+    });
+    expect(result.current.joins).toHaveLength(1);
+    expect(result.current.joins[0]).toEqual(MOCK_JOIN_ROW);
+  });
+
+  it("suppresses Realtime error when app is backgrounded", async () => {
+    const AppState = require("react-native").AppState;
+    AppState.currentState = "background";
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mockEqFn.mockResolvedValue({ data: [], error: null });
+    renderHook(() => usePresenceJoins());
+    await flush();
+
     act(() => {
-      renderer = create(React.createElement(function TestUnmount() {
-        usePresenceJoins()
-        return null
-      }))
-    })
-    await flush()
+      mockSubscribeCallback!("CHANNEL_ERROR");
+    });
 
-    act(() => { renderer!.unmount() })
+    expect(consoleSpy).not.toHaveBeenCalled();
 
-    const { supabase } = require('@/lib/supabase')
-    expect(supabase.removeChannel).toHaveBeenCalled()
-  })
-})
+    AppState.currentState = "active";
+    consoleSpy.mockRestore();
+  });
+
+  it("logs Realtime error when app is active", async () => {
+    const AppState = require("react-native").AppState;
+    AppState.currentState = "active";
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mockEqFn.mockResolvedValue({ data: [], error: null });
+    renderHook(() => usePresenceJoins());
+    await flush();
+
+    act(() => {
+      mockSubscribeCallback!("CHANNEL_ERROR", new Error("ws error"));
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("CHANNEL_ERROR"),
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it("suppresses TIMED_OUT status when app is backgrounded", async () => {
+    const AppState = require("react-native").AppState;
+    AppState.currentState = "background";
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mockEqFn.mockResolvedValue({ data: [], error: null });
+    renderHook(() => usePresenceJoins());
+    await flush();
+
+    act(() => {
+      mockSubscribeCallback!("TIMED_OUT");
+    });
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
+  it("logs TIMED_OUT status when app is active", async () => {
+    const AppState = require("react-native").AppState;
+    AppState.currentState = "active";
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mockEqFn.mockResolvedValue({ data: [], error: null });
+    renderHook(() => usePresenceJoins());
+    await flush();
+
+    act(() => {
+      mockSubscribeCallback!("TIMED_OUT", new Error("timeout"));
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("TIMED_OUT"),
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it("removes Realtime channel on unmount", async () => {
+    mockEqFn.mockResolvedValue({ data: [], error: null });
+
+    let renderer: ReturnType<typeof create>;
+    act(() => {
+      renderer = create(
+        React.createElement(function TestUnmount() {
+          usePresenceJoins();
+          return null;
+        }),
+      );
+    });
+    await flush();
+
+    act(() => {
+      renderer!.unmount();
+    });
+
+    const { supabase } = require("@/lib/supabase");
+    expect(supabase.removeChannel).toHaveBeenCalled();
+  });
+});

--- a/hooks/__tests__/useProximity.test.ts
+++ b/hooks/__tests__/useProximity.test.ts
@@ -5,8 +5,8 @@
  * and mock expo-location for the hook behaviour tests.
  */
 
-import React from 'react'
-import { act, create } from 'react-test-renderer'
+import React from "react";
+import { act, create } from "react-test-renderer";
 
 // ---------------------------------------------------------------------------
 // Mock expo-location before any imports that trigger it.
@@ -14,178 +14,184 @@ import { act, create } from 'react-test-renderer'
 // avoid TDZ issues with Babel's jest.mock hoisting.
 // ---------------------------------------------------------------------------
 
-jest.mock('expo-location', () => ({
+jest.mock("expo-location", () => ({
   Accuracy: { Balanced: 3 },
   watchPositionAsync: jest.fn(),
-}))
+}));
 
-import * as ExpoLocation from 'expo-location'
-import { getDistanceMeters } from '../useProximity'
-import { useProximity } from '../useProximity'
+import * as ExpoLocation from "expo-location";
+import { getDistanceMeters } from "../useProximity";
+import { useProximity } from "../useProximity";
 
-const mockRemove = jest.fn()
-const mockWatchPositionAsync = ExpoLocation.watchPositionAsync as jest.Mock
+const mockRemove = jest.fn();
+const mockWatchPositionAsync = ExpoLocation.watchPositionAsync as jest.Mock;
 
 // ---------------------------------------------------------------------------
 // renderHook helper (same pattern as other hook tests)
 // ---------------------------------------------------------------------------
 
-type HookResult<T> = { current: T }
+type HookResult<T> = { current: T };
 
 function renderHook<T>(useHook: () => T): HookResult<T> {
-  const result: HookResult<T> = { current: undefined as unknown as T }
+  const result: HookResult<T> = { current: undefined as unknown as T };
 
   function TestComponent() {
-    result.current = useHook()
-    return null
+    result.current = useHook();
+    return null;
   }
 
   act(() => {
-    create(React.createElement(TestComponent))
-  })
+    create(React.createElement(TestComponent));
+  });
 
-  return result
+  return result;
 }
 
 async function flush() {
   await act(async () => {
-    await Promise.resolve()
-  })
+    await Promise.resolve();
+  });
 }
 
 // ---------------------------------------------------------------------------
 // Haversine tests
 // ---------------------------------------------------------------------------
 
-describe('getDistanceMeters', () => {
-  it('returns 0 for identical coordinates', () => {
+describe("getDistanceMeters", () => {
+  it("returns 0 for identical coordinates", () => {
     // Fix 8: use toBeLessThan(1) instead of toBe(0) to avoid floating-point brittleness
-    expect(getDistanceMeters(55.6761, 12.5683, 55.6761, 12.5683)).toBeLessThan(1)
-  })
+    expect(getDistanceMeters(55.6761, 12.5683, 55.6761, 12.5683)).toBeLessThan(1);
+  });
 
-  it('returns approximately correct distance for two known Copenhagen points', () => {
+  it("returns approximately correct distance for two known Copenhagen points", () => {
     // Copenhagen City Hall (55.6761, 12.5683) to Nyhavn (55.6800, 12.5900)
     // Straight-line distance is roughly 1.5 km
-    const dist = getDistanceMeters(55.6761, 12.5683, 55.6800, 12.5900)
-    expect(dist).toBeGreaterThan(1_400)
-    expect(dist).toBeLessThan(1_700)
-  })
+    const dist = getDistanceMeters(55.6761, 12.5683, 55.68, 12.59);
+    expect(dist).toBeGreaterThan(1_400);
+    expect(dist).toBeLessThan(1_700);
+  });
 
-  it('returns approximately correct distance for a ~100m separation', () => {
+  it("returns approximately correct distance for a ~100m separation", () => {
     // Move ~0.0009 degrees lat ≈ 100m
-    const dist = getDistanceMeters(55.6761, 12.5683, 55.6770, 12.5683)
-    expect(dist).toBeGreaterThan(80)
-    expect(dist).toBeLessThan(120)
-  })
-})
+    const dist = getDistanceMeters(55.6761, 12.5683, 55.677, 12.5683);
+    expect(dist).toBeGreaterThan(80);
+    expect(dist).toBeLessThan(120);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Hook tests
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-  mockRemove.mockReset()
-  mockWatchPositionAsync.mockReset()
-  mockWatchPositionAsync.mockResolvedValue({ remove: mockRemove })
-})
+  mockRemove.mockReset();
+  mockWatchPositionAsync.mockReset();
+  mockWatchPositionAsync.mockResolvedValue({ remove: mockRemove });
+});
 
-describe('useProximity', () => {
-  const TARGET = { lat: 55.6761, lng: 12.5683 }
+describe("useProximity", () => {
+  const TARGET = { lat: 55.6761, lng: 12.5683 };
 
-  it('isNearby is false when target is null', async () => {
-    const result = renderHook(() => useProximity(null))
-    await flush()
+  it("isNearby is false when target is null", async () => {
+    const result = renderHook(() => useProximity(null));
+    await flush();
 
-    expect(result.current.isNearby).toBe(false)
-    expect(mockWatchPositionAsync).not.toHaveBeenCalled()
-  })
+    expect(result.current.isNearby).toBe(false);
+    expect(mockWatchPositionAsync).not.toHaveBeenCalled();
+  });
 
   // Fix 3: make async, flush before invoking callback, assert callback is not null
-  it('isNearby is true when simulated location is within 100m', async () => {
-    let locationCallback: ((loc: { coords: { latitude: number; longitude: number } }) => void) | null = null
+  it("isNearby is true when simulated location is within 100m", async () => {
+    let locationCallback:
+      | ((loc: { coords: { latitude: number; longitude: number } }) => void)
+      | null = null;
 
     mockWatchPositionAsync.mockImplementation((_opts: unknown, cb: typeof locationCallback) => {
-      locationCallback = cb
-      return Promise.resolve({ remove: mockRemove })
-    })
+      locationCallback = cb;
+      return Promise.resolve({ remove: mockRemove });
+    });
 
-    const result = renderHook(() => useProximity(TARGET))
-    await flush() // ensure the .then has run
+    const result = renderHook(() => useProximity(TARGET));
+    await flush(); // ensure the .then has run
 
-    expect(locationCallback).not.toBeNull()
+    expect(locationCallback).not.toBeNull();
 
     // Simulate location update ~50m away
     act(() => {
-      locationCallback!({ coords: { latitude: 55.6766, longitude: 12.5683 } })
-    })
+      locationCallback!({ coords: { latitude: 55.6766, longitude: 12.5683 } });
+    });
 
-    expect(result.current.isNearby).toBe(true)
-  })
+    expect(result.current.isNearby).toBe(true);
+  });
 
   // Fix 3: make async, flush before invoking callback, assert callback is not null
-  it('isNearby is false when simulated location is beyond 100m', async () => {
-    let locationCallback: ((loc: { coords: { latitude: number; longitude: number } }) => void) | null = null
+  it("isNearby is false when simulated location is beyond 100m", async () => {
+    let locationCallback:
+      | ((loc: { coords: { latitude: number; longitude: number } }) => void)
+      | null = null;
 
     mockWatchPositionAsync.mockImplementation((_opts: unknown, cb: typeof locationCallback) => {
-      locationCallback = cb
-      return Promise.resolve({ remove: mockRemove })
-    })
+      locationCallback = cb;
+      return Promise.resolve({ remove: mockRemove });
+    });
 
-    const result = renderHook(() => useProximity(TARGET))
-    await flush() // ensure the .then has run
+    const result = renderHook(() => useProximity(TARGET));
+    await flush(); // ensure the .then has run
 
-    expect(locationCallback).not.toBeNull()
+    expect(locationCallback).not.toBeNull();
 
     // Simulate location update ~500m away
     act(() => {
-      locationCallback!({ coords: { latitude: 55.6806, longitude: 12.5683 } })
-    })
+      locationCallback!({ coords: { latitude: 55.6806, longitude: 12.5683 } });
+    });
 
-    expect(result.current.isNearby).toBe(false)
-  })
+    expect(result.current.isNearby).toBe(false);
+  });
 
   // Fix 4: test custom radiusMeters parameter
-  it('isNearby is false when location is within default radius but beyond custom radiusMeters', async () => {
-    let locationCallback: ((loc: { coords: { latitude: number; longitude: number } }) => void) | null = null
+  it("isNearby is false when location is within default radius but beyond custom radiusMeters", async () => {
+    let locationCallback:
+      | ((loc: { coords: { latitude: number; longitude: number } }) => void)
+      | null = null;
 
     mockWatchPositionAsync.mockImplementation((_opts: unknown, cb: typeof locationCallback) => {
-      locationCallback = cb
-      return Promise.resolve({ remove: mockRemove })
-    })
+      locationCallback = cb;
+      return Promise.resolve({ remove: mockRemove });
+    });
 
     // radiusMeters: 50 — target is ~80m away, within 100m but outside 50m
-    const result = renderHook(() => useProximity(TARGET, 50))
-    await flush() // ensure the .then has run
+    const result = renderHook(() => useProximity(TARGET, 50));
+    await flush(); // ensure the .then has run
 
-    expect(locationCallback).not.toBeNull()
+    expect(locationCallback).not.toBeNull();
 
     // ~80m north of target (0.00072 degrees ≈ 80m)
     act(() => {
-      locationCallback!({ coords: { latitude: 55.6769, longitude: 12.5683 } })
-    })
+      locationCallback!({ coords: { latitude: 55.6769, longitude: 12.5683 } });
+    });
 
-    expect(result.current.isNearby).toBe(false)
-  })
+    expect(result.current.isNearby).toBe(false);
+  });
 
   // Fix 1: make async, await flush inside async act before unmounting
-  it('calls subscription.remove() on cleanup', async () => {
-    let instance: ReturnType<typeof create>
+  it("calls subscription.remove() on cleanup", async () => {
+    let instance: ReturnType<typeof create>;
 
     await act(async () => {
       instance = create(
         React.createElement(function TestComponent() {
-          useProximity(TARGET)
-          return null
-        })
-      )
-    })
+          useProximity(TARGET);
+          return null;
+        }),
+      );
+    });
 
-    await flush()
+    await flush();
 
     act(() => {
-      instance!.unmount()
-    })
+      instance!.unmount();
+    });
 
-    expect(mockRemove).toHaveBeenCalled()
-  })
-})
+    expect(mockRemove).toHaveBeenCalled();
+  });
+});

--- a/hooks/__tests__/useUserSearch.test.ts
+++ b/hooks/__tests__/useUserSearch.test.ts
@@ -1,233 +1,241 @@
-import React, { useState } from 'react'
-import { act, create } from 'react-test-renderer'
+import React, { useState } from "react";
+import { act, create } from "react-test-renderer";
 
-const mockSearchUsers = jest.fn()
+const mockSearchUsers = jest.fn();
 
-jest.mock('@/lib/friends', () => ({
+jest.mock("@/lib/friends", () => ({
   searchUsers: (...args: unknown[]) => mockSearchUsers(...args),
-}))
+}));
 
-jest.mock('@/lib/supabase', () => ({
+jest.mock("@/lib/supabase", () => ({
   supabase: {},
-}))
+}));
 
-import { useUserSearch } from '../useUserSearch'
+import { useUserSearch } from "../useUserSearch";
 
-type HookResult<T> = { current: T }
+type HookResult<T> = { current: T };
 
 function renderHook<T>(useHook: () => T): HookResult<T> {
-  const result: HookResult<T> = { current: undefined as unknown as T }
+  const result: HookResult<T> = { current: undefined as unknown as T };
 
   function TestComponent() {
-    result.current = useHook()
-    return null
+    result.current = useHook();
+    return null;
   }
 
   act(() => {
-    create(React.createElement(TestComponent))
-  })
+    create(React.createElement(TestComponent));
+  });
 
-  return result
+  return result;
 }
 
 async function flush() {
   await act(async () => {
-    await Promise.resolve()
-  })
+    await Promise.resolve();
+  });
 }
 
-const MOCK_RESULTS = [
-  { id: 'user-1', display_name: 'Jane Doe', avatar_url: null },
-]
+const MOCK_RESULTS = [{ id: "user-1", display_name: "Jane Doe", avatar_url: null }];
 
 beforeEach(() => {
-  jest.clearAllMocks()
-  jest.useFakeTimers()
-})
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
 
 afterEach(() => {
-  jest.useRealTimers()
-})
+  jest.useRealTimers();
+});
 
-describe('useUserSearch', () => {
-  it('state is idle when query is empty string', () => {
-    const result = renderHook(() => useUserSearch(''))
-    expect(result.current.state).toBe('idle')
-    expect(result.current.results).toEqual([])
-    expect(mockSearchUsers).not.toHaveBeenCalled()
-  })
+describe("useUserSearch", () => {
+  it("state is idle when query is empty string", () => {
+    const result = renderHook(() => useUserSearch(""));
+    expect(result.current.state).toBe("idle");
+    expect(result.current.results).toEqual([]);
+    expect(mockSearchUsers).not.toHaveBeenCalled();
+  });
 
-  it('state is idle when query is 1 character', () => {
-    const result = renderHook(() => useUserSearch('J'))
-    expect(result.current.state).toBe('idle')
-    expect(mockSearchUsers).not.toHaveBeenCalled()
-  })
+  it("state is idle when query is 1 character", () => {
+    const result = renderHook(() => useUserSearch("J"));
+    expect(result.current.state).toBe("idle");
+    expect(mockSearchUsers).not.toHaveBeenCalled();
+  });
 
-  it('state transitions to searching immediately for 2+ char query', () => {
-    const result = renderHook(() => useUserSearch('Ja'))
-    expect(result.current.state).toBe('searching')
-  })
+  it("state transitions to searching immediately for 2+ char query", () => {
+    const result = renderHook(() => useUserSearch("Ja"));
+    expect(result.current.state).toBe("searching");
+  });
 
-  it('fires search after 300ms debounce and transitions to results', async () => {
-    mockSearchUsers.mockResolvedValue(MOCK_RESULTS)
+  it("fires search after 300ms debounce and transitions to results", async () => {
+    mockSearchUsers.mockResolvedValue(MOCK_RESULTS);
 
-    const result = renderHook(() => useUserSearch('Ja'))
-    expect(result.current.state).toBe('searching')
-
-    await act(async () => {
-      jest.advanceTimersByTime(300)
-      await Promise.resolve()
-    })
-
-    expect(mockSearchUsers).toHaveBeenCalledTimes(1)
-    expect(result.current.state).toBe('results')
-    expect(result.current.results).toEqual(MOCK_RESULTS)
-    expect(result.current.error).toBeNull()
-  })
-
-  it('does not fire search before debounce delay', () => {
-    mockSearchUsers.mockResolvedValue(MOCK_RESULTS)
-
-    renderHook(() => useUserSearch('Jane'))
-    jest.advanceTimersByTime(299)
-
-    expect(mockSearchUsers).not.toHaveBeenCalled()
-  })
-
-  it('state is error with message when searchUsers throws', async () => {
-    mockSearchUsers.mockRejectedValue(new Error('network failure'))
-
-    const result = renderHook(() => useUserSearch('Ja'))
+    const result = renderHook(() => useUserSearch("Ja"));
+    expect(result.current.state).toBe("searching");
 
     await act(async () => {
-      jest.advanceTimersByTime(300)
-      await Promise.resolve()
-    })
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
 
-    expect(result.current.state).toBe('error')
-    expect(result.current.error).toBe('network failure')
-    expect(result.current.results).toEqual([])
-  })
+    expect(mockSearchUsers).toHaveBeenCalledTimes(1);
+    expect(result.current.state).toBe("results");
+    expect(result.current.results).toEqual(MOCK_RESULTS);
+    expect(result.current.error).toBeNull();
+  });
 
-  it('resets to idle and clears results when query drops below 2 chars', async () => {
-    mockSearchUsers.mockResolvedValue(MOCK_RESULTS)
+  it("does not fire search before debounce delay", () => {
+    mockSearchUsers.mockResolvedValue(MOCK_RESULTS);
+
+    renderHook(() => useUserSearch("Jane"));
+    jest.advanceTimersByTime(299);
+
+    expect(mockSearchUsers).not.toHaveBeenCalled();
+  });
+
+  it("state is error with message when searchUsers throws", async () => {
+    mockSearchUsers.mockRejectedValue(new Error("network failure"));
+
+    const result = renderHook(() => useUserSearch("Ja"));
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(result.current.state).toBe("error");
+    expect(result.current.error).toBe("network failure");
+    expect(result.current.results).toEqual([]);
+  });
+
+  it("resets to idle and clears results when query drops below 2 chars", async () => {
+    mockSearchUsers.mockResolvedValue(MOCK_RESULTS);
 
     // First render with valid query to get results
-    let query = 'Jane'
-    const result = renderHook(() => useUserSearch(query))
+    let query = "Jane";
+    const result = renderHook(() => useUserSearch(query));
 
     await act(async () => {
-      jest.advanceTimersByTime(300)
-      await Promise.resolve()
-    })
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
 
-    expect(result.current.state).toBe('results')
+    expect(result.current.state).toBe("results");
 
     // Re-render with short query — in practice this happens via useState in the parent
     // We test the hook in isolation by directly verifying idle transition
-    const result2 = renderHook(() => useUserSearch(''))
-    expect(result2.current.state).toBe('idle')
-    expect(result2.current.results).toEqual([])
-  })
+    const result2 = renderHook(() => useUserSearch(""));
+    expect(result2.current.state).toBe("idle");
+    expect(result2.current.results).toEqual([]);
+  });
 
-  it('passes trimmed query to searchUsers', async () => {
-    mockSearchUsers.mockResolvedValue([])
+  it("passes trimmed query to searchUsers", async () => {
+    mockSearchUsers.mockResolvedValue([]);
 
-    renderHook(() => useUserSearch('  Jane  '))
+    renderHook(() => useUserSearch("  Jane  "));
 
     await act(async () => {
-      jest.advanceTimersByTime(300)
-      await Promise.resolve()
-    })
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
 
-    expect(mockSearchUsers).toHaveBeenCalledWith(
-      expect.anything(),
-      { query: 'Jane' }
-    )
-  })
+    expect(mockSearchUsers).toHaveBeenCalledWith(expect.anything(), { query: "Jane" });
+  });
 
-  it('discards stale results when query drops below threshold while search is in-flight', async () => {
-    let resolveSearch!: (v: typeof MOCK_RESULTS) => void
-    mockSearchUsers.mockImplementation(() => new Promise((r) => { resolveSearch = r }))
+  it("discards stale results when query drops below threshold while search is in-flight", async () => {
+    let resolveSearch!: (v: typeof MOCK_RESULTS) => void;
+    mockSearchUsers.mockImplementation(
+      () =>
+        new Promise((r) => {
+          resolveSearch = r;
+        }),
+    );
 
-    let setQueryExternal!: (q: string) => void
-    const result: { current: ReturnType<typeof useUserSearch> } = { current: undefined as never }
+    let setQueryExternal!: (q: string) => void;
+    const result: { current: ReturnType<typeof useUserSearch> } = { current: undefined as never };
 
     function TestComponent() {
-      const [q, setQ] = useState('Ja')
-      setQueryExternal = setQ
-      result.current = useUserSearch(q)
-      return null
+      const [q, setQ] = useState("Ja");
+      setQueryExternal = setQ;
+      result.current = useUserSearch(q);
+      return null;
     }
 
-    act(() => { create(React.createElement(TestComponent)) })
+    act(() => {
+      create(React.createElement(TestComponent));
+    });
 
     // Advance past debounce — search fires and is now in-flight
     await act(async () => {
-      jest.advanceTimersByTime(300)
-      await Promise.resolve()
-    })
-    expect(mockSearchUsers).toHaveBeenCalledTimes(1)
-    expect(result.current.state).toBe('searching')
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+    expect(mockSearchUsers).toHaveBeenCalledTimes(1);
+    expect(result.current.state).toBe("searching");
 
     // Drop query below threshold while search is in-flight — cleanup sets active = false
-    act(() => { setQueryExternal('J') })
-    expect(result.current.state).toBe('idle')
+    act(() => {
+      setQueryExternal("J");
+    });
+    expect(result.current.state).toBe("idle");
 
     // Stale search resolves — should be discarded because active is false
     await act(async () => {
-      resolveSearch(MOCK_RESULTS)
-      await Promise.resolve()
-    })
+      resolveSearch(MOCK_RESULTS);
+      await Promise.resolve();
+    });
 
-    expect(result.current.state).toBe('idle')
-    expect(result.current.results).toEqual([])
-  })
+    expect(result.current.state).toBe("idle");
+    expect(result.current.results).toEqual([]);
+  });
 
-  it('cancels the previous debounce timer when the query changes', async () => {
-    mockSearchUsers.mockResolvedValue(MOCK_RESULTS)
+  it("cancels the previous debounce timer when the query changes", async () => {
+    mockSearchUsers.mockResolvedValue(MOCK_RESULTS);
 
-    let setQueryExternal!: (q: string) => void
-    const result: { current: ReturnType<typeof useUserSearch> } = { current: undefined as never }
+    let setQueryExternal!: (q: string) => void;
+    const result: { current: ReturnType<typeof useUserSearch> } = { current: undefined as never };
 
     function TestComponent() {
-      const [q, setQ] = useState('Ja')
-      setQueryExternal = setQ
-      result.current = useUserSearch(q)
-      return null
+      const [q, setQ] = useState("Ja");
+      setQueryExternal = setQ;
+      result.current = useUserSearch(q);
+      return null;
     }
 
-    act(() => { create(React.createElement(TestComponent)) })
+    act(() => {
+      create(React.createElement(TestComponent));
+    });
 
     // Advance 200ms — debounce has not yet fired
-    jest.advanceTimersByTime(200)
-    expect(mockSearchUsers).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(200);
+    expect(mockSearchUsers).not.toHaveBeenCalled();
 
     // Change query — previous timer should be cancelled and a new 300ms window starts
-    act(() => { setQueryExternal('Jane') })
+    act(() => {
+      setQueryExternal("Jane");
+    });
 
     // Advance 300ms more — only the 'Jane' search should fire
     await act(async () => {
-      jest.advanceTimersByTime(300)
-      await Promise.resolve()
-    })
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
 
-    expect(mockSearchUsers).toHaveBeenCalledTimes(1)
-    expect(mockSearchUsers).toHaveBeenCalledWith(expect.anything(), { query: 'Jane' })
-    expect(result.current.state).toBe('results')
-  })
+    expect(mockSearchUsers).toHaveBeenCalledTimes(1);
+    expect(mockSearchUsers).toHaveBeenCalledWith(expect.anything(), { query: "Jane" });
+    expect(result.current.state).toBe("results");
+  });
 
-  it('sets error to Search failed when a non-Error value is thrown', async () => {
-    mockSearchUsers.mockRejectedValue('plain string error')
+  it("sets error to Search failed when a non-Error value is thrown", async () => {
+    mockSearchUsers.mockRejectedValue("plain string error");
 
-    const result = renderHook(() => useUserSearch('Ja'))
+    const result = renderHook(() => useUserSearch("Ja"));
 
     await act(async () => {
-      jest.advanceTimersByTime(300)
-      await Promise.resolve()
-    })
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
 
-    expect(result.current.state).toBe('error')
-    expect(result.current.error).toBe('Search failed')
-  })
-})
+    expect(result.current.state).toBe("error");
+    expect(result.current.error).toBe("Search failed");
+  });
+});

--- a/hooks/useActivePresence.ts
+++ b/hooks/useActivePresence.ts
@@ -1,53 +1,53 @@
-import { useState, useEffect, useCallback } from 'react'
-import { supabase } from '@/lib/supabase'
-import { useAuth } from '@/hooks/useAuth'
-import { ActivePresence } from '@/lib/presence'
+import { useState, useEffect, useCallback } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
+import { ActivePresence } from "@/lib/presence";
 
 export function useActivePresence() {
-  const { session } = useAuth()
-  const [activePresence, setActivePresence] = useState<ActivePresence | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const { session } = useAuth();
+  const [activePresence, setActivePresence] = useState<ActivePresence | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const userId = session?.user.id
+    const userId = session?.user.id;
     if (!userId) {
-      setActivePresence(null)
-      setLoading(false)
-      return
+      setActivePresence(null);
+      setLoading(false);
+      return;
     }
 
-    let active = true
+    let active = true;
 
     supabase
-      .from('live_presence')
-      .select('id, poi_id, message, visible_to')
-      .eq('user_id', userId)
-      .is('dismissed_at', null)
-      .order('created_at', { ascending: false })
+      .from("live_presence")
+      .select("id, poi_id, message, visible_to")
+      .eq("user_id", userId)
+      .is("dismissed_at", null)
+      .order("created_at", { ascending: false })
       .limit(1)
       .then(({ data, error: fetchError }) => {
-        if (!active) return
+        if (!active) return;
         if (fetchError) {
-          setError(fetchError.message)
+          setError(fetchError.message);
         } else {
-          setActivePresence((data && data.length > 0) ? (data[0] as ActivePresence) : null)
+          setActivePresence(data && data.length > 0 ? (data[0] as ActivePresence) : null);
         }
-        setLoading(false)
-      })
+        setLoading(false);
+      });
 
     return () => {
-      active = false
-    }
-  }, [session?.user.id])
+      active = false;
+    };
+  }, [session?.user.id]);
 
   const setBroadcast = useCallback((presence: ActivePresence) => {
-    setActivePresence(presence)
-  }, [])
+    setActivePresence(presence);
+  }, []);
 
   const clearBroadcast = useCallback(() => {
-    setActivePresence(null)
-  }, [])
+    setActivePresence(null);
+  }, []);
 
-  return { activePresence, loading, error, setBroadcast, clearBroadcast }
+  return { activePresence, loading, error, setBroadcast, clearBroadcast };
 }

--- a/hooks/useAllPoiRatings.ts
+++ b/hooks/useAllPoiRatings.ts
@@ -1,55 +1,60 @@
-import { useState, useEffect, useCallback } from 'react'
-import { supabase } from '@/lib/supabase'
+import { useState, useEffect, useCallback } from "react";
+import { supabase } from "@/lib/supabase";
 
 // Shape of a row returned by the poi_avg_ratings view (migration 009).
 // Typed manually here because the view was added after the last `supabase gen types` run.
 // TODO: remove AvgRatingRow, the response type cast, and the (supabase as any) cast once
 // types/supabase.ts is regenerated after migration 009 (`supabase gen types`).
-type AvgRatingRow = { poi_id: string; avg_rating: number | null }
+type AvgRatingRow = { poi_id: string; avg_rating: number | null };
 
 export function useAllPoiRatings() {
-  const [avgRatings, setAvgRatings] = useState<Record<string, number>>({})
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [avgRatings, setAvgRatings] = useState<Record<string, number>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const refetch = useCallback(async (signal?: { cancelled: boolean }) => {
-    setLoading(true)
-    setError(null)
+    setLoading(true);
+    setError(null);
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data, error: fetchError } = await (supabase as any)
-        .from('poi_avg_ratings')
-        .select('poi_id, avg_rating') as { data: AvgRatingRow[] | null; error: { message: string } | null }
+      const { data, error: fetchError } = (await (supabase as any)
+        .from("poi_avg_ratings")
+        .select("poi_id, avg_rating")) as {
+        data: AvgRatingRow[] | null;
+        error: { message: string } | null;
+      };
 
-      if (signal?.cancelled) return
+      if (signal?.cancelled) return;
 
       if (fetchError) {
-        console.error('useAllPoiRatings:', fetchError.message)
-        setError(fetchError.message)
-        return
+        console.error("useAllPoiRatings:", fetchError.message);
+        setError(fetchError.message);
+        return;
       }
-      const result: Record<string, number> = {}
+      const result: Record<string, number> = {};
       for (const row of data ?? []) {
         if (row.avg_rating !== null) {
-          result[row.poi_id] = Number(row.avg_rating)
+          result[row.poi_id] = Number(row.avg_rating);
         }
       }
-      setAvgRatings(result)
+      setAvgRatings(result);
     } catch (e) {
-      if (signal?.cancelled) return
-      const message = e instanceof Error ? e.message : 'Unknown error fetching ratings'
-      console.error('useAllPoiRatings (unexpected):', message)
-      setError(message)
+      if (signal?.cancelled) return;
+      const message = e instanceof Error ? e.message : "Unknown error fetching ratings";
+      console.error("useAllPoiRatings (unexpected):", message);
+      setError(message);
     } finally {
-      if (!signal?.cancelled) setLoading(false)
+      if (!signal?.cancelled) setLoading(false);
     }
-  }, [])
+  }, []);
 
   useEffect(() => {
-    const signal = { cancelled: false }
-    refetch(signal)
-    return () => { signal.cancelled = true }
-  }, [refetch])
+    const signal = { cancelled: false };
+    refetch(signal);
+    return () => {
+      signal.cancelled = true;
+    };
+  }, [refetch]);
 
-  return { avgRatings, loading, error, refetch }
+  return { avgRatings, loading, error, refetch };
 }

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,32 +1,34 @@
-import { useState, useEffect } from 'react'
-import { Session } from '@supabase/supabase-js'
-import { supabase } from '@/lib/supabase'
+import { useState, useEffect } from "react";
+import { Session } from "@supabase/supabase-js";
+import { supabase } from "@/lib/supabase";
 
 export function useAuth() {
-  const [session, setSession] = useState<Session | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session }, error }) => {
       if (error) {
-        console.error('Failed to restore session:', error.message)
+        console.error("Failed to restore session:", error.message);
       } else {
-        setSession(session)
+        setSession(session);
       }
-      setLoading(false)
-    })
+      setLoading(false);
+    });
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session)
-    })
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+    });
 
-    return () => subscription.unsubscribe()
-  }, [])
+    return () => subscription.unsubscribe();
+  }, []);
 
   const signOut = async () => {
-    const { error } = await supabase.auth.signOut()
-    if (error) console.error('Sign out failed:', error.message)
-  }
+    const { error } = await supabase.auth.signOut();
+    if (error) console.error("Sign out failed:", error.message);
+  };
 
-  return { session, loading, signOut }
+  return { session, loading, signOut };
 }

--- a/hooks/useFriendships.ts
+++ b/hooks/useFriendships.ts
@@ -1,7 +1,7 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { AppState } from 'react-native'
-import { supabase } from '@/lib/supabase'
-import { useAuth } from '@/hooks/useAuth'
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { AppState } from "react-native";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
 import {
   FriendshipStatus,
   FriendshipWithProfiles,
@@ -11,235 +11,253 @@ import {
   acceptRequest as libAcceptRequest,
   declineRequest as libDeclineRequest,
   unfriend as libUnfriend,
-} from '@/lib/friendships'
+} from "@/lib/friendships";
 
 export type FriendEntry = {
-  friendshipId: string
-  userId: string
-  displayName: string
-  avatarUrl: string | null
-}
+  friendshipId: string;
+  userId: string;
+  displayName: string;
+  avatarUrl: string | null;
+};
 
 export type IncomingRequestEntry = {
-  friendshipId: string
-  requesterId: string
-  displayName: string
-  avatarUrl: string | null
-}
+  friendshipId: string;
+  requesterId: string;
+  displayName: string;
+  avatarUrl: string | null;
+};
 
 function deriveState(rows: FriendshipWithProfiles[], userId: string) {
-  const friends: FriendEntry[] = []
-  const incomingRequests: IncomingRequestEntry[] = []
+  const friends: FriendEntry[] = [];
+  const incomingRequests: IncomingRequestEntry[] = [];
   // Maps counterparty userId → friendshipId for pending-sent rows.
   // Using a Map enables O(1) status lookups in the search results view.
-  const outgoingRequestMap = new Map<string, string>()
+  const outgoingRequestMap = new Map<string, string>();
 
   for (const row of rows) {
-    const iAmRequester = row.requester_id === userId
-    const counterparty = iAmRequester ? row.addressee : row.requester
+    const iAmRequester = row.requester_id === userId;
+    const counterparty = iAmRequester ? row.addressee : row.requester;
 
-    if (row.status === 'accepted') {
+    if (row.status === "accepted") {
       friends.push({
         friendshipId: row.id,
         userId: counterparty.id,
         displayName: counterparty.display_name,
         avatarUrl: counterparty.avatar_url,
-      })
-    } else if (row.status === 'pending') {
+      });
+    } else if (row.status === "pending") {
       if (iAmRequester) {
-        outgoingRequestMap.set(counterparty.id, row.id)
+        outgoingRequestMap.set(counterparty.id, row.id);
       } else {
         incomingRequests.push({
           friendshipId: row.id,
           requesterId: row.requester.id,
           displayName: row.requester.display_name,
           avatarUrl: row.requester.avatar_url,
-        })
+        });
       }
     }
   }
 
-  return { friends, incomingRequests, outgoingRequestMap }
+  return { friends, incomingRequests, outgoingRequestMap };
 }
 
 export function useFriendships() {
-  const { session } = useAuth()
-  const [rows, setRows] = useState<FriendshipWithProfiles[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const channelId = useRef(`friendships-changes-${Date.now()}-${Math.random()}`)
+  const { session } = useAuth();
+  const [rows, setRows] = useState<FriendshipWithProfiles[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const channelId = useRef(`friendships-changes-${Date.now()}-${Math.random()}`);
 
   useEffect(() => {
-    const userId = session?.user.id
+    const userId = session?.user.id;
     if (!userId) {
-      setRows([])
-      setLoading(false)
-      return
+      setRows([]);
+      setLoading(false);
+      return;
     }
 
-    let active = true
-    setError(null)
-    setLoading(true)
+    let active = true;
+    setError(null);
+    setLoading(true);
 
     async function load() {
       try {
-        const data = await fetchFriendships(supabase)
-        if (!active) return
-        setRows(data)
+        const data = await fetchFriendships(supabase);
+        if (!active) return;
+        setRows(data);
       } catch (err) {
-        if (!active) return
-        const message = err instanceof Error ? err.message : 'Unknown error'
-        console.error('useFriendships:', message)
-        setError(message)
+        if (!active) return;
+        const message = err instanceof Error ? err.message : "Unknown error";
+        console.error("useFriendships:", message);
+        setError(message);
       } finally {
-        if (active) setLoading(false)
+        if (active) setLoading(false);
       }
     }
 
-    load()
+    load();
 
     // Subscribe to changes on the friendships table and refetch.
     // RLS ensures only events for the current user's rows are delivered.
     // This keeps both parties in sync without a reload — e.g. the recipient
     // sees an incoming request immediately when the sender taps "Add Friend".
-    let subscribedOnce = false
+    let subscribedOnce = false;
     const channel = supabase
       .channel(channelId.current)
-      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'friendships' }, () => {
-        if (active) load()
+      .on("postgres_changes", { event: "INSERT", schema: "public", table: "friendships" }, () => {
+        if (active) load();
       })
-      .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'friendships' }, () => {
-        if (active) load()
+      .on("postgres_changes", { event: "UPDATE", schema: "public", table: "friendships" }, () => {
+        if (active) load();
       })
-      .on('postgres_changes', { event: 'DELETE', schema: 'public', table: 'friendships' }, () => {
-        if (active) load()
+      .on("postgres_changes", { event: "DELETE", schema: "public", table: "friendships" }, () => {
+        if (active) load();
       })
       .subscribe((status, err) => {
-        if (!active) return
-        if (status === 'SUBSCRIBED') {
+        if (!active) return;
+        if (status === "SUBSCRIBED") {
           if (subscribedOnce) {
             // Reconnected after a drop — re-fetch to catch missed events and clear error
             if (active) {
-              setError(null)
-              load()
+              setError(null);
+              load();
             }
           } else {
-            subscribedOnce = true
+            subscribedOnce = true;
           }
-        } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
+        } else if (status === "CHANNEL_ERROR" || status === "TIMED_OUT" || status === "CLOSED") {
           // App backgrounding drops the WebSocket — suppress noise, reconnect handles recovery
-          if (AppState.currentState === 'background') return
-          console.error(`useFriendships: Realtime ${status}`, err ?? '(no details)')
-          setError('Live updates disconnected — pull to refresh.')
+          if (AppState.currentState === "background") return;
+          console.error(`useFriendships: Realtime ${status}`, err ?? "(no details)");
+          setError("Live updates disconnected — pull to refresh.");
         }
-      })
+      });
 
     return () => {
-      active = false
-      supabase.removeChannel(channel)
-    }
-  }, [session?.user.id])
+      active = false;
+      supabase.removeChannel(channel);
+    };
+  }, [session?.user.id]);
 
-  const userId = session?.user.id ?? ''
+  const userId = session?.user.id ?? "";
 
   const { friends, incomingRequests, outgoingRequestMap } = useMemo(
     () => deriveState(rows, userId),
-    [rows, userId]
-  )
+    [rows, userId],
+  );
 
-  const readonlyOutgoingRequestMap: ReadonlyMap<string, string> = outgoingRequestMap
-  const pendingCount = incomingRequests.length
+  const readonlyOutgoingRequestMap: ReadonlyMap<string, string> = outgoingRequestMap;
+  const pendingCount = incomingRequests.length;
 
-  const getStatusForUser = useCallback((targetUserId: string): FriendshipStatus => {
-    if (friends.some((f) => f.userId === targetUserId)) return 'accepted'
-    if (outgoingRequestMap.has(targetUserId)) return 'pending_sent'
-    if (incomingRequests.some((r) => r.requesterId === targetUserId)) return 'pending_received'
-    return 'none'
-  }, [friends, outgoingRequestMap, incomingRequests])
+  const getStatusForUser = useCallback(
+    (targetUserId: string): FriendshipStatus => {
+      if (friends.some((f) => f.userId === targetUserId)) return "accepted";
+      if (outgoingRequestMap.has(targetUserId)) return "pending_sent";
+      if (incomingRequests.some((r) => r.requesterId === targetUserId)) return "pending_received";
+      return "none";
+    },
+    [friends, outgoingRequestMap, incomingRequests],
+  );
 
-  const getFriendshipId = useCallback((targetUserId: string): string | null => {
-    return outgoingRequestMap.get(targetUserId) ??
-      incomingRequests.find((r) => r.requesterId === targetUserId)?.friendshipId ??
-      friends.find((f) => f.userId === targetUserId)?.friendshipId ??
-      null
-  }, [friends, outgoingRequestMap, incomingRequests])
+  const getFriendshipId = useCallback(
+    (targetUserId: string): string | null => {
+      return (
+        outgoingRequestMap.get(targetUserId) ??
+        incomingRequests.find((r) => r.requesterId === targetUserId)?.friendshipId ??
+        friends.find((f) => f.userId === targetUserId)?.friendshipId ??
+        null
+      );
+    },
+    [friends, outgoingRequestMap, incomingRequests],
+  );
 
-  const sendRequest = useCallback(async (addresseeId: string): Promise<void> => {
-    // Optimistic: insert a synthetic row into raw state so deriveState()
-    // immediately reflects the pending-sent status.
-    const optimisticRow: FriendshipWithProfiles = {
-      id: `optimistic-${Date.now()}`,
-      requester_id: userId,
-      addressee_id: addresseeId,
-      status: 'pending',
-      created_at: new Date().toISOString(),
-      requester: { id: userId, display_name: '', avatar_url: null },
-      addressee: { id: addresseeId, display_name: '', avatar_url: null },
-    }
-    setRows((prev) => [...prev, optimisticRow])
-    try {
-      const inserted = await libSendRequest(supabase, { addresseeId })
-      // Replace optimistic row with real row. Profile data is still placeholder —
-      // the Realtime INSERT event will trigger a full refetch with joined profiles.
-      setRows((prev) =>
-        prev.map((r) =>
-          r.id === optimisticRow.id
-            ? { ...optimisticRow, id: inserted.id }
-            : r
-        )
-      )
-    } catch (err) {
-      setRows((prev) => prev.filter((r) => r.id !== optimisticRow.id))
-      throw err
-    }
-  }, [userId])
+  const sendRequest = useCallback(
+    async (addresseeId: string): Promise<void> => {
+      // Optimistic: insert a synthetic row into raw state so deriveState()
+      // immediately reflects the pending-sent status.
+      const optimisticRow: FriendshipWithProfiles = {
+        id: `optimistic-${Date.now()}`,
+        requester_id: userId,
+        addressee_id: addresseeId,
+        status: "pending",
+        created_at: new Date().toISOString(),
+        requester: { id: userId, display_name: "", avatar_url: null },
+        addressee: { id: addresseeId, display_name: "", avatar_url: null },
+      };
+      setRows((prev) => [...prev, optimisticRow]);
+      try {
+        const inserted = await libSendRequest(supabase, { addresseeId });
+        // Replace optimistic row with real row. Profile data is still placeholder —
+        // the Realtime INSERT event will trigger a full refetch with joined profiles.
+        setRows((prev) =>
+          prev.map((r) => (r.id === optimisticRow.id ? { ...optimisticRow, id: inserted.id } : r)),
+        );
+      } catch (err) {
+        setRows((prev) => prev.filter((r) => r.id !== optimisticRow.id));
+        throw err;
+      }
+    },
+    [userId],
+  );
 
   const cancelRequest = useCallback(async (friendshipId: string): Promise<void> => {
-    let snapshot: FriendshipWithProfiles[] = []
-    setRows((current) => { snapshot = current; return current.filter((row) => row.id !== friendshipId) })
+    let snapshot: FriendshipWithProfiles[] = [];
+    setRows((current) => {
+      snapshot = current;
+      return current.filter((row) => row.id !== friendshipId);
+    });
     try {
-      await libCancelRequest(supabase, { friendshipId })
+      await libCancelRequest(supabase, { friendshipId });
     } catch (err) {
-      setRows(snapshot)
-      throw err
+      setRows(snapshot);
+      throw err;
     }
-  }, [])
+  }, []);
 
   const acceptRequest = useCallback(async (friendshipId: string): Promise<void> => {
-    let snapshot: FriendshipWithProfiles[] = []
+    let snapshot: FriendshipWithProfiles[] = [];
     setRows((current) => {
-      snapshot = current
-      return current.map((row) => row.id === friendshipId ? { ...row, status: 'accepted' as const } : row)
-    })
+      snapshot = current;
+      return current.map((row) =>
+        row.id === friendshipId ? { ...row, status: "accepted" as const } : row,
+      );
+    });
     try {
-      await libAcceptRequest(supabase, { friendshipId })
+      await libAcceptRequest(supabase, { friendshipId });
     } catch (err) {
-      setRows(snapshot)
-      throw err
+      setRows(snapshot);
+      throw err;
     }
-  }, [])
+  }, []);
 
   const declineRequest = useCallback(async (friendshipId: string): Promise<void> => {
-    let snapshot: FriendshipWithProfiles[] = []
-    setRows((current) => { snapshot = current; return current.filter((row) => row.id !== friendshipId) })
+    let snapshot: FriendshipWithProfiles[] = [];
+    setRows((current) => {
+      snapshot = current;
+      return current.filter((row) => row.id !== friendshipId);
+    });
     try {
-      await libDeclineRequest(supabase, { friendshipId })
+      await libDeclineRequest(supabase, { friendshipId });
     } catch (err) {
-      setRows(snapshot)
-      throw err
+      setRows(snapshot);
+      throw err;
     }
-  }, [])
+  }, []);
 
   const unfriend = useCallback(async (friendshipId: string): Promise<void> => {
-    let snapshot: FriendshipWithProfiles[] = []
-    setRows((current) => { snapshot = current; return current.filter((row) => row.id !== friendshipId) })
+    let snapshot: FriendshipWithProfiles[] = [];
+    setRows((current) => {
+      snapshot = current;
+      return current.filter((row) => row.id !== friendshipId);
+    });
     try {
-      await libUnfriend(supabase, { friendshipId })
+      await libUnfriend(supabase, { friendshipId });
     } catch (err) {
-      setRows(snapshot)
-      throw err
+      setRows(snapshot);
+      throw err;
     }
-  }, [])
+  }, []);
 
   return {
     friends,
@@ -255,5 +273,5 @@ export function useFriendships() {
     unfriend,
     getStatusForUser,
     getFriendshipId,
-  }
+  };
 }

--- a/hooks/useGeofenceNotifications.ts
+++ b/hooks/useGeofenceNotifications.ts
@@ -1,99 +1,101 @@
-import { useEffect, useRef, useCallback, useState } from 'react'
-import * as Notifications from 'expo-notifications'
-import { supabase } from '@/lib/supabase'
-import { insertCheckIn } from '@/lib/checkIns'
-import { confirmJoins } from '@/lib/presenceJoins'
-import { ACTION_CONFIRM, ACTION_DISMISS, CHECKIN_CATEGORY } from '@/lib/notifications'
+import { useEffect, useRef, useCallback, useState } from "react";
+import * as Notifications from "expo-notifications";
+import { supabase } from "@/lib/supabase";
+import { insertCheckIn } from "@/lib/checkIns";
+import { confirmJoins } from "@/lib/presenceJoins";
+import { ACTION_CONFIRM, ACTION_DISMISS, CHECKIN_CATEGORY } from "@/lib/notifications";
 
 export type ToastState = {
-  visible: boolean
-  message: string
-}
+  visible: boolean;
+  message: string;
+};
 
 export function useGeofenceNotifications() {
-  const [toast, setToast] = useState<ToastState>({ visible: false, message: '' })
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const isMounted = useRef(true)
+  const [toast, setToast] = useState<ToastState>({ visible: false, message: "" });
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isMounted = useRef(true);
   // Track notification IDs already processed to prevent duplicate check-ins
   // when the OS delivers the same geofence event twice (e.g. cold start
   // re-registration). The DB exclusion constraint is the authoritative guard;
   // this is a fast client-side short-circuit.
-  const processedIds = useRef(new Set<string>())
+  const processedIds = useRef(new Set<string>());
 
   const showToast = useCallback((message: string) => {
-    if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    setToast({ visible: true, message })
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    setToast({ visible: true, message });
     timeoutRef.current = setTimeout(() => {
-      setToast({ visible: false, message: '' })
-    }, 2000)
-    ;(timeoutRef.current as unknown as { unref?: () => void }).unref?.()
-  }, [])
+      setToast({ visible: false, message: "" });
+    }, 2000);
+    (timeoutRef.current as unknown as { unref?: () => void }).unref?.();
+  }, []);
 
   useEffect(() => {
-    const subscription = Notifications.addNotificationResponseReceivedListener(
-      async (response) => {
-        const { actionIdentifier, notification } = response
-        const category = notification.request.content.categoryIdentifier
-        if (category !== CHECKIN_CATEGORY) return
+    const subscription = Notifications.addNotificationResponseReceivedListener(async (response) => {
+      const { actionIdentifier, notification } = response;
+      const category = notification.request.content.categoryIdentifier;
+      if (category !== CHECKIN_CATEGORY) return;
 
-        const notifId = notification.request.identifier
+      const notifId = notification.request.identifier;
 
-        // Dismiss the notification on any action to prevent stale banners —
-        // on Android, notification actions do not always auto-dismiss.
-        await Notifications.dismissNotificationAsync(notifId)
+      // Dismiss the notification on any action to prevent stale banners —
+      // on Android, notification actions do not always auto-dismiss.
+      await Notifications.dismissNotificationAsync(notifId);
 
-        // Any action other than explicit confirm or default tap (banner tap) is
-        // ignored — e.g. ACTION_DISMISS ("No" button). The notification was
-        // already dismissed above.
-        if (
-          actionIdentifier !== ACTION_CONFIRM &&
-          actionIdentifier !== Notifications.DEFAULT_ACTION_IDENTIFIER
-        ) return
+      // Any action other than explicit confirm or default tap (banner tap) is
+      // ignored — e.g. ACTION_DISMISS ("No" button). The notification was
+      // already dismissed above.
+      if (
+        actionIdentifier !== ACTION_CONFIRM &&
+        actionIdentifier !== Notifications.DEFAULT_ACTION_IDENTIFIER
+      )
+        return;
 
-        // Skip if this notification was already processed — prevents duplicate
-        // check-ins from duplicate notifications triggered by geofence
-        // re-registration on cold start.
-        if (processedIds.current.has(notifId)) return
-        processedIds.current.add(notifId)
+      // Skip if this notification was already processed — prevents duplicate
+      // check-ins from duplicate notifications triggered by geofence
+      // re-registration on cold start.
+      if (processedIds.current.has(notifId)) return;
+      processedIds.current.add(notifId);
 
-        const data = notification.request.content.data as {
-          poiId?: string
-          poiName?: string
-        }
+      const data = notification.request.content.data as {
+        poiId?: string;
+        poiName?: string;
+      };
 
-        if (!data?.poiId || !data?.poiName) {
-          console.error('[Geofence notification] Missing poiId or poiName in data')
-          return
-        }
-
-        try {
-          await insertCheckIn(supabase, { poiId: data.poiId })
-          // Confirm any pending joins at this POI — best-effort, never blocks check-in
-          try {
-            await confirmJoins(supabase, { poiId: data.poiId })
-          } catch {
-            try {
-              await new Promise(r => setTimeout(r, 2000))
-              if (!isMounted.current) return
-              await confirmJoins(supabase, { poiId: data.poiId })
-            } catch (retryErr) {
-              console.error('[Geofence notification] Join confirmation failed after retry:', retryErr)
-            }
-          }
-          showToast(`Checked in at ${data.poiName}`)
-        } catch (err) {
-          console.error('[Geofence notification] Check-in failed:', err)
-          showToast('Check-in failed — please try again')
-        }
+      if (!data?.poiId || !data?.poiName) {
+        console.error("[Geofence notification] Missing poiId or poiName in data");
+        return;
       }
-    )
+
+      try {
+        await insertCheckIn(supabase, { poiId: data.poiId });
+        // Confirm any pending joins at this POI — best-effort, never blocks check-in
+        try {
+          await confirmJoins(supabase, { poiId: data.poiId });
+        } catch {
+          try {
+            await new Promise((r) => setTimeout(r, 2000));
+            if (!isMounted.current) return;
+            await confirmJoins(supabase, { poiId: data.poiId });
+          } catch (retryErr) {
+            console.error(
+              "[Geofence notification] Join confirmation failed after retry:",
+              retryErr,
+            );
+          }
+        }
+        showToast(`Checked in at ${data.poiName}`);
+      } catch (err) {
+        console.error("[Geofence notification] Check-in failed:", err);
+        showToast("Check-in failed — please try again");
+      }
+    });
 
     return () => {
-      isMounted.current = false
-      subscription.remove()
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    }
-  }, [showToast])
+      isMounted.current = false;
+      subscription.remove();
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [showToast]);
 
-  return { toast }
+  return { toast };
 }

--- a/hooks/useLivePresences.ts
+++ b/hooks/useLivePresences.ts
@@ -1,75 +1,75 @@
-import { useState, useEffect, useRef } from 'react'
-import { AppState } from 'react-native'
-import { supabase } from '@/lib/supabase'
-import { useAuth } from '@/hooks/useAuth'
+import { useState, useEffect, useRef } from "react";
+import { AppState } from "react-native";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
 
 export type LivePresenceEntry = {
-  id: string
-  userId: string
-  poiId: string
-  displayName: string
-  avatarUrl: string | null
-  message: string | null
-}
+  id: string;
+  userId: string;
+  poiId: string;
+  displayName: string;
+  avatarUrl: string | null;
+  message: string | null;
+};
 
 type ProfileData = {
-  displayName: string
-  avatarUrl: string | null
-}
+  displayName: string;
+  avatarUrl: string | null;
+};
 
 export function useLivePresences(friendIds: string[]) {
-  const { session } = useAuth()
-  const [presences, setPresences] = useState<LivePresenceEntry[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const profileCache = useRef<Map<string, ProfileData>>(new Map())
-  const channelId = useRef(`live-presence-changes-${Date.now()}-${Math.random()}`)
+  const { session } = useAuth();
+  const [presences, setPresences] = useState<LivePresenceEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const profileCache = useRef<Map<string, ProfileData>>(new Map());
+  const channelId = useRef(`live-presence-changes-${Date.now()}-${Math.random()}`);
   // Tracks whether each channel has successfully subscribed, used to distinguish
   // initial connect (initial load is in flight — no refetch needed) from reconnects.
-  const channelHealth = useRef({ community: false, friends: false })
+  const channelHealth = useRef({ community: false, friends: false });
   // Monotonic: flips true on first SUBSCRIBED, never reset to false.
   // Distinct from channelHealth so that a CHANNEL_ERROR doesn't erase the
   // "we've connected before" signal and break the reconnect-refetch path.
-  const everSubscribed = useRef({ community: false, friends: false })
+  const everSubscribed = useRef({ community: false, friends: false });
 
   // Stable string key for the dependency array — avoids re-running the effect
   // on every render when the caller passes a new array reference with the same IDs.
-  const friendIdsKey = friendIds.join(',')
+  const friendIdsKey = friendIds.join(",");
 
   useEffect(() => {
-    const userId = session?.user.id
+    const userId = session?.user.id;
     if (!userId) {
-      setPresences([])
-      setLoading(false)
-      return
+      setPresences([]);
+      setLoading(false);
+      return;
     }
 
-    let active = true
+    let active = true;
     // Reset health for this effect run — channels are recreated on every re-subscribe.
-    channelHealth.current = { community: false, friends: false }
-    everSubscribed.current = { community: false, friends: false }
-    setError(null)
-    setLoading(true)
+    channelHealth.current = { community: false, friends: false };
+    everSubscribed.current = { community: false, friends: false };
+    setError(null);
+    setLoading(true);
 
     const fetchPresences = async () => {
       const { data, error: fetchError } = await supabase
-        .from('live_presence')
-        .select('id, user_id, poi_id, message, profiles(display_name, avatar_url)')
-        .is('dismissed_at', null)
-        .neq('user_id', userId)
-      if (!active) return
+        .from("live_presence")
+        .select("id, user_id, poi_id, message, profiles(display_name, avatar_url)")
+        .is("dismissed_at", null)
+        .neq("user_id", userId);
+      if (!active) return;
       if (fetchError) {
-        console.error('useLivePresences:', fetchError.message)
-        setError(fetchError.message)
-        setLoading(false)
-        return
+        console.error("useLivePresences:", fetchError.message);
+        setError(fetchError.message);
+        setLoading(false);
+        return;
       }
-      const entries: LivePresenceEntry[] = []
-      for (const row of (data ?? [])) {
-        const profile = row.profiles as { display_name: string; avatar_url: string | null } | null
-        const displayName = profile?.display_name ?? ''
-        const avatarUrl = profile?.avatar_url ?? null
-        profileCache.current.set(row.user_id, { displayName, avatarUrl })
+      const entries: LivePresenceEntry[] = [];
+      for (const row of data ?? []) {
+        const profile = row.profiles as { display_name: string; avatar_url: string | null } | null;
+        const displayName = profile?.display_name ?? "";
+        const avatarUrl = profile?.avatar_url ?? null;
+        profileCache.current.set(row.user_id, { displayName, avatarUrl });
         entries.push({
           id: row.id,
           userId: row.user_id,
@@ -77,40 +77,45 @@ export function useLivePresences(friendIds: string[]) {
           displayName,
           avatarUrl,
           message: row.message,
-        })
+        });
       }
-      setPresences(entries)
-      setError(null)
-      setLoading(false)
-    }
+      setPresences(entries);
+      setError(null);
+      setLoading(false);
+    };
 
-    fetchPresences()
+    fetchPresences();
 
     const handleInsert = async (payload: { new: Record<string, unknown> }) => {
-      if (!active) return
+      if (!active) return;
       try {
-        const row = payload.new
-        const rowUserId = row.user_id as string
-        if (rowUserId === userId || !!row.dismissed_at) return
+        const row = payload.new;
+        const rowUserId = row.user_id as string;
+        if (rowUserId === userId || !!row.dismissed_at) return;
 
         // Always fetch fresh profile data on INSERT — the cache may hold a stale
         // avatar_url if the user updated their profile picture since it was cached.
         const { data, error: profileError } = await supabase
-          .from('profiles')
-          .select('display_name, avatar_url')
-          .eq('id', rowUserId)
-          .single()
-        if (!active) return
+          .from("profiles")
+          .select("display_name, avatar_url")
+          .eq("id", rowUserId)
+          .single();
+        if (!active) return;
         if (profileError) {
-          console.error(`useLivePresences: Failed to fetch profile for ${rowUserId}:`, profileError.message)
+          console.error(
+            `useLivePresences: Failed to fetch profile for ${rowUserId}:`,
+            profileError.message,
+          );
           if (!profileCache.current.has(rowUserId)) {
-            console.warn(`useLivePresences: no cached profile for user ${rowUserId}, presence will show as Unknown`)
+            console.warn(
+              `useLivePresences: no cached profile for user ${rowUserId}, presence will show as Unknown`,
+            );
           }
         }
         const profile: ProfileData = data
           ? { displayName: data.display_name, avatarUrl: data.avatar_url }
-          : profileCache.current.get(rowUserId) ?? { displayName: 'Unknown', avatarUrl: null }
-        profileCache.current.set(rowUserId, profile)
+          : (profileCache.current.get(rowUserId) ?? { displayName: "Unknown", avatarUrl: null });
+        profileCache.current.set(rowUserId, profile);
 
         const entry: LivePresenceEntry = {
           id: row.id as string,
@@ -119,115 +124,147 @@ export function useLivePresences(friendIds: string[]) {
           displayName: profile.displayName,
           avatarUrl: profile.avatarUrl,
           message: (row.message as string | null) ?? null,
-        }
+        };
 
         setPresences((prev) => {
-          if (prev.some((p) => p.id === entry.id)) return prev
-          return [...prev, entry]
-        })
+          if (prev.some((p) => p.id === entry.id)) return prev;
+          return [...prev, entry];
+        });
       } catch (err) {
         console.error(
           `useLivePresences: Failed to process INSERT for presence ${payload.new.id} / user ${payload.new.user_id}`,
-          err
-        )
+          err,
+        );
       }
-    }
+    };
 
     const handleUpdate = (payload: { new: Record<string, unknown> }) => {
-      if (!active) return
+      if (!active) return;
       try {
-        const row = payload.new
-        if ((row.user_id as string) === userId) return
+        const row = payload.new;
+        if ((row.user_id as string) === userId) return;
         if (!!row.dismissed_at) {
-          setPresences((prev) => prev.filter((p) => p.id !== (row.id as string)))
+          setPresences((prev) => prev.filter((p) => p.id !== (row.id as string)));
         } else {
           // Non-dismissal UPDATE (e.g. message edit) — update in-place
           setPresences((prev) =>
             prev.map((p) =>
               p.id === (row.id as string)
                 ? { ...p, message: (row.message as string | null) ?? null }
-                : p
-            )
-          )
+                : p,
+            ),
+          );
         }
       } catch (err) {
         console.error(
           `useLivePresences: Failed to process UPDATE for presence ${payload.new.id} / user ${payload.new.user_id}`,
-          err
-        )
+          err,
+        );
       }
-    }
+    };
 
     // Creates a status handler for the named channel.
     // Each channel tracks its own health independently so that one channel reconnecting
     // does not clear the error state set by a still-broken sibling channel.
-    const makeStatusHandler = (channelName: 'community' | 'friends') => (status: string, err?: Error) => {
-      if (!active) return
-      if (status === 'SUBSCRIBED') {
-        const wasEverSubscribed = everSubscribed.current[channelName]
-        everSubscribed.current[channelName] = true
-        channelHealth.current[channelName] = true
-        if (wasEverSubscribed) {
-          // Reconnected after a drop or CHANNEL_ERROR — re-fetch to catch missed events.
-          // fetchPresences() calls setError(null) on success, so we intentionally do NOT
-          // clear the error here — clearing it before the async fetch resolves would
-          // create a race where the banner dismisses even if the refetch fails.
-          fetchPresences()
-        } else {
-          // Initial connect — no refetch needed. Clear any stale error if all channels healthy.
-          const allHealthy = channelHealth.current.community &&
-            (friendIds.length === 0 || channelHealth.current.friends)
-          if (allHealthy) setError(null)
+    const makeStatusHandler =
+      (channelName: "community" | "friends") => (status: string, err?: Error) => {
+        if (!active) return;
+        if (status === "SUBSCRIBED") {
+          const wasEverSubscribed = everSubscribed.current[channelName];
+          everSubscribed.current[channelName] = true;
+          channelHealth.current[channelName] = true;
+          if (wasEverSubscribed) {
+            // Reconnected after a drop or CHANNEL_ERROR — re-fetch to catch missed events.
+            // fetchPresences() calls setError(null) on success, so we intentionally do NOT
+            // clear the error here — clearing it before the async fetch resolves would
+            // create a race where the banner dismisses even if the refetch fails.
+            fetchPresences();
+          } else {
+            // Initial connect — no refetch needed. Clear any stale error if all channels healthy.
+            const allHealthy =
+              channelHealth.current.community &&
+              (friendIds.length === 0 || channelHealth.current.friends);
+            if (allHealthy) setError(null);
+          }
+        } else if (status === "TIMED_OUT" || status === "CHANNEL_ERROR" || status === "CLOSED") {
+          channelHealth.current[channelName] = false;
+          // App backgrounding drops the WebSocket — suppress noise, reconnect handles recovery
+          if (AppState.currentState === "background") return;
+          console.error(
+            `useLivePresences [${channelName}]: Realtime ${status}`,
+            err?.message ?? "(no details)",
+          );
+          setError("Live updates disconnected — pull to refresh.");
         }
-      } else if (status === 'TIMED_OUT' || status === 'CHANNEL_ERROR' || status === 'CLOSED') {
-        channelHealth.current[channelName] = false
-        // App backgrounding drops the WebSocket — suppress noise, reconnect handles recovery
-        if (AppState.currentState === 'background') return
-        console.error(`useLivePresences [${channelName}]: Realtime ${status}`, err?.message ?? '(no details)')
-        setError('Live updates disconnected — pull to refresh.')
-      }
-    }
+      };
 
     // Channel 1: community broadcasts — always active, no friend list needed.
     const communityChannel = supabase
       .channel(`${channelId.current}-community`)
-      .on('postgres_changes', {
-        event: 'INSERT', schema: 'public', table: 'live_presence',
-        filter: 'visible_to=eq.community',
-      }, handleInsert)
-      .on('postgres_changes', {
-        event: 'UPDATE', schema: 'public', table: 'live_presence',
-        filter: 'visible_to=eq.community',
-      }, handleUpdate)
-      .subscribe(makeStatusHandler('community'))
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "live_presence",
+          filter: "visible_to=eq.community",
+        },
+        handleInsert,
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "live_presence",
+          filter: "visible_to=eq.community",
+        },
+        handleUpdate,
+      )
+      .subscribe(makeStatusHandler("community"));
 
     // Channel 2: friends-only broadcasts — only created when the caller has accepted friends.
     // Filtered to visible_to==='friends' in the handler to avoid double-processing a friend's
     // community broadcast (which arrives via the community channel above).
-    const friendsChannel = friendIds.length > 0
-      ? supabase
-          .channel(`${channelId.current}-friends`)
-          .on('postgres_changes', {
-            event: 'INSERT', schema: 'public', table: 'live_presence',
-            filter: `user_id=in.(${friendIdsKey})`,
-          }, (payload) => {
-            if ((payload.new as Record<string, unknown>).visible_to === 'friends') handleInsert(payload)
-          })
-          .on('postgres_changes', {
-            event: 'UPDATE', schema: 'public', table: 'live_presence',
-            filter: `user_id=in.(${friendIdsKey})`,
-          }, (payload) => {
-            if ((payload.new as Record<string, unknown>).visible_to === 'friends') handleUpdate(payload)
-          })
-          .subscribe(makeStatusHandler('friends'))
-      : null
+    const friendsChannel =
+      friendIds.length > 0
+        ? supabase
+            .channel(`${channelId.current}-friends`)
+            .on(
+              "postgres_changes",
+              {
+                event: "INSERT",
+                schema: "public",
+                table: "live_presence",
+                filter: `user_id=in.(${friendIdsKey})`,
+              },
+              (payload) => {
+                if ((payload.new as Record<string, unknown>).visible_to === "friends")
+                  handleInsert(payload);
+              },
+            )
+            .on(
+              "postgres_changes",
+              {
+                event: "UPDATE",
+                schema: "public",
+                table: "live_presence",
+                filter: `user_id=in.(${friendIdsKey})`,
+              },
+              (payload) => {
+                if ((payload.new as Record<string, unknown>).visible_to === "friends")
+                  handleUpdate(payload);
+              },
+            )
+            .subscribe(makeStatusHandler("friends"))
+        : null;
 
     return () => {
-      active = false
-      supabase.removeChannel(communityChannel)
-      if (friendsChannel) supabase.removeChannel(friendsChannel)
-    }
-  }, [session?.user.id, friendIdsKey])
+      active = false;
+      supabase.removeChannel(communityChannel);
+      if (friendsChannel) supabase.removeChannel(friendsChannel);
+    };
+  }, [session?.user.id, friendIdsKey]);
 
-  return { presences, loading, error }
+  return { presences, loading, error };
 }

--- a/hooks/usePendingRequestCount.ts
+++ b/hooks/usePendingRequestCount.ts
@@ -1,80 +1,80 @@
-import { useState, useEffect, useRef } from 'react'
-import { AppState } from 'react-native'
-import { supabase } from '@/lib/supabase'
-import { useAuth } from '@/hooks/useAuth'
+import { useState, useEffect, useRef } from "react";
+import { AppState } from "react-native";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
 
 // Lightweight hook used by the tab layout to drive the Friends tab badge.
 // Returns the count of pending incoming friend requests, or 0 on error/no session.
 // NOTE: This hook maintains its own Realtime subscription, independent of
 // useFriendships, because it is mounted in the tab layout which outlives the friends screen.
 export function usePendingRequestCount(): number {
-  const { session } = useAuth()
-  const [count, setCount] = useState(0)
-  const channelId = useRef(`pending-count-${Date.now()}-${Math.random()}`)
+  const { session } = useAuth();
+  const [count, setCount] = useState(0);
+  const channelId = useRef(`pending-count-${Date.now()}-${Math.random()}`);
 
   useEffect(() => {
-    const userId = session?.user.id
+    const userId = session?.user.id;
     if (!userId) {
-      setCount(0)
-      return
+      setCount(0);
+      return;
     }
 
-    let active = true
+    let active = true;
 
     async function load() {
       try {
         const { count: c, error } = await supabase
-          .from('friendships')
-          .select('id', { count: 'exact', head: true })
-          .eq('addressee_id', userId!)
-          .eq('status', 'pending')
+          .from("friendships")
+          .select("id", { count: "exact", head: true })
+          .eq("addressee_id", userId!)
+          .eq("status", "pending");
 
-        if (!active) return
+        if (!active) return;
         if (error) {
-          console.error('usePendingRequestCount: query error', error.message)
-          return
+          console.error("usePendingRequestCount: query error", error.message);
+          return;
         }
-        setCount(c ?? 0)
+        setCount(c ?? 0);
       } catch (err) {
         // Non-fatal — badge simply stays at its last value
-        console.error('usePendingRequestCount: failed to fetch count', err)
+        console.error("usePendingRequestCount: failed to fetch count", err);
       }
     }
 
-    load()
+    load();
 
-    let subscribedOnce = false
+    let subscribedOnce = false;
     const channel = supabase
       .channel(channelId.current)
-      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'friendships' }, () => {
-        if (active) load()
+      .on("postgres_changes", { event: "INSERT", schema: "public", table: "friendships" }, () => {
+        if (active) load();
       })
-      .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'friendships' }, () => {
-        if (active) load()
+      .on("postgres_changes", { event: "UPDATE", schema: "public", table: "friendships" }, () => {
+        if (active) load();
       })
-      .on('postgres_changes', { event: 'DELETE', schema: 'public', table: 'friendships' }, () => {
-        if (active) load()
+      .on("postgres_changes", { event: "DELETE", schema: "public", table: "friendships" }, () => {
+        if (active) load();
       })
       .subscribe((status, err) => {
-        if (!active) return
-        if (status === 'SUBSCRIBED') {
+        if (!active) return;
+        if (status === "SUBSCRIBED") {
           if (subscribedOnce) {
             // Reconnected after a drop — re-fetch so the badge count is fresh
-            if (active) load()
+            if (active) load();
           } else {
-            subscribedOnce = true
+            subscribedOnce = true;
           }
-        } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
-          if (AppState.currentState === 'background') return
-          console.error(`usePendingRequestCount: Realtime ${status}`, err ?? '(no details)')
+        } else if (status === "CHANNEL_ERROR" || status === "TIMED_OUT" || status === "CLOSED") {
+          if (AppState.currentState === "background") return;
+          console.error(`usePendingRequestCount: Realtime ${status}`, err ?? "(no details)");
         }
-      })
+      });
 
     return () => {
-      active = false
-      supabase.removeChannel(channel)
-    }
-  }, [session?.user.id])
+      active = false;
+      supabase.removeChannel(channel);
+    };
+  }, [session?.user.id]);
 
-  return count
+  return count;
 }

--- a/hooks/usePoiRatings.ts
+++ b/hooks/usePoiRatings.ts
@@ -1,111 +1,116 @@
-import { useState, useEffect, useCallback } from 'react'
-import { supabase } from '@/lib/supabase'
-import { useAuth } from '@/hooks/useAuth'
+import { useState, useEffect, useCallback } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
 
 export type RatingComment = {
-  id: string
-  rating: number
+  id: string;
+  rating: number;
   // Only rows where comment IS NOT NULL are included — non-null guaranteed by filter before mapping
-  comment: string
-  created_at: string
-  user_id: string
-  display_name: string
-  avatar_url: string | null
-}
+  comment: string;
+  created_at: string;
+  user_id: string;
+  display_name: string;
+  avatar_url: string | null;
+};
 
 export type MyRating = {
-  id: string
-  rating: number
-  comment: string | null
-}
+  id: string;
+  rating: number;
+  comment: string | null;
+};
 
-type ProfileJoin = { display_name?: string; avatar_url?: string | null }
+type ProfileJoin = { display_name?: string; avatar_url?: string | null };
 
 function getProfileField(profiles: unknown): ProfileJoin {
-  if (!profiles) return {}
-  if (Array.isArray(profiles)) return (profiles[0] as ProfileJoin) ?? {}
-  return profiles as ProfileJoin
+  if (!profiles) return {};
+  if (Array.isArray(profiles)) return (profiles[0] as ProfileJoin) ?? {};
+  return profiles as ProfileJoin;
 }
 
 export function usePoiRatings(poiId: string | undefined) {
-  const { session } = useAuth()
-  const userId = session?.user.id
-  const [avgRating, setAvgRating] = useState<number | null>(null)
-  const [ratingCount, setRatingCount] = useState(0)
-  const [comments, setComments] = useState<RatingComment[]>([])
-  const [myRating, setMyRating] = useState<MyRating | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const { session } = useAuth();
+  const userId = session?.user.id;
+  const [avgRating, setAvgRating] = useState<number | null>(null);
+  const [ratingCount, setRatingCount] = useState(0);
+  const [comments, setComments] = useState<RatingComment[]>([]);
+  const [myRating, setMyRating] = useState<MyRating | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   // Accepts an optional isCancelled guard so the useEffect can cancel in-flight
   // requests when poiId changes, while refetch() calls pass no guard.
-  const load = useCallback(async (isCancelled?: () => boolean) => {
-    if (!poiId) return
-    setLoading(true)
-    setError(null)
+  const load = useCallback(
+    async (isCancelled?: () => boolean) => {
+      if (!poiId) return;
+      setLoading(true);
+      setError(null);
 
-    // Relies on the "Profiles viewable by authenticated users" RLS SELECT policy
-    // allowing cross-user reads of display_name and avatar_url. If that policy is ever
-    // tightened, the profiles join will silently return null and both fields will fall
-    // back to defaults.
-    const { data, error } = await supabase
-      .from('poi_ratings')
-      .select('id, rating, comment, created_at, user_id, profiles(display_name, avatar_url)')
-      .eq('poi_id', poiId)
-      .order('created_at', { ascending: false })
+      // Relies on the "Profiles viewable by authenticated users" RLS SELECT policy
+      // allowing cross-user reads of display_name and avatar_url. If that policy is ever
+      // tightened, the profiles join will silently return null and both fields will fall
+      // back to defaults.
+      const { data, error } = await supabase
+        .from("poi_ratings")
+        .select("id, rating, comment, created_at, user_id, profiles(display_name, avatar_url)")
+        .eq("poi_id", poiId)
+        .order("created_at", { ascending: false });
 
-    if (isCancelled?.()) return
+      if (isCancelled?.()) return;
 
-    if (error) {
-      console.error('usePoiRatings:', error.message)
-      setError(error.message)
-      setLoading(false)
-      return
-    }
+      if (error) {
+        console.error("usePoiRatings:", error.message);
+        setError(error.message);
+        setLoading(false);
+        return;
+      }
 
-    const rows = data ?? []
-    const total = rows.reduce((sum, r) => sum + r.rating, 0)
-    setRatingCount(rows.length)
-    setAvgRating(rows.length > 0 ? total / rows.length : null)
+      const rows = data ?? [];
+      const total = rows.reduce((sum, r) => sum + r.rating, 0);
+      setRatingCount(rows.length);
+      setAvgRating(rows.length > 0 ? total / rows.length : null);
 
-    setComments(
-      rows
-        .filter((r) => r.comment !== null && r.created_at !== null)
-        .slice(0, 5)
-        .map((r) => {
-          const profile = getProfileField(r.profiles)
-          return {
-            id: r.id,
-            rating: r.rating,
-            comment: r.comment as string,
-            created_at: r.created_at as string,
-            user_id: r.user_id,
-            display_name: profile.display_name ?? 'Unknown',
-            avatar_url: profile.avatar_url ?? null,
-          }
-        })
-    )
+      setComments(
+        rows
+          .filter((r) => r.comment !== null && r.created_at !== null)
+          .slice(0, 5)
+          .map((r) => {
+            const profile = getProfileField(r.profiles);
+            return {
+              id: r.id,
+              rating: r.rating,
+              comment: r.comment as string,
+              created_at: r.created_at as string,
+              user_id: r.user_id,
+              display_name: profile.display_name ?? "Unknown",
+              avatar_url: profile.avatar_url ?? null,
+            };
+          }),
+      );
 
-    const mine = userId ? (rows.find((r) => r.user_id === userId) ?? null) : null
-    setMyRating(mine ? { id: mine.id, rating: mine.rating, comment: mine.comment ?? null } : null)
+      const mine = userId ? (rows.find((r) => r.user_id === userId) ?? null) : null;
+      setMyRating(
+        mine ? { id: mine.id, rating: mine.rating, comment: mine.comment ?? null } : null,
+      );
 
-    setLoading(false)
-  }, [poiId, userId])
+      setLoading(false);
+    },
+    [poiId, userId],
+  );
 
   useEffect(() => {
-    let cancelled = false
+    let cancelled = false;
     if (!poiId) {
-      setAvgRating(null)
-      setRatingCount(0)
-      setComments([])
-      setMyRating(null)
-      return
+      setAvgRating(null);
+      setRatingCount(0);
+      setComments([]);
+      setMyRating(null);
+      return;
     }
-    load(() => cancelled)
+    load(() => cancelled);
     return () => {
-      cancelled = true
-    }
-  }, [poiId, load])
+      cancelled = true;
+    };
+  }, [poiId, load]);
 
-  return { avgRating, ratingCount, comments, myRating, loading, error, refetch: load }
+  return { avgRating, ratingCount, comments, myRating, loading, error, refetch: load };
 }

--- a/hooks/usePois.ts
+++ b/hooks/usePois.ts
@@ -1,34 +1,34 @@
-import { useState, useEffect } from 'react'
-import { supabase } from '@/lib/supabase'
-import { Tables } from '@/types/supabase'
+import { useState, useEffect } from "react";
+import { supabase } from "@/lib/supabase";
+import { Tables } from "@/types/supabase";
 
-type Poi = Tables<'pois'>
+type Poi = Tables<"pois">;
 
 export function usePois() {
-  const [pois, setPois] = useState<Poi[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [pois, setPois] = useState<Poi[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    let active = true
+    let active = true;
 
     supabase
-      .from('pois')
-      .select('*')
+      .from("pois")
+      .select("*")
       .then(({ data, error: fetchError }) => {
-        if (!active) return
+        if (!active) return;
         if (fetchError) {
-          setError(fetchError.message)
+          setError(fetchError.message);
         } else {
-          setPois(data ?? [])
+          setPois(data ?? []);
         }
-        setLoading(false)
-      })
+        setLoading(false);
+      });
 
     return () => {
-      active = false
-    }
-  }, [])
+      active = false;
+    };
+  }, []);
 
-  return { pois, loading, error }
+  return { pois, loading, error };
 }

--- a/hooks/usePresenceJoins.ts
+++ b/hooks/usePresenceJoins.ts
@@ -1,55 +1,55 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
-import { AppState } from 'react-native'
-import { supabase } from '@/lib/supabase'
-import { useAuth } from '@/hooks/useAuth'
-import { PresenceJoin, joinPresence, cancelJoin } from '@/lib/presenceJoins'
+import { useState, useEffect, useCallback, useRef } from "react";
+import { AppState } from "react-native";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
+import { PresenceJoin, joinPresence, cancelJoin } from "@/lib/presenceJoins";
 
 export function usePresenceJoins() {
-  const { session } = useAuth()
-  const [joins, setJoins] = useState<PresenceJoin[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const channelId = useRef(`presence-joins-changes-${Date.now()}-${Math.random()}`)
+  const { session } = useAuth();
+  const [joins, setJoins] = useState<PresenceJoin[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const channelId = useRef(`presence-joins-changes-${Date.now()}-${Math.random()}`);
 
   useEffect(() => {
-    const userId = session?.user.id
+    const userId = session?.user.id;
     if (!userId) {
-      setJoins([])
-      setLoading(false)
-      return
+      setJoins([]);
+      setLoading(false);
+      return;
     }
 
-    let active = true
-    setError(null)
-    setLoading(true)
+    let active = true;
+    setError(null);
+    setLoading(true);
 
     async function load() {
       try {
         const { data, error: fetchError } = await supabase
-          .from('presence_joins')
-          .select('id, presence_id, joiner_user_id, joined_at, confirmed')
-          .eq('joiner_user_id', userId!)
-        if (!active) return
+          .from("presence_joins")
+          .select("id, presence_id, joiner_user_id, joined_at, confirmed")
+          .eq("joiner_user_id", userId!);
+        if (!active) return;
         if (fetchError) {
-          console.error('usePresenceJoins:', fetchError.message)
-          setError(fetchError.message)
+          console.error("usePresenceJoins:", fetchError.message);
+          setError(fetchError.message);
         } else {
           // Note: joins for dismissed presences (dismissed_at set) are not filtered here
           // because soft-deleted live_presence rows persist. Stale joins are harmless —
           // dismissed presences never render PresenceCards so the stale join is never acted on.
-          setJoins((data ?? []) as PresenceJoin[])
+          setJoins((data ?? []) as PresenceJoin[]);
         }
       } catch (err) {
-        if (!active) return
-        const message = err instanceof Error ? err.message : 'Unknown error'
-        console.error('usePresenceJoins:', message)
-        setError(message)
+        if (!active) return;
+        const message = err instanceof Error ? err.message : "Unknown error";
+        console.error("usePresenceJoins:", message);
+        setError(message);
       } finally {
-        if (active) setLoading(false)
+        if (active) setLoading(false);
       }
     }
 
-    load()
+    load();
 
     // Subscribe to UPDATE events on the joiner's own joins so the UI reflects
     // confirmed = true immediately when the broadcaster-side RLS allows it or
@@ -57,52 +57,52 @@ export function usePresenceJoins() {
     const channel = supabase
       .channel(channelId.current)
       .on(
-        'postgres_changes',
+        "postgres_changes",
         {
-          event: 'UPDATE',
-          schema: 'public',
-          table: 'presence_joins',
+          event: "UPDATE",
+          schema: "public",
+          table: "presence_joins",
           filter: `joiner_user_id=eq.${userId}`,
         },
         (payload) => {
-          if (!active) return
-          const updated = payload.new as PresenceJoin
-          setJoins((prev) => prev.map((j) => (j.id === updated.id ? { ...j, ...updated } : j)))
-        }
+          if (!active) return;
+          const updated = payload.new as PresenceJoin;
+          setJoins((prev) => prev.map((j) => (j.id === updated.id ? { ...j, ...updated } : j)));
+        },
       )
       .subscribe((status, err) => {
-        if (!active) return
-        if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
-          if (AppState.currentState === 'background') return
-          console.error(`usePresenceJoins: Realtime ${status}`, err ?? '(no details)')
+        if (!active) return;
+        if (status === "CHANNEL_ERROR" || status === "TIMED_OUT" || status === "CLOSED") {
+          if (AppState.currentState === "background") return;
+          console.error(`usePresenceJoins: Realtime ${status}`, err ?? "(no details)");
         }
-      })
+      });
 
     return () => {
-      active = false
-      supabase.removeChannel(channel)
-    }
-  }, [session?.user.id])
+      active = false;
+      supabase.removeChannel(channel);
+    };
+  }, [session?.user.id]);
 
   const join = useCallback(async (presenceId: string): Promise<PresenceJoin> => {
-    const newJoin = await joinPresence(supabase, { presenceId })
+    const newJoin = await joinPresence(supabase, { presenceId });
     setJoins((prev) => {
-      if (prev.some((j) => j.id === newJoin.id)) return prev
-      return [...prev, newJoin]
-    })
-    return newJoin
-  }, [])
+      if (prev.some((j) => j.id === newJoin.id)) return prev;
+      return [...prev, newJoin];
+    });
+    return newJoin;
+  }, []);
 
   const cancel = useCallback(async (joinId: string): Promise<void> => {
-    await cancelJoin(supabase, { joinId })
-    setJoins((prev) => prev.filter((j) => j.id !== joinId))
-  }, [])
+    await cancelJoin(supabase, { joinId });
+    setJoins((prev) => prev.filter((j) => j.id !== joinId));
+  }, []);
 
   const getJoinForPresence = useCallback(
     (presenceId: string): PresenceJoin | undefined =>
       joins.find((j) => j.presence_id === presenceId),
-    [joins]
-  )
+    [joins],
+  );
 
-  return { joins, loading, error, join, cancel, getJoinForPresence }
+  return { joins, loading, error, join, cancel, getJoinForPresence };
 }

--- a/hooks/useProximity.ts
+++ b/hooks/useProximity.ts
@@ -1,23 +1,23 @@
-import { useState, useEffect } from 'react'
-import * as Location from 'expo-location'
-import { getDistanceMeters } from '@/lib/geo'
+import { useState, useEffect } from "react";
+import * as Location from "expo-location";
+import { getDistanceMeters } from "@/lib/geo";
 
-export { getDistanceMeters }
+export { getDistanceMeters };
 
 export function useProximity(
   target: { lat: number; lng: number } | null,
-  radiusMeters = 100
+  radiusMeters = 100,
 ): { isNearby: boolean } {
-  const [isNearby, setIsNearby] = useState(false)
+  const [isNearby, setIsNearby] = useState(false);
 
   useEffect(() => {
     if (!target) {
-      setIsNearby(false)
-      return
+      setIsNearby(false);
+      return;
     }
 
-    let cancelled = false
-    let subscription: Location.LocationSubscription | null = null
+    let cancelled = false;
+    let subscription: Location.LocationSubscription | null = null;
 
     Location.watchPositionAsync(
       {
@@ -29,24 +29,27 @@ export function useProximity(
           location.coords.latitude,
           location.coords.longitude,
           target.lat,
-          target.lng
-        )
-        setIsNearby(distance <= radiusMeters)
-      }
+          target.lng,
+        );
+        setIsNearby(distance <= radiusMeters);
+      },
     )
       .then((sub) => {
-        if (cancelled) { sub.remove(); return }
-        subscription = sub
+        if (cancelled) {
+          sub.remove();
+          return;
+        }
+        subscription = sub;
       })
       .catch(() => {
         // Location unavailable (permission denied, GPS off, emulator) — stay false
-      })
+      });
 
     return () => {
-      cancelled = true
-      subscription?.remove()
-    }
-  }, [target?.lat, target?.lng, radiusMeters])
+      cancelled = true;
+      subscription?.remove();
+    };
+  }, [target?.lat, target?.lng, radiusMeters]);
 
-  return { isNearby }
+  return { isNearby };
 }

--- a/hooks/useUserSearch.ts
+++ b/hooks/useUserSearch.ts
@@ -1,57 +1,57 @@
-import { useEffect, useRef, useState } from 'react'
-import { supabase } from '@/lib/supabase'
-import { searchUsers, SearchUser } from '@/lib/friends'
+import { useEffect, useRef, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { searchUsers, SearchUser } from "@/lib/friends";
 
 export type SearchResult =
-  | { state: 'idle'; results: []; error: null }
-  | { state: 'searching'; results: SearchUser[]; error: null }
-  | { state: 'results'; results: SearchUser[]; error: null }
-  | { state: 'error'; results: []; error: string }
+  | { state: "idle"; results: []; error: null }
+  | { state: "searching"; results: SearchUser[]; error: null }
+  | { state: "results"; results: SearchUser[]; error: null }
+  | { state: "error"; results: []; error: string };
 
 export function useUserSearch(query: string): SearchResult {
-  const [results, setResults] = useState<SearchUser[]>([])
-  const [state, setState] = useState<SearchResult['state']>('idle')
-  const [error, setError] = useState<string | null>(null)
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [results, setResults] = useState<SearchUser[]>([]);
+  const [state, setState] = useState<SearchResult["state"]>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (timerRef.current) clearTimeout(timerRef.current)
+    if (timerRef.current) clearTimeout(timerRef.current);
 
-    const trimmed = query.trim()
+    const trimmed = query.trim();
 
     // Require at least 2 characters to avoid overly broad prefix queries
     if (trimmed.length < 2) {
-      setResults([])
-      setState('idle')
-      setError(null)
-      return
+      setResults([]);
+      setState("idle");
+      setError(null);
+      return;
     }
 
-    let active = true
-    setState('searching')
+    let active = true;
+    setState("searching");
 
     // 300ms debounce to avoid firing a search request on every keystroke
     timerRef.current = setTimeout(async () => {
       try {
-        const data = await searchUsers(supabase, { query: trimmed })
-        if (!active) return
-        setResults(data)
-        setState('results')
-        setError(null)
+        const data = await searchUsers(supabase, { query: trimmed });
+        if (!active) return;
+        setResults(data);
+        setState("results");
+        setError(null);
       } catch (err) {
-        if (!active) return
-        console.error('useUserSearch: search failed for query:', trimmed, err)
-        setError(err instanceof Error ? err.message : 'Search failed')
-        setState('error')
-        setResults([])
+        if (!active) return;
+        console.error("useUserSearch: search failed for query:", trimmed, err);
+        setError(err instanceof Error ? err.message : "Search failed");
+        setState("error");
+        setResults([]);
       }
-    }, 300)
+    }, 300);
 
     return () => {
-      active = false
-      if (timerRef.current) clearTimeout(timerRef.current)
-    }
-  }, [query])
+      active = false;
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [query]);
 
-  return { results, state, error } as SearchResult
+  return { results, state, error } as SearchResult;
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 // expo-router never renders components, so side-effect imports inside layout
 // files are never executed. Importing here guarantees defineTask runs in both
 // foreground and headless contexts.
-import './lib/backgroundGeofences';
-import './lib/notifications';
+import "./lib/backgroundGeofences";
+import "./lib/notifications";
 
-import 'expo-router/entry';
+import "expo-router/entry";

--- a/lib/__tests__/authErrors.test.ts
+++ b/lib/__tests__/authErrors.test.ts
@@ -36,15 +36,11 @@ describe("isEduEmail", () => {
 
 describe("friendlyAuthError", () => {
   it("maps an exact known error message", () => {
-    expect(friendlyAuthError("Invalid login credentials")).toBe(
-      "Incorrect email or password.",
-    );
+    expect(friendlyAuthError("Invalid login credentials")).toBe("Incorrect email or password.");
   });
 
   it("matches case-insensitively", () => {
-    expect(friendlyAuthError("INVALID LOGIN CREDENTIALS")).toBe(
-      "Incorrect email or password.",
-    );
+    expect(friendlyAuthError("INVALID LOGIN CREDENTIALS")).toBe("Incorrect email or password.");
   });
 
   it("matches when the known key is a substring of a longer message", () => {
@@ -66,8 +62,6 @@ describe("friendlyAuthError", () => {
   });
 
   it("returns the fallback for an empty string", () => {
-    expect(friendlyAuthError("")).toBe(
-      "Something went wrong. Please try again.",
-    );
+    expect(friendlyAuthError("")).toBe("Something went wrong. Please try again.");
   });
 });

--- a/lib/__tests__/backgroundGeofences.test.ts
+++ b/lib/__tests__/backgroundGeofences.test.ts
@@ -1,12 +1,12 @@
-import { Platform } from 'react-native'
-import { getNearestPois, getGeofenceLimit, PoiSlim } from '../backgroundGeofences'
+import { Platform } from "react-native";
+import { getNearestPois, getGeofenceLimit, PoiSlim } from "../backgroundGeofences";
 
 // Mock the modules that defineTask calls at import time
-jest.mock('expo-task-manager', () => ({
+jest.mock("expo-task-manager", () => ({
   defineTask: jest.fn(),
   isTaskRegisteredAsync: jest.fn().mockResolvedValue(false),
-}))
-jest.mock('expo-location', () => ({
+}));
+jest.mock("expo-location", () => ({
   startGeofencingAsync: jest.fn().mockResolvedValue(undefined),
   startLocationUpdatesAsync: jest.fn().mockResolvedValue(undefined),
   stopGeofencingAsync: jest.fn().mockResolvedValue(undefined),
@@ -14,435 +14,433 @@ jest.mock('expo-location', () => ({
   LocationGeofencingEventType: { Enter: 1, Exit: 2 },
   Accuracy: { Low: 2, Balanced: 3 },
   ActivityType: { Other: 3 },
-}))
-jest.mock('expo-notifications', () => ({
-  scheduleNotificationAsync: jest.fn().mockResolvedValue('notif-id'),
-  SchedulableTriggerInputTypes: { TIME_INTERVAL: 'timeInterval' },
-}))
-jest.mock('@react-native-async-storage/async-storage', () => ({
+}));
+jest.mock("expo-notifications", () => ({
+  scheduleNotificationAsync: jest.fn().mockResolvedValue("notif-id"),
+  SchedulableTriggerInputTypes: { TIME_INTERVAL: "timeInterval" },
+}));
+jest.mock("@react-native-async-storage/async-storage", () => ({
   getItem: jest.fn().mockResolvedValue(null),
   setItem: jest.fn().mockResolvedValue(undefined),
-}))
-jest.mock('../notifications', () => ({
-  CHECKIN_CATEGORY: 'geofence-checkin',
+}));
+jest.mock("../notifications", () => ({
+  CHECKIN_CATEGORY: "geofence-checkin",
   setupNotificationCategories: jest.fn().mockResolvedValue(undefined),
-}))
-jest.mock('../supabase', () => ({
+}));
+jest.mock("../supabase", () => ({
   supabase: {
     from: jest.fn(() => ({
-      select: jest.fn(() => Promise.resolve({
-        data: [
-          { id: 'poi-1', name: 'Alpha', lat: 55.676, lng: 12.568 },
-          { id: 'poi-2', name: 'Bravo', lat: 55.680, lng: 12.570 },
-        ],
-        error: null,
-      })),
+      select: jest.fn(() =>
+        Promise.resolve({
+          data: [
+            { id: "poi-1", name: "Alpha", lat: 55.676, lng: 12.568 },
+            { id: "poi-2", name: "Bravo", lat: 55.68, lng: 12.57 },
+          ],
+          error: null,
+        }),
+      ),
     })),
   },
-}))
+}));
 
 const SAMPLE_POIS: PoiSlim[] = [
-  { id: 'a', name: 'Alpha', lat: 55.676, lng: 12.568 },
-  { id: 'b', name: 'Bravo', lat: 55.680, lng: 12.570 },
-  { id: 'c', name: 'Charlie', lat: 55.690, lng: 12.580 },
-  { id: 'd', name: 'Delta', lat: 55.700, lng: 12.600 },
-  { id: 'e', name: 'Echo', lat: 55.750, lng: 12.650 },
-]
+  { id: "a", name: "Alpha", lat: 55.676, lng: 12.568 },
+  { id: "b", name: "Bravo", lat: 55.68, lng: 12.57 },
+  { id: "c", name: "Charlie", lat: 55.69, lng: 12.58 },
+  { id: "d", name: "Delta", lat: 55.7, lng: 12.6 },
+  { id: "e", name: "Echo", lat: 55.75, lng: 12.65 },
+];
 
-describe('getNearestPois', () => {
-  it('returns the N nearest POIs sorted by distance', () => {
+describe("getNearestPois", () => {
+  it("returns the N nearest POIs sorted by distance", () => {
     // User is at Alpha's location — Alpha should be first
-    const result = getNearestPois(SAMPLE_POIS, 55.676, 12.568, 3)
-    expect(result).toHaveLength(3)
-    expect(result[0].id).toBe('a') // closest
-    expect(result[1].id).toBe('b') // second closest
-    expect(result[2].id).toBe('c') // third closest
-  })
+    const result = getNearestPois(SAMPLE_POIS, 55.676, 12.568, 3);
+    expect(result).toHaveLength(3);
+    expect(result[0].id).toBe("a"); // closest
+    expect(result[1].id).toBe("b"); // second closest
+    expect(result[2].id).toBe("c"); // third closest
+  });
 
-  it('returns all POIs when limit exceeds array length', () => {
-    const result = getNearestPois(SAMPLE_POIS, 55.676, 12.568, 100)
-    expect(result).toHaveLength(SAMPLE_POIS.length)
-  })
+  it("returns all POIs when limit exceeds array length", () => {
+    const result = getNearestPois(SAMPLE_POIS, 55.676, 12.568, 100);
+    expect(result).toHaveLength(SAMPLE_POIS.length);
+  });
 
-  it('returns empty array for empty input', () => {
-    const result = getNearestPois([], 55.676, 12.568, 5)
-    expect(result).toHaveLength(0)
-  })
+  it("returns empty array for empty input", () => {
+    const result = getNearestPois([], 55.676, 12.568, 5);
+    expect(result).toHaveLength(0);
+  });
 
-  it('does not mutate the original array', () => {
-    const original = [...SAMPLE_POIS]
-    getNearestPois(SAMPLE_POIS, 55.750, 12.650, 2)
-    expect(SAMPLE_POIS).toEqual(original)
-  })
-})
+  it("does not mutate the original array", () => {
+    const original = [...SAMPLE_POIS];
+    getNearestPois(SAMPLE_POIS, 55.75, 12.65, 2);
+    expect(SAMPLE_POIS).toEqual(original);
+  });
+});
 
-describe('getGeofenceLimit', () => {
-  const originalOS = Platform.OS
+describe("getGeofenceLimit", () => {
+  const originalOS = Platform.OS;
 
   afterEach(() => {
-    Object.defineProperty(Platform, 'OS', { value: originalOS })
-  })
+    Object.defineProperty(Platform, "OS", { value: originalOS });
+  });
 
-  it('returns 20 for iOS', () => {
-    Object.defineProperty(Platform, 'OS', { value: 'ios' })
-    expect(getGeofenceLimit()).toBe(20)
-  })
+  it("returns 20 for iOS", () => {
+    Object.defineProperty(Platform, "OS", { value: "ios" });
+    expect(getGeofenceLimit()).toBe(20);
+  });
 
-  it('returns 100 for Android', () => {
-    Object.defineProperty(Platform, 'OS', { value: 'android' })
-    expect(getGeofenceLimit()).toBe(100)
-  })
-})
+  it("returns 100 for Android", () => {
+    Object.defineProperty(Platform, "OS", { value: "android" });
+    expect(getGeofenceLimit()).toBe(100);
+  });
+});
 
-describe('geofence task handler', () => {
-  const TaskManager = require('expo-task-manager')
-  const Notifications = require('expo-notifications')
-  const AsyncStorage = require('@react-native-async-storage/async-storage')
+describe("geofence task handler", () => {
+  const TaskManager = require("expo-task-manager");
+  const Notifications = require("expo-notifications");
+  const AsyncStorage = require("@react-native-async-storage/async-storage");
 
   // Capture the handler at describe time — before any beforeEach clearAllMocks runs.
   // defineTask was called at module-load time when backgroundGeofences.ts was imported.
   const geofenceCall = TaskManager.defineTask.mock.calls.find(
-    (c: [string, unknown]) => c[0] === 'dispatch-geofence-task'
-  )
-  const handler = geofenceCall![1] as (args: { data: unknown; error: unknown }) => Promise<void>
+    (c: [string, unknown]) => c[0] === "dispatch-geofence-task",
+  );
+  const handler = geofenceCall![1] as (args: { data: unknown; error: unknown }) => Promise<void>;
 
   beforeEach(() => {
     // Only clear the mocks we use in each test — not defineTask itself
-    Notifications.scheduleNotificationAsync.mockClear()
-    AsyncStorage.getItem.mockReset()
-    AsyncStorage.setItem.mockReset()
-    AsyncStorage.getItem.mockResolvedValue(null)
-    AsyncStorage.setItem.mockResolvedValue(undefined)
-  })
+    Notifications.scheduleNotificationAsync.mockClear();
+    AsyncStorage.getItem.mockReset();
+    AsyncStorage.setItem.mockReset();
+    AsyncStorage.getItem.mockResolvedValue(null);
+    AsyncStorage.setItem.mockResolvedValue(undefined);
+  });
 
-  it('schedules a notification on geofence enter', async () => {
+  it("schedules a notification on geofence enter", async () => {
     await handler({
       data: {
         eventType: 1, // Enter
-        region: { identifier: 'poi-1::Paludan Bogcafé' },
+        region: { identifier: "poi-1::Paludan Bogcafé" },
       },
       error: null,
-    })
+    });
 
     expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
-      identifier: 'geofence-checkin:poi-1',
+      identifier: "geofence-checkin:poi-1",
       content: {
         title: "You're at Paludan Bogcafé",
-        body: 'Are you here? Tap to check in!',
-        categoryIdentifier: 'geofence-checkin',
-        data: { poiId: 'poi-1', poiName: 'Paludan Bogcafé' },
+        body: "Are you here? Tap to check in!",
+        categoryIdentifier: "geofence-checkin",
+        data: { poiId: "poi-1", poiName: "Paludan Bogcafé" },
       },
       trigger: null, // Platform.OS defaults to 'ios' in jest; Android uses TIME_INTERVAL trigger with channelId
-    })
-  })
+    });
+  });
 
-  it('does not schedule notification on exit event', async () => {
+  it("does not schedule notification on exit event", async () => {
     await handler({
       data: {
         eventType: 2, // Exit
-        region: { identifier: 'poi-1::Paludan' },
+        region: { identifier: "poi-1::Paludan" },
       },
       error: null,
-    })
+    });
 
-    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled()
-  })
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
 
-  it('does not schedule notification when error is provided', async () => {
+  it("does not schedule notification when error is provided", async () => {
     await handler({
       data: {
         eventType: 1,
-        region: { identifier: 'poi-1::Paludan' },
+        region: { identifier: "poi-1::Paludan" },
       },
-      error: { message: 'Location unavailable' },
-    })
+      error: { message: "Location unavailable" },
+    });
 
-    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled()
-  })
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
 
-  it('does not schedule notification when region.identifier is missing', async () => {
+  it("does not schedule notification when region.identifier is missing", async () => {
     await handler({
       data: {
         eventType: 1,
-        region: { identifier: '' },
+        region: { identifier: "" },
       },
       error: null,
-    })
+    });
 
-    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled()
-  })
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
 
-  it('suppresses notification within cooldown window', async () => {
-    AsyncStorage.getItem.mockResolvedValue((Date.now() - 1000).toString()) // 1 second ago
-
-    await handler({
-      data: {
-        eventType: 1,
-        region: { identifier: 'poi-1::Paludan' },
-      },
-      error: null,
-    })
-
-    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled()
-  })
-
-  it('fires notification after cooldown expires', async () => {
-    const twoHoursAgo = Date.now() - (2 * 60 * 60 * 1000 + 1000)
-    AsyncStorage.getItem.mockResolvedValue(twoHoursAgo.toString())
+  it("suppresses notification within cooldown window", async () => {
+    AsyncStorage.getItem.mockResolvedValue((Date.now() - 1000).toString()); // 1 second ago
 
     await handler({
       data: {
         eventType: 1,
-        region: { identifier: 'poi-1::Paludan' },
+        region: { identifier: "poi-1::Paludan" },
       },
       error: null,
-    })
+    });
 
-    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled()
-  })
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
 
-  it('correctly parses identifier with :: in the POI name', async () => {
+  it("fires notification after cooldown expires", async () => {
+    const twoHoursAgo = Date.now() - (2 * 60 * 60 * 1000 + 1000);
+    AsyncStorage.getItem.mockResolvedValue(twoHoursAgo.toString());
+
     await handler({
       data: {
         eventType: 1,
-        region: { identifier: 'poi-1::Café :: Lounge' },
+        region: { identifier: "poi-1::Paludan" },
       },
       error: null,
-    })
+    });
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
+  });
+
+  it("correctly parses identifier with :: in the POI name", async () => {
+    await handler({
+      data: {
+        eventType: 1,
+        region: { identifier: "poi-1::Café :: Lounge" },
+      },
+      error: null,
+    });
 
     expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
       expect.objectContaining({
-        identifier: 'geofence-checkin:poi-1',
+        identifier: "geofence-checkin:poi-1",
         content: expect.objectContaining({
-          data: { poiId: 'poi-1', poiName: 'Café :: Lounge' },
+          data: { poiId: "poi-1", poiName: "Café :: Lounge" },
         }),
-      })
-    )
-  })
+      }),
+    );
+  });
 
-  it('sets cooldown only after successful notification', async () => {
+  it("sets cooldown only after successful notification", async () => {
     await handler({
       data: {
         eventType: 1,
-        region: { identifier: 'poi-1::Paludan' },
+        region: { identifier: "poi-1::Paludan" },
       },
       error: null,
-    })
+    });
 
     // Verify setCooldown was called after scheduleNotificationAsync
-    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled()
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
-      'geofence-cooldown:poi-1',
-      expect.any(String)
-    )
-  })
+      "geofence-cooldown:poi-1",
+      expect.any(String),
+    );
+  });
 
-  it('does not set cooldown when notification fails', async () => {
-    Notifications.scheduleNotificationAsync.mockRejectedValueOnce(new Error('Channel not found'))
+  it("does not set cooldown when notification fails", async () => {
+    Notifications.scheduleNotificationAsync.mockRejectedValueOnce(new Error("Channel not found"));
 
     await handler({
       data: {
         eventType: 1,
-        region: { identifier: 'poi-1::Paludan' },
+        region: { identifier: "poi-1::Paludan" },
       },
       error: null,
-    })
+    });
 
     // setCooldown (setItem for cooldown key) should NOT have been called
     expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
-      'geofence-cooldown:poi-1',
-      expect.any(String)
-    )
-  })
+      "geofence-cooldown:poi-1",
+      expect.any(String),
+    );
+  });
 
-  it('allows notification when AsyncStorage.getItem fails (cooldown check)', async () => {
-    AsyncStorage.getItem.mockRejectedValueOnce(new Error('Storage full'))
+  it("allows notification when AsyncStorage.getItem fails (cooldown check)", async () => {
+    AsyncStorage.getItem.mockRejectedValueOnce(new Error("Storage full"));
 
     await handler({
       data: {
         eventType: 1,
-        region: { identifier: 'poi-1::Paludan' },
+        region: { identifier: "poi-1::Paludan" },
       },
       error: null,
-    })
+    });
 
     // Should allow the notification rather than silently blocking
-    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled()
-  })
-})
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
+  });
+});
 
-describe('SLC task handler', () => {
-  const TaskManager = require('expo-task-manager')
-  const AsyncStorage = require('@react-native-async-storage/async-storage')
-  const Location = require('expo-location')
-  const originalOS = Platform.OS
+describe("SLC task handler", () => {
+  const TaskManager = require("expo-task-manager");
+  const AsyncStorage = require("@react-native-async-storage/async-storage");
+  const Location = require("expo-location");
+  const originalOS = Platform.OS;
 
   const slcCall = TaskManager.defineTask.mock.calls.find(
-    (c: [string, unknown]) => c[0] === 'dispatch-slc-task'
-  )
-  const handler = slcCall![1] as (args: { data: unknown; error: unknown }) => Promise<void>
+    (c: [string, unknown]) => c[0] === "dispatch-slc-task",
+  );
+  const handler = slcCall![1] as (args: { data: unknown; error: unknown }) => Promise<void>;
 
   beforeEach(() => {
-    AsyncStorage.getItem.mockReset()
-    AsyncStorage.setItem.mockReset()
-    AsyncStorage.getItem.mockResolvedValue(null)
-    AsyncStorage.setItem.mockResolvedValue(undefined)
-    Location.startGeofencingAsync.mockClear()
-  })
+    AsyncStorage.getItem.mockReset();
+    AsyncStorage.setItem.mockReset();
+    AsyncStorage.getItem.mockResolvedValue(null);
+    AsyncStorage.setItem.mockResolvedValue(undefined);
+    Location.startGeofencingAsync.mockClear();
+  });
 
   afterEach(() => {
-    Object.defineProperty(Platform, 'OS', { value: originalOS })
-  })
+    Object.defineProperty(Platform, "OS", { value: originalOS });
+  });
 
-  it('skips re-registration on Android', async () => {
-    Object.defineProperty(Platform, 'OS', { value: 'android' })
+  it("skips re-registration on Android", async () => {
+    Object.defineProperty(Platform, "OS", { value: "android" });
 
     await handler({
       data: { locations: [{ coords: { latitude: 55.676, longitude: 12.568 } }] },
       error: null,
-    })
+    });
 
-    expect(Location.startGeofencingAsync).not.toHaveBeenCalled()
-  })
+    expect(Location.startGeofencingAsync).not.toHaveBeenCalled();
+  });
 
-  it('skips when locations array is empty', async () => {
-    Object.defineProperty(Platform, 'OS', { value: 'ios' })
+  it("skips when locations array is empty", async () => {
+    Object.defineProperty(Platform, "OS", { value: "ios" });
 
     await handler({
       data: { locations: [] },
       error: null,
-    })
+    });
 
-    expect(Location.startGeofencingAsync).not.toHaveBeenCalled()
-  })
+    expect(Location.startGeofencingAsync).not.toHaveBeenCalled();
+  });
 
-  it('skips when distance moved is below threshold', async () => {
-    Object.defineProperty(Platform, 'OS', { value: 'ios' })
+  it("skips when distance moved is below threshold", async () => {
+    Object.defineProperty(Platform, "OS", { value: "ios" });
 
     // Stored location is very close to the new one (< 500m)
-    AsyncStorage.getItem.mockResolvedValue(JSON.stringify({ latitude: 55.676, longitude: 12.568 }))
+    AsyncStorage.getItem.mockResolvedValue(JSON.stringify({ latitude: 55.676, longitude: 12.568 }));
 
     await handler({
       data: { locations: [{ coords: { latitude: 55.6761, longitude: 12.5681 } }] },
       error: null,
-    })
+    });
 
-    expect(Location.startGeofencingAsync).not.toHaveBeenCalled()
-  })
+    expect(Location.startGeofencingAsync).not.toHaveBeenCalled();
+  });
 
-  it('re-registers and updates stored location when distance exceeds threshold', async () => {
-    Object.defineProperty(Platform, 'OS', { value: 'ios' })
+  it("re-registers and updates stored location when distance exceeds threshold", async () => {
+    Object.defineProperty(Platform, "OS", { value: "ios" });
 
     // Stored location is far from the new one (> 500m)
-    AsyncStorage.getItem.mockResolvedValue(JSON.stringify({ latitude: 55.670, longitude: 12.560 }))
+    AsyncStorage.getItem.mockResolvedValue(JSON.stringify({ latitude: 55.67, longitude: 12.56 }));
 
     await handler({
-      data: { locations: [{ coords: { latitude: 55.690, longitude: 12.590 } }] },
+      data: { locations: [{ coords: { latitude: 55.69, longitude: 12.59 } }] },
       error: null,
-    })
+    });
 
-    expect(Location.startGeofencingAsync).toHaveBeenCalled()
+    expect(Location.startGeofencingAsync).toHaveBeenCalled();
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
-      'geofence-slc-last-loc',
-      JSON.stringify({ latitude: 55.690, longitude: 12.590 })
-    )
-  })
+      "geofence-slc-last-loc",
+      JSON.stringify({ latitude: 55.69, longitude: 12.59 }),
+    );
+  });
 
-  it('does not throw when error parameter is provided', async () => {
+  it("does not throw when error parameter is provided", async () => {
     await handler({
       data: { locations: [] },
-      error: { message: 'something broke' },
-    })
+      error: { message: "something broke" },
+    });
 
-    expect(Location.startGeofencingAsync).not.toHaveBeenCalled()
-  })
-})
+    expect(Location.startGeofencingAsync).not.toHaveBeenCalled();
+  });
+});
 
-describe('stopGeofences', () => {
-  const Location = require('expo-location')
-
-  beforeEach(() => {
-    Location.stopGeofencingAsync.mockClear()
-    Location.stopLocationUpdatesAsync.mockClear()
-    Location.stopGeofencingAsync.mockResolvedValue(undefined)
-    Location.stopLocationUpdatesAsync.mockResolvedValue(undefined)
-  })
-
-  it('calls both stop functions', async () => {
-    const { stopGeofences } = require('../backgroundGeofences')
-    await stopGeofences()
-
-    expect(Location.stopGeofencingAsync).toHaveBeenCalledWith('dispatch-geofence-task')
-    expect(Location.stopLocationUpdatesAsync).toHaveBeenCalledWith('dispatch-slc-task')
-  })
-
-  it('does not throw when tasks are not registered', async () => {
-    Location.stopGeofencingAsync.mockRejectedValue(new Error('Task not registered'))
-    Location.stopLocationUpdatesAsync.mockRejectedValue(new Error('Task not found'))
-
-    const { stopGeofences } = require('../backgroundGeofences')
-    await expect(stopGeofences()).resolves.toBeUndefined()
-  })
-})
-
-describe('registerGeofences', () => {
-  const Location = require('expo-location')
-  const TaskManagerReg = require('expo-task-manager')
-  const originalOS = Platform.OS
+describe("stopGeofences", () => {
+  const Location = require("expo-location");
 
   beforeEach(() => {
-    Location.startGeofencingAsync.mockClear()
-    Location.startLocationUpdatesAsync.mockClear()
-    TaskManagerReg.isTaskRegisteredAsync.mockClear()
-    TaskManagerReg.isTaskRegisteredAsync.mockResolvedValue(false)
-  })
+    Location.stopGeofencingAsync.mockClear();
+    Location.stopLocationUpdatesAsync.mockClear();
+    Location.stopGeofencingAsync.mockResolvedValue(undefined);
+    Location.stopLocationUpdatesAsync.mockResolvedValue(undefined);
+  });
+
+  it("calls both stop functions", async () => {
+    const { stopGeofences } = require("../backgroundGeofences");
+    await stopGeofences();
+
+    expect(Location.stopGeofencingAsync).toHaveBeenCalledWith("dispatch-geofence-task");
+    expect(Location.stopLocationUpdatesAsync).toHaveBeenCalledWith("dispatch-slc-task");
+  });
+
+  it("does not throw when tasks are not registered", async () => {
+    Location.stopGeofencingAsync.mockRejectedValue(new Error("Task not registered"));
+    Location.stopLocationUpdatesAsync.mockRejectedValue(new Error("Task not found"));
+
+    const { stopGeofences } = require("../backgroundGeofences");
+    await expect(stopGeofences()).resolves.toBeUndefined();
+  });
+});
+
+describe("registerGeofences", () => {
+  const Location = require("expo-location");
+  const TaskManagerReg = require("expo-task-manager");
+  const originalOS = Platform.OS;
+
+  beforeEach(() => {
+    Location.startGeofencingAsync.mockClear();
+    Location.startLocationUpdatesAsync.mockClear();
+    TaskManagerReg.isTaskRegisteredAsync.mockClear();
+    TaskManagerReg.isTaskRegisteredAsync.mockResolvedValue(false);
+  });
 
   afterEach(() => {
-    Object.defineProperty(Platform, 'OS', { value: originalOS })
-  })
+    Object.defineProperty(Platform, "OS", { value: originalOS });
+  });
 
-  it('stops existing geofence task before re-registering', async () => {
-    Object.defineProperty(Platform, 'OS', { value: 'android' })
-    const { registerGeofences } = require('../backgroundGeofences')
+  it("stops existing geofence task before re-registering", async () => {
+    Object.defineProperty(Platform, "OS", { value: "android" });
+    const { registerGeofences } = require("../backgroundGeofences");
 
     // Track call order via a shared array
-    const callOrder: string[] = []
+    const callOrder: string[] = [];
     Location.stopGeofencingAsync.mockImplementation(() => {
-      callOrder.push('stopGeofencing')
-      return Promise.resolve(undefined)
-    })
+      callOrder.push("stopGeofencing");
+      return Promise.resolve(undefined);
+    });
     Location.startGeofencingAsync.mockImplementation(() => {
-      callOrder.push('startGeofencing')
-      return Promise.resolve(undefined)
-    })
+      callOrder.push("startGeofencing");
+      return Promise.resolve(undefined);
+    });
 
-    const pois: PoiSlim[] = [
-      { id: 'poi-1', name: 'Test', lat: 55.676, lng: 12.568 },
-    ]
+    const pois: PoiSlim[] = [{ id: "poi-1", name: "Test", lat: 55.676, lng: 12.568 }];
 
-    await registerGeofences(pois, { latitude: 55.676, longitude: 12.568 })
+    await registerGeofences(pois, { latitude: 55.676, longitude: 12.568 });
 
-    expect(Location.stopGeofencingAsync).toHaveBeenCalledWith('dispatch-geofence-task')
-    expect(callOrder.indexOf('stopGeofencing')).toBeLessThan(callOrder.indexOf('startGeofencing'))
-  })
+    expect(Location.stopGeofencingAsync).toHaveBeenCalledWith("dispatch-geofence-task");
+    expect(callOrder.indexOf("stopGeofencing")).toBeLessThan(callOrder.indexOf("startGeofencing"));
+  });
 
-  it('tolerates not-registered error when stopping geofence task', async () => {
-    Object.defineProperty(Platform, 'OS', { value: 'android' })
-    Location.stopGeofencingAsync.mockRejectedValueOnce(new Error('Task not registered'))
+  it("tolerates not-registered error when stopping geofence task", async () => {
+    Object.defineProperty(Platform, "OS", { value: "android" });
+    Location.stopGeofencingAsync.mockRejectedValueOnce(new Error("Task not registered"));
 
-    const { registerGeofences } = require('../backgroundGeofences')
-    const pois: PoiSlim[] = [
-      { id: 'poi-1', name: 'Test', lat: 55.676, lng: 12.568 },
-    ]
+    const { registerGeofences } = require("../backgroundGeofences");
+    const pois: PoiSlim[] = [{ id: "poi-1", name: "Test", lat: 55.676, lng: 12.568 }];
 
     // Should not throw — the error is silently swallowed
-    await expect(registerGeofences(pois)).resolves.toBeUndefined()
-    expect(Location.startGeofencingAsync).toHaveBeenCalled()
-  })
+    await expect(registerGeofences(pois)).resolves.toBeUndefined();
+    expect(Location.startGeofencingAsync).toHaveBeenCalled();
+  });
 
-  it('registers all POIs on Android (limit 100 > 63 POIs)', async () => {
-    Object.defineProperty(Platform, 'OS', { value: 'android' })
-    const { registerGeofences } = require('../backgroundGeofences')
+  it("registers all POIs on Android (limit 100 > 63 POIs)", async () => {
+    Object.defineProperty(Platform, "OS", { value: "android" });
+    const { registerGeofences } = require("../backgroundGeofences");
 
     // Generate 63 POIs — all fit under Android's 100 limit
     const pois: PoiSlim[] = Array.from({ length: 63 }, (_, i) => ({
@@ -450,64 +448,64 @@ describe('registerGeofences', () => {
       name: `Place ${i}`,
       lat: 55.676 + i * 0.001,
       lng: 12.568 + i * 0.001,
-    }))
+    }));
 
-    await registerGeofences(pois, { latitude: 55.676, longitude: 12.568 })
+    await registerGeofences(pois, { latitude: 55.676, longitude: 12.568 });
 
-    const regions = Location.startGeofencingAsync.mock.calls[0][1]
-    expect(regions).toHaveLength(63)
-  })
+    const regions = Location.startGeofencingAsync.mock.calls[0][1];
+    expect(regions).toHaveLength(63);
+  });
 
-  it('registers nearest 20 POIs on iOS', async () => {
-    Object.defineProperty(Platform, 'OS', { value: 'ios' })
-    const { registerGeofences } = require('../backgroundGeofences')
+  it("registers nearest 20 POIs on iOS", async () => {
+    Object.defineProperty(Platform, "OS", { value: "ios" });
+    const { registerGeofences } = require("../backgroundGeofences");
 
     const pois: PoiSlim[] = Array.from({ length: 63 }, (_, i) => ({
       id: `poi-${i}`,
       name: `Place ${i}`,
       lat: 55.676 + i * 0.001,
       lng: 12.568 + i * 0.001,
-    }))
+    }));
 
-    await registerGeofences(pois, { latitude: 55.676, longitude: 12.568 })
+    await registerGeofences(pois, { latitude: 55.676, longitude: 12.568 });
 
-    const regions = Location.startGeofencingAsync.mock.calls[0][1]
-    expect(regions).toHaveLength(20)
-  })
+    const regions = Location.startGeofencingAsync.mock.calls[0][1];
+    expect(regions).toHaveLength(20);
+  });
 
-  it('uses Copenhagen center when no currentLocation provided', async () => {
-    Object.defineProperty(Platform, 'OS', { value: 'ios' })
-    const { registerGeofences } = require('../backgroundGeofences')
+  it("uses Copenhagen center when no currentLocation provided", async () => {
+    Object.defineProperty(Platform, "OS", { value: "ios" });
+    const { registerGeofences } = require("../backgroundGeofences");
 
     const pois: PoiSlim[] = Array.from({ length: 5 }, (_, i) => ({
       id: `poi-${i}`,
       name: `Place ${i}`,
       lat: 55.676 + i * 0.01,
       lng: 12.568 + i * 0.01,
-    }))
+    }));
 
-    await registerGeofences(pois) // no second argument
+    await registerGeofences(pois); // no second argument
 
-    expect(Location.startGeofencingAsync).toHaveBeenCalled()
-    const regions = Location.startGeofencingAsync.mock.calls[0][1]
-    expect(regions).toHaveLength(5)
-  })
+    expect(Location.startGeofencingAsync).toHaveBeenCalled();
+    const regions = Location.startGeofencingAsync.mock.calls[0][1];
+    expect(regions).toHaveLength(5);
+  });
 
-  it('sets notifyOnEnter: true and notifyOnExit: false on each region', async () => {
-    Object.defineProperty(Platform, 'OS', { value: 'ios' })
-    const { registerGeofences } = require('../backgroundGeofences')
+  it("sets notifyOnEnter: true and notifyOnExit: false on each region", async () => {
+    Object.defineProperty(Platform, "OS", { value: "ios" });
+    const { registerGeofences } = require("../backgroundGeofences");
 
-    const pois: PoiSlim[] = [
-      { id: 'poi-1', name: 'Test', lat: 55.676, lng: 12.568 },
-    ]
+    const pois: PoiSlim[] = [{ id: "poi-1", name: "Test", lat: 55.676, lng: 12.568 }];
 
-    await registerGeofences(pois, { latitude: 55.676, longitude: 12.568 })
+    await registerGeofences(pois, { latitude: 55.676, longitude: 12.568 });
 
-    const regions = Location.startGeofencingAsync.mock.calls[0][1]
-    expect(regions[0]).toEqual(expect.objectContaining({
-      notifyOnEnter: true,
-      notifyOnExit: false,
-      radius: 100,
-    }))
-  })
-})
+    const regions = Location.startGeofencingAsync.mock.calls[0][1];
+    expect(regions[0]).toEqual(
+      expect.objectContaining({
+        notifyOnEnter: true,
+        notifyOnExit: false,
+        radius: 100,
+      }),
+    );
+  });
+});

--- a/lib/__tests__/checkIns.test.ts
+++ b/lib/__tests__/checkIns.test.ts
@@ -1,124 +1,132 @@
-import { insertCheckIn } from '../checkIns'
-import { SupabaseClient } from '@supabase/supabase-js'
-import { Database } from '../../types/supabase'
+import { insertCheckIn } from "../checkIns";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "../../types/supabase";
 
-const MOCK_USER_ID = 'user-123'
-const MOCK_POI_ID = 'poi-456'
-const MOCK_SEMESTER_ID = 'sem-789'
+const MOCK_USER_ID = "user-123";
+const MOCK_POI_ID = "poi-456";
+const MOCK_SEMESTER_ID = "sem-789";
 
 type MockSupabase = {
-  from: jest.Mock
-  auth: { getUser: jest.Mock }
-}
+  from: jest.Mock;
+  auth: { getUser: jest.Mock };
+};
 
 function makeMockSupabase({
   profileResult = { data: { semester_id: MOCK_SEMESTER_ID }, error: null },
   insertResult = { error: null },
 }: {
-  profileResult?: { data: { semester_id: string | null } | null; error: { message: string } | null }
-  insertResult?: { error: { message: string; code?: string } | null }
+  profileResult?: {
+    data: { semester_id: string | null } | null;
+    error: { message: string } | null;
+  };
+  insertResult?: { error: { message: string; code?: string } | null };
 } = {}): MockSupabase {
-  const single = jest.fn().mockResolvedValue(profileResult)
-  const eqProfile = jest.fn().mockReturnValue({ single })
-  const selectProfile = jest.fn().mockReturnValue({ eq: eqProfile })
+  const single = jest.fn().mockResolvedValue(profileResult);
+  const eqProfile = jest.fn().mockReturnValue({ single });
+  const selectProfile = jest.fn().mockReturnValue({ eq: eqProfile });
 
-  const insert = jest.fn().mockResolvedValue(insertResult)
+  const insert = jest.fn().mockResolvedValue(insertResult);
 
   const from = jest.fn().mockImplementation((table: string) => {
-    if (table === 'profiles') return { select: selectProfile }
-    if (table === 'check_ins') return { insert }
-    return {}
-  })
+    if (table === "profiles") return { select: selectProfile };
+    if (table === "check_ins") return { insert };
+    return {};
+  });
 
   const getUser = jest.fn().mockResolvedValue({
     data: { user: { id: MOCK_USER_ID } },
     error: null,
-  })
+  });
 
-  return { from, auth: { getUser } }
+  return { from, auth: { getUser } };
 }
 
 function asClient(mock: MockSupabase): SupabaseClient<Database> {
-  return mock as unknown as SupabaseClient<Database>
+  return mock as unknown as SupabaseClient<Database>;
 }
 
-describe('insertCheckIn', () => {
-  it('inserts a check-in with correct user_id, poi_id, and semester_id', async () => {
-    const mock = makeMockSupabase()
-    await insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })
+describe("insertCheckIn", () => {
+  it("inserts a check-in with correct user_id, poi_id, and semester_id", async () => {
+    const mock = makeMockSupabase();
+    await insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID });
 
-    expect(mock.from).toHaveBeenCalledWith('check_ins')
+    expect(mock.from).toHaveBeenCalledWith("check_ins");
     const checkInsFrom = mock.from.mock.results.find(
-      (_r: { value: unknown }, i: number) => mock.from.mock.calls[i][0] === 'check_ins'
-    )!.value
+      (_r: { value: unknown }, i: number) => mock.from.mock.calls[i][0] === "check_ins",
+    )!.value;
     expect(checkInsFrom.insert).toHaveBeenCalledWith({
       user_id: MOCK_USER_ID,
       poi_id: MOCK_POI_ID,
       semester_id: MOCK_SEMESTER_ID,
-    })
-  })
+    });
+  });
 
-  it('handles null semester_id from profile', async () => {
+  it("handles null semester_id from profile", async () => {
     const mock = makeMockSupabase({
       profileResult: { data: { semester_id: null }, error: null },
-    })
-    await insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })
+    });
+    await insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID });
 
     const checkInsFrom = mock.from.mock.results.find(
-      (_r: { value: unknown }, i: number) => mock.from.mock.calls[i][0] === 'check_ins'
-    )!.value
+      (_r: { value: unknown }, i: number) => mock.from.mock.calls[i][0] === "check_ins",
+    )!.value;
     expect(checkInsFrom.insert).toHaveBeenCalledWith(
-      expect.objectContaining({ semester_id: null })
-    )
-  })
+      expect.objectContaining({ semester_id: null }),
+    );
+  });
 
-  it('throws when user is not authenticated', async () => {
-    const mock = makeMockSupabase()
-    mock.auth.getUser.mockResolvedValue({ data: { user: null }, error: null })
+  it("throws when user is not authenticated", async () => {
+    const mock = makeMockSupabase();
+    mock.auth.getUser.mockResolvedValue({ data: { user: null }, error: null });
 
-    await expect(
-      insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })
-    ).rejects.toThrow('Not authenticated')
-  })
+    await expect(insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow(
+      "Not authenticated",
+    );
+  });
 
-  it('throws when auth returns an error', async () => {
-    const mock = makeMockSupabase()
+  it("throws when auth returns an error", async () => {
+    const mock = makeMockSupabase();
     mock.auth.getUser.mockResolvedValue({
       data: { user: null },
-      error: { message: 'auth error' },
-    })
+      error: { message: "auth error" },
+    });
 
-    await expect(
-      insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })
-    ).rejects.toThrow('Not authenticated')
-  })
+    await expect(insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow(
+      "Not authenticated",
+    );
+  });
 
-  it('throws when profile fetch fails', async () => {
+  it("throws when profile fetch fails", async () => {
     const mock = makeMockSupabase({
-      profileResult: { data: null, error: { message: 'profile not found' } },
-    })
+      profileResult: { data: null, error: { message: "profile not found" } },
+    });
 
-    await expect(
-      insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })
-    ).rejects.toThrow('profile not found')
-  })
+    await expect(insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow(
+      "profile not found",
+    );
+  });
 
-  it('throws when check-in insert fails', async () => {
+  it("throws when check-in insert fails", async () => {
     const mock = makeMockSupabase({
-      insertResult: { error: { message: 'insert failed' } },
-    })
+      insertResult: { error: { message: "insert failed" } },
+    });
 
-    await expect(
-      insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })
-    ).rejects.toThrow('insert failed')
-  })
+    await expect(insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow(
+      "insert failed",
+    );
+  });
 
-  it('treats exclusion constraint violation (23P01) as success', async () => {
+  it("treats exclusion constraint violation (23P01) as success", async () => {
     const mock = makeMockSupabase({
-      insertResult: { error: { code: '23P01', message: 'conflicting key value violates exclusion constraint' } as any },
-    })
+      insertResult: {
+        error: {
+          code: "23P01",
+          message: "conflicting key value violates exclusion constraint",
+        } as any,
+      },
+    });
 
     // Should resolve without throwing — the first check-in already exists
-    await expect(insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })).resolves.toBeUndefined()
-  })
-})
+    await expect(insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })).resolves.toBeUndefined();
+  });
+});

--- a/lib/__tests__/friends.test.ts
+++ b/lib/__tests__/friends.test.ts
@@ -1,105 +1,109 @@
-import { searchUsers, SearchUser } from '../friends'
-import { SupabaseClient } from '@supabase/supabase-js'
-import { Database } from '../../types/supabase'
+import { searchUsers, SearchUser } from "../friends";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "../../types/supabase";
 
-const MOCK_USER_ID = 'user-123'
+const MOCK_USER_ID = "user-123";
 
 const MOCK_RESULTS: SearchUser[] = [
-  { id: 'user-456', display_name: 'Jane Doe', avatar_url: null },
-  { id: 'user-789', display_name: 'James Smith', avatar_url: 'https://example.com/avatar.png' },
-]
+  { id: "user-456", display_name: "Jane Doe", avatar_url: null },
+  { id: "user-789", display_name: "James Smith", avatar_url: "https://example.com/avatar.png" },
+];
 
 type MockSupabase = {
-  from: jest.Mock
-  auth: { getUser: jest.Mock }
-}
+  from: jest.Mock;
+  auth: { getUser: jest.Mock };
+};
 
 function makeMockSupabase({
   queryResult = { data: MOCK_RESULTS, error: null },
   getUserResult = { data: { user: { id: MOCK_USER_ID } }, error: null },
 }: {
-  queryResult?: { data: typeof MOCK_RESULTS | null; error: { message: string } | null }
-  getUserResult?: { data: { user: { id: string } | null }; error: { message: string } | null }
+  queryResult?: { data: typeof MOCK_RESULTS | null; error: { message: string } | null };
+  getUserResult?: { data: { user: { id: string } | null }; error: { message: string } | null };
 } = {}): MockSupabase {
-  const limit = jest.fn().mockResolvedValue(queryResult)
-  const neq = jest.fn().mockReturnValue({ limit })
-  const ilike = jest.fn().mockReturnValue({ neq })
-  const select = jest.fn().mockReturnValue({ ilike })
-  const from = jest.fn().mockReturnValue({ select })
-  const getUser = jest.fn().mockResolvedValue(getUserResult)
+  const limit = jest.fn().mockResolvedValue(queryResult);
+  const neq = jest.fn().mockReturnValue({ limit });
+  const ilike = jest.fn().mockReturnValue({ neq });
+  const select = jest.fn().mockReturnValue({ ilike });
+  const from = jest.fn().mockReturnValue({ select });
+  const getUser = jest.fn().mockResolvedValue(getUserResult);
 
-  return { from, auth: { getUser } }
+  return { from, auth: { getUser } };
 }
 
 function asClient(mock: MockSupabase): SupabaseClient<Database> {
-  return mock as unknown as SupabaseClient<Database>
+  return mock as unknown as SupabaseClient<Database>;
 }
 
-describe('searchUsers', () => {
-  it('queries profiles with correct ilike pattern and excludes self', async () => {
-    const mock = makeMockSupabase()
-    await searchUsers(asClient(mock), { query: 'Jane' })
+describe("searchUsers", () => {
+  it("queries profiles with correct ilike pattern and excludes self", async () => {
+    const mock = makeMockSupabase();
+    await searchUsers(asClient(mock), { query: "Jane" });
 
-    expect(mock.from).toHaveBeenCalledWith('profiles')
-    const fromInstance = mock.from.mock.results[0].value
-    expect(fromInstance.select).toHaveBeenCalledWith('id, display_name, avatar_url')
-    const selectInstance = fromInstance.select.mock.results[0].value
-    expect(selectInstance.ilike).toHaveBeenCalledWith('display_name', 'Jane%')
-    const ilikeInstance = selectInstance.ilike.mock.results[0].value
-    expect(ilikeInstance.neq).toHaveBeenCalledWith('id', MOCK_USER_ID)
-    const neqInstance = ilikeInstance.neq.mock.results[0].value
-    expect(neqInstance.limit).toHaveBeenCalledWith(20)
-  })
+    expect(mock.from).toHaveBeenCalledWith("profiles");
+    const fromInstance = mock.from.mock.results[0].value;
+    expect(fromInstance.select).toHaveBeenCalledWith("id, display_name, avatar_url");
+    const selectInstance = fromInstance.select.mock.results[0].value;
+    expect(selectInstance.ilike).toHaveBeenCalledWith("display_name", "Jane%");
+    const ilikeInstance = selectInstance.ilike.mock.results[0].value;
+    expect(ilikeInstance.neq).toHaveBeenCalledWith("id", MOCK_USER_ID);
+    const neqInstance = ilikeInstance.neq.mock.results[0].value;
+    expect(neqInstance.limit).toHaveBeenCalledWith(20);
+  });
 
-  it('returns data array on success', async () => {
-    const mock = makeMockSupabase()
-    const results = await searchUsers(asClient(mock), { query: 'Jane' })
-    expect(results).toEqual(MOCK_RESULTS)
-  })
+  it("returns data array on success", async () => {
+    const mock = makeMockSupabase();
+    const results = await searchUsers(asClient(mock), { query: "Jane" });
+    expect(results).toEqual(MOCK_RESULTS);
+  });
 
-  it('returns empty array when data is null but no error', async () => {
-    const mock = makeMockSupabase({ queryResult: { data: null, error: null } })
-    const results = await searchUsers(asClient(mock), { query: 'Jane' })
-    expect(results).toEqual([])
-  })
+  it("returns empty array when data is null but no error", async () => {
+    const mock = makeMockSupabase({ queryResult: { data: null, error: null } });
+    const results = await searchUsers(asClient(mock), { query: "Jane" });
+    expect(results).toEqual([]);
+  });
 
-  it('throws Not authenticated when getUser returns no user', async () => {
+  it("throws Not authenticated when getUser returns no user", async () => {
     const mock = makeMockSupabase({
       getUserResult: { data: { user: null }, error: null },
-    })
-    await expect(searchUsers(asClient(mock), { query: 'Jane' })).rejects.toThrow('Not authenticated')
-    expect(mock.from).not.toHaveBeenCalled()
-  })
+    });
+    await expect(searchUsers(asClient(mock), { query: "Jane" })).rejects.toThrow(
+      "Not authenticated",
+    );
+    expect(mock.from).not.toHaveBeenCalled();
+  });
 
-  it('throws Not authenticated when getUser returns an error', async () => {
+  it("throws Not authenticated when getUser returns an error", async () => {
     const mock = makeMockSupabase({
-      getUserResult: { data: { user: null }, error: { message: 'auth error' } },
-    })
-    await expect(searchUsers(asClient(mock), { query: 'Jane' })).rejects.toThrow('Not authenticated')
-  })
+      getUserResult: { data: { user: null }, error: { message: "auth error" } },
+    });
+    await expect(searchUsers(asClient(mock), { query: "Jane" })).rejects.toThrow(
+      "Not authenticated",
+    );
+  });
 
-  it('throws Supabase error message on query failure', async () => {
+  it("throws Supabase error message on query failure", async () => {
     const mock = makeMockSupabase({
-      queryResult: { data: null, error: { message: 'network failure' } },
-    })
-    await expect(searchUsers(asClient(mock), { query: 'Jane' })).rejects.toThrow('network failure')
-  })
+      queryResult: { data: null, error: { message: "network failure" } },
+    });
+    await expect(searchUsers(asClient(mock), { query: "Jane" })).rejects.toThrow("network failure");
+  });
 
-  it('escapes ILIKE special characters in the query', async () => {
-    const mock = makeMockSupabase()
-    await searchUsers(asClient(mock), { query: '%admin' })
+  it("escapes ILIKE special characters in the query", async () => {
+    const mock = makeMockSupabase();
+    await searchUsers(asClient(mock), { query: "%admin" });
 
-    const fromInstance = mock.from.mock.results[0].value
-    const selectInstance = fromInstance.select.mock.results[0].value
-    expect(selectInstance.ilike).toHaveBeenCalledWith('display_name', '\\%admin%')
-  })
+    const fromInstance = mock.from.mock.results[0].value;
+    const selectInstance = fromInstance.select.mock.results[0].value;
+    expect(selectInstance.ilike).toHaveBeenCalledWith("display_name", "\\%admin%");
+  });
 
-  it('escapes underscore wildcard in the query', async () => {
-    const mock = makeMockSupabase()
-    await searchUsers(asClient(mock), { query: '_test' })
+  it("escapes underscore wildcard in the query", async () => {
+    const mock = makeMockSupabase();
+    await searchUsers(asClient(mock), { query: "_test" });
 
-    const fromInstance = mock.from.mock.results[0].value
-    const selectInstance = fromInstance.select.mock.results[0].value
-    expect(selectInstance.ilike).toHaveBeenCalledWith('display_name', '\\_test%')
-  })
-})
+    const fromInstance = mock.from.mock.results[0].value;
+    const selectInstance = fromInstance.select.mock.results[0].value;
+    expect(selectInstance.ilike).toHaveBeenCalledWith("display_name", "\\_test%");
+  });
+});

--- a/lib/__tests__/friendships.test.ts
+++ b/lib/__tests__/friendships.test.ts
@@ -5,273 +5,284 @@ import {
   acceptRequest,
   declineRequest,
   unfriend,
-} from '../friendships'
-import { SupabaseClient } from '@supabase/supabase-js'
-import { Database } from '../../types/supabase'
+} from "../friendships";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "../../types/supabase";
 
-const MOCK_USER_ID = 'user-abc'
-const MOCK_ADDRESSEE_ID = 'user-xyz'
-const MOCK_FRIENDSHIP_ID = 'friendship-123'
+const MOCK_USER_ID = "user-abc";
+const MOCK_ADDRESSEE_ID = "user-xyz";
+const MOCK_FRIENDSHIP_ID = "friendship-123";
 
 const MOCK_ROW = {
   id: MOCK_FRIENDSHIP_ID,
   requester_id: MOCK_USER_ID,
   addressee_id: MOCK_ADDRESSEE_ID,
-  status: 'pending',
-  created_at: '2026-01-01T00:00:00Z',
-}
+  status: "pending",
+  created_at: "2026-01-01T00:00:00Z",
+};
 
-type MockSupabase = { from: jest.Mock; auth: { getUser: jest.Mock } }
+type MockSupabase = { from: jest.Mock; auth: { getUser: jest.Mock } };
 
 function asClient(mock: MockSupabase): SupabaseClient<Database> {
-  return mock as unknown as SupabaseClient<Database>
+  return mock as unknown as SupabaseClient<Database>;
 }
 
 function authedGetUser(userId = MOCK_USER_ID) {
-  return jest.fn().mockResolvedValue({ data: { user: { id: userId } }, error: null })
+  return jest.fn().mockResolvedValue({ data: { user: { id: userId } }, error: null });
 }
 
 // ---------- fetchFriendships ----------
 
-describe('fetchFriendships', () => {
-  it('selects with embedded profile joins and user filter', async () => {
-    const or = jest.fn().mockResolvedValue({ data: [MOCK_ROW], error: null })
-    const select = jest.fn().mockReturnValue({ or })
-    const from = jest.fn().mockReturnValue({ select })
-    const mock: MockSupabase = { from, auth: { getUser: authedGetUser() } }
+describe("fetchFriendships", () => {
+  it("selects with embedded profile joins and user filter", async () => {
+    const or = jest.fn().mockResolvedValue({ data: [MOCK_ROW], error: null });
+    const select = jest.fn().mockReturnValue({ or });
+    const from = jest.fn().mockReturnValue({ select });
+    const mock: MockSupabase = { from, auth: { getUser: authedGetUser() } };
 
-    const result = await fetchFriendships(asClient(mock))
-    expect(mock.from).toHaveBeenCalledWith('friendships')
-    expect(select).toHaveBeenCalledWith(expect.stringContaining('requester:requester_id'))
-    expect(select).toHaveBeenCalledWith(expect.stringContaining('addressee:addressee_id'))
-    expect(or).toHaveBeenCalledWith(expect.stringContaining(`requester_id.eq.${MOCK_USER_ID}`))
-    expect(or).toHaveBeenCalledWith(expect.stringContaining(`addressee_id.eq.${MOCK_USER_ID}`))
-    expect(result).toEqual([MOCK_ROW])
-  })
+    const result = await fetchFriendships(asClient(mock));
+    expect(mock.from).toHaveBeenCalledWith("friendships");
+    expect(select).toHaveBeenCalledWith(expect.stringContaining("requester:requester_id"));
+    expect(select).toHaveBeenCalledWith(expect.stringContaining("addressee:addressee_id"));
+    expect(or).toHaveBeenCalledWith(expect.stringContaining(`requester_id.eq.${MOCK_USER_ID}`));
+    expect(or).toHaveBeenCalledWith(expect.stringContaining(`addressee_id.eq.${MOCK_USER_ID}`));
+    expect(result).toEqual([MOCK_ROW]);
+  });
 
-  it('throws when not authenticated', async () => {
-    const from = jest.fn()
+  it("throws when not authenticated", async () => {
+    const from = jest.fn();
     const mock: MockSupabase = {
       from,
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: null }) },
-    }
-    await expect(fetchFriendships(asClient(mock))).rejects.toThrow('Not authenticated')
-  })
+    };
+    await expect(fetchFriendships(asClient(mock))).rejects.toThrow("Not authenticated");
+  });
 
-  it('throws on Supabase error', async () => {
-    const or = jest.fn().mockResolvedValue({ data: null, error: { message: 'db error' } })
-    const select = jest.fn().mockReturnValue({ or })
-    const from = jest.fn().mockReturnValue({ select })
-    const mock: MockSupabase = { from, auth: { getUser: authedGetUser() } }
-    await expect(fetchFriendships(asClient(mock))).rejects.toThrow('db error')
-  })
-})
+  it("throws on Supabase error", async () => {
+    const or = jest.fn().mockResolvedValue({ data: null, error: { message: "db error" } });
+    const select = jest.fn().mockReturnValue({ or });
+    const from = jest.fn().mockReturnValue({ select });
+    const mock: MockSupabase = { from, auth: { getUser: authedGetUser() } };
+    await expect(fetchFriendships(asClient(mock))).rejects.toThrow("db error");
+  });
+});
 
 // ---------- sendRequest ----------
 
-describe('sendRequest', () => {
-  function makeSendMock(result: { data: typeof MOCK_ROW | null; error: unknown } = { data: MOCK_ROW, error: null }) {
-    const single = jest.fn().mockResolvedValue(result)
-    const select = jest.fn().mockReturnValue({ single })
-    const insert = jest.fn().mockReturnValue({ select })
-    const from = jest.fn().mockReturnValue({ insert })
-    return { from, auth: { getUser: authedGetUser() } }
+describe("sendRequest", () => {
+  function makeSendMock(
+    result: { data: typeof MOCK_ROW | null; error: unknown } = { data: MOCK_ROW, error: null },
+  ) {
+    const single = jest.fn().mockResolvedValue(result);
+    const select = jest.fn().mockReturnValue({ single });
+    const insert = jest.fn().mockReturnValue({ select });
+    const from = jest.fn().mockReturnValue({ insert });
+    return { from, auth: { getUser: authedGetUser() } };
   }
 
-  it('inserts with correct fields', async () => {
-    const mock = makeSendMock()
-    await sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })
+  it("inserts with correct fields", async () => {
+    const mock = makeSendMock();
+    await sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID });
 
-    expect(mock.from).toHaveBeenCalledWith('friendships')
-    const fromInstance = mock.from.mock.results[0].value
+    expect(mock.from).toHaveBeenCalledWith("friendships");
+    const fromInstance = mock.from.mock.results[0].value;
     expect(fromInstance.insert).toHaveBeenCalledWith({
       requester_id: MOCK_USER_ID,
       addressee_id: MOCK_ADDRESSEE_ID,
-      status: 'pending',
-    })
-  })
+      status: "pending",
+    });
+  });
 
-  it('returns the created friendship row', async () => {
-    const mock = makeSendMock()
-    const result = await sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })
-    expect(result).toEqual(MOCK_ROW)
-  })
+  it("returns the created friendship row", async () => {
+    const mock = makeSendMock();
+    const result = await sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID });
+    expect(result).toEqual(MOCK_ROW);
+  });
 
   it('throws "Friend request already exists" on unique violation (23505)', async () => {
-    const mock = makeSendMock({ data: null, error: { message: 'duplicate', code: '23505' } })
-    await expect(
-      sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })
-    ).rejects.toThrow('Friend request already exists')
-  })
+    const mock = makeSendMock({ data: null, error: { message: "duplicate", code: "23505" } });
+    await expect(sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })).rejects.toThrow(
+      "Friend request already exists",
+    );
+  });
 
-  it('throws Supabase message on other errors', async () => {
-    const mock = makeSendMock({ data: null, error: { message: 'insert failed' } })
-    await expect(
-      sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })
-    ).rejects.toThrow('insert failed')
-  })
+  it("throws Supabase message on other errors", async () => {
+    const mock = makeSendMock({ data: null, error: { message: "insert failed" } });
+    await expect(sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })).rejects.toThrow(
+      "insert failed",
+    );
+  });
 
-  it('throws when not authenticated', async () => {
-    const mock = makeSendMock()
-    mock.auth.getUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null })
-    await expect(
-      sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })
-    ).rejects.toThrow('Not authenticated')
-  })
-})
+  it("throws when not authenticated", async () => {
+    const mock = makeSendMock();
+    mock.auth.getUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null });
+    await expect(sendRequest(asClient(mock), { addresseeId: MOCK_ADDRESSEE_ID })).rejects.toThrow(
+      "Not authenticated",
+    );
+  });
+});
 
 // ---------- cancelRequest ----------
 
-describe('cancelRequest', () => {
+describe("cancelRequest", () => {
   function makeDeleteMock(result = { count: 1, error: null }) {
-    const eq = jest.fn().mockResolvedValue(result)
-    const del = jest.fn().mockReturnValue({ eq })
-    const from = jest.fn().mockReturnValue({ delete: del })
-    return { from, auth: { getUser: authedGetUser() } }
+    const eq = jest.fn().mockResolvedValue(result);
+    const del = jest.fn().mockReturnValue({ eq });
+    const from = jest.fn().mockReturnValue({ delete: del });
+    return { from, auth: { getUser: authedGetUser() } };
   }
 
-  it('deletes by friendshipId', async () => {
-    const mock = makeDeleteMock()
-    await cancelRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+  it("deletes by friendshipId", async () => {
+    const mock = makeDeleteMock();
+    await cancelRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID });
 
-    expect(mock.from).toHaveBeenCalledWith('friendships')
-    const del = mock.from.mock.results[0].value.delete
-    expect(del).toHaveBeenCalledWith({ count: 'exact' })
-    const eq = del.mock.results[0].value.eq
-    expect(eq).toHaveBeenCalledWith('id', MOCK_FRIENDSHIP_ID)
-  })
+    expect(mock.from).toHaveBeenCalledWith("friendships");
+    const del = mock.from.mock.results[0].value.delete;
+    expect(del).toHaveBeenCalledWith({ count: "exact" });
+    const eq = del.mock.results[0].value.eq;
+    expect(eq).toHaveBeenCalledWith("id", MOCK_FRIENDSHIP_ID);
+  });
 
   it('throws "Request not found" when 0 rows deleted', async () => {
-    const mock = makeDeleteMock({ count: 0, error: null })
+    const mock = makeDeleteMock({ count: 0, error: null });
     await expect(
-      cancelRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
-    ).rejects.toThrow('Request not found or already cancelled')
-  })
+      cancelRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID }),
+    ).rejects.toThrow("Request not found or already cancelled");
+  });
 
-  it('throws Supabase error message on DB error', async () => {
-    const mock = makeDeleteMock({ count: null as never, error: { message: 'delete failed' } as never })
+  it("throws Supabase error message on DB error", async () => {
+    const mock = makeDeleteMock({
+      count: null as never,
+      error: { message: "delete failed" } as never,
+    });
     await expect(
-      cancelRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
-    ).rejects.toThrow('delete failed')
-  })
+      cancelRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID }),
+    ).rejects.toThrow("delete failed");
+  });
 
-  it('throws when not authenticated', async () => {
-    const mock = makeDeleteMock()
-    mock.auth.getUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null })
+  it("throws when not authenticated", async () => {
+    const mock = makeDeleteMock();
+    mock.auth.getUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null });
     await expect(
-      cancelRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
-    ).rejects.toThrow('Not authenticated')
-  })
-})
+      cancelRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID }),
+    ).rejects.toThrow("Not authenticated");
+  });
+});
 
 // ---------- acceptRequest ----------
 
-describe('acceptRequest', () => {
+describe("acceptRequest", () => {
   function makeUpdateMock(result = { count: 1, error: null }) {
-    const eq = jest.fn().mockResolvedValue(result)
-    const update = jest.fn().mockReturnValue({ eq })
-    const from = jest.fn().mockReturnValue({ update })
-    return { from, auth: { getUser: authedGetUser() } }
+    const eq = jest.fn().mockResolvedValue(result);
+    const update = jest.fn().mockReturnValue({ eq });
+    const from = jest.fn().mockReturnValue({ update });
+    return { from, auth: { getUser: authedGetUser() } };
   }
 
-  it('updates status to accepted by friendshipId with count check', async () => {
-    const mock = makeUpdateMock()
-    await acceptRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+  it("updates status to accepted by friendshipId with count check", async () => {
+    const mock = makeUpdateMock();
+    await acceptRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID });
 
-    const upd = mock.from.mock.results[0].value.update
-    expect(upd).toHaveBeenCalledWith({ status: 'accepted' }, { count: 'exact' })
-    const eq = upd.mock.results[0].value.eq
-    expect(eq).toHaveBeenCalledWith('id', MOCK_FRIENDSHIP_ID)
-  })
+    const upd = mock.from.mock.results[0].value.update;
+    expect(upd).toHaveBeenCalledWith({ status: "accepted" }, { count: "exact" });
+    const eq = upd.mock.results[0].value.eq;
+    expect(eq).toHaveBeenCalledWith("id", MOCK_FRIENDSHIP_ID);
+  });
 
   it('throws "Request not found or already handled" when 0 rows updated', async () => {
-    const mock = makeUpdateMock({ count: 0, error: null })
+    const mock = makeUpdateMock({ count: 0, error: null });
     await expect(
-      acceptRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
-    ).rejects.toThrow('Request not found or already handled')
-  })
+      acceptRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID }),
+    ).rejects.toThrow("Request not found or already handled");
+  });
 
-  it('throws Supabase error message on failure', async () => {
-    const mock = makeUpdateMock({ count: null as never, error: { message: 'update failed' } as never })
+  it("throws Supabase error message on failure", async () => {
+    const mock = makeUpdateMock({
+      count: null as never,
+      error: { message: "update failed" } as never,
+    });
     await expect(
-      acceptRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
-    ).rejects.toThrow('update failed')
-  })
+      acceptRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID }),
+    ).rejects.toThrow("update failed");
+  });
 
-  it('throws when not authenticated', async () => {
-    const mock = makeUpdateMock()
-    mock.auth.getUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null })
+  it("throws when not authenticated", async () => {
+    const mock = makeUpdateMock();
+    mock.auth.getUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null });
     await expect(
-      acceptRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
-    ).rejects.toThrow('Not authenticated')
-  })
-})
+      acceptRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID }),
+    ).rejects.toThrow("Not authenticated");
+  });
+});
 
 // ---------- declineRequest ----------
 
-describe('declineRequest', () => {
+describe("declineRequest", () => {
   function makeDeleteMock(result = { count: 1, error: null }) {
-    const eq = jest.fn().mockResolvedValue(result)
-    const del = jest.fn().mockReturnValue({ eq })
-    const from = jest.fn().mockReturnValue({ delete: del })
-    return { from, auth: { getUser: authedGetUser() } }
+    const eq = jest.fn().mockResolvedValue(result);
+    const del = jest.fn().mockReturnValue({ eq });
+    const from = jest.fn().mockReturnValue({ delete: del });
+    return { from, auth: { getUser: authedGetUser() } };
   }
 
-  it('deletes by friendshipId', async () => {
-    const mock = makeDeleteMock()
-    await declineRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+  it("deletes by friendshipId", async () => {
+    const mock = makeDeleteMock();
+    await declineRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID });
 
-    const del = mock.from.mock.results[0].value.delete
-    expect(del).toHaveBeenCalledWith({ count: 'exact' })
-  })
+    const del = mock.from.mock.results[0].value.delete;
+    expect(del).toHaveBeenCalledWith({ count: "exact" });
+  });
 
   it('throws "Request not found" when 0 rows deleted', async () => {
-    const mock = makeDeleteMock({ count: 0, error: null })
+    const mock = makeDeleteMock({ count: 0, error: null });
     await expect(
-      declineRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
-    ).rejects.toThrow('Request not found or already declined')
-  })
+      declineRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID }),
+    ).rejects.toThrow("Request not found or already declined");
+  });
 
-  it('throws when not authenticated', async () => {
-    const mock = makeDeleteMock()
-    mock.auth.getUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null })
+  it("throws when not authenticated", async () => {
+    const mock = makeDeleteMock();
+    mock.auth.getUser = jest.fn().mockResolvedValue({ data: { user: null }, error: null });
     await expect(
-      declineRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
-    ).rejects.toThrow('Not authenticated')
-  })
-})
+      declineRequest(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID }),
+    ).rejects.toThrow("Not authenticated");
+  });
+});
 
 // ---------- unfriend ----------
 
-describe('unfriend', () => {
+describe("unfriend", () => {
   function makeDeleteMock(result = { count: 1, error: null }) {
-    const eq = jest.fn().mockResolvedValue(result)
-    const del = jest.fn().mockReturnValue({ eq })
-    const from = jest.fn().mockReturnValue({ delete: del })
-    return { from, auth: { getUser: authedGetUser() } }
+    const eq = jest.fn().mockResolvedValue(result);
+    const del = jest.fn().mockReturnValue({ eq });
+    const from = jest.fn().mockReturnValue({ delete: del });
+    return { from, auth: { getUser: authedGetUser() } };
   }
 
-  it('deletes by friendshipId', async () => {
-    const mock = makeDeleteMock()
-    await unfriend(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
+  it("deletes by friendshipId", async () => {
+    const mock = makeDeleteMock();
+    await unfriend(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID });
 
-    expect(mock.from).toHaveBeenCalledWith('friendships')
-    const del = mock.from.mock.results[0].value.delete
-    const eq = del.mock.results[0].value.eq
-    expect(eq).toHaveBeenCalledWith('id', MOCK_FRIENDSHIP_ID)
-  })
+    expect(mock.from).toHaveBeenCalledWith("friendships");
+    const del = mock.from.mock.results[0].value.delete;
+    const eq = del.mock.results[0].value.eq;
+    expect(eq).toHaveBeenCalledWith("id", MOCK_FRIENDSHIP_ID);
+  });
 
   it('throws "Friendship not found" when 0 rows deleted', async () => {
-    const mock = makeDeleteMock({ count: 0, error: null })
-    await expect(
-      unfriend(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
-    ).rejects.toThrow('Friendship not found')
-  })
+    const mock = makeDeleteMock({ count: 0, error: null });
+    await expect(unfriend(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })).rejects.toThrow(
+      "Friendship not found",
+    );
+  });
 
-  it('throws Supabase error message on DB error', async () => {
-    const mock = makeDeleteMock({ count: null as never, error: { message: 'delete failed' } as never })
-    await expect(
-      unfriend(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })
-    ).rejects.toThrow('delete failed')
-  })
-})
+  it("throws Supabase error message on DB error", async () => {
+    const mock = makeDeleteMock({
+      count: null as never,
+      error: { message: "delete failed" } as never,
+    });
+    await expect(unfriend(asClient(mock), { friendshipId: MOCK_FRIENDSHIP_ID })).rejects.toThrow(
+      "delete failed",
+    );
+  });
+});

--- a/lib/__tests__/poiCategories.test.ts
+++ b/lib/__tests__/poiCategories.test.ts
@@ -1,132 +1,129 @@
-import {
-  POI_CATEGORIES,
-  CATEGORY_LABELS,
-  PoiCategory,
-  isPoiCategory,
-} from '../poiCategories'
+import { POI_CATEGORIES, CATEGORY_LABELS, PoiCategory, isPoiCategory } from "../poiCategories";
 
-describe('POI_CATEGORIES', () => {
-  it('contains exactly 5 categories', () => {
-    expect(POI_CATEGORIES).toHaveLength(5)
-  })
+describe("POI_CATEGORIES", () => {
+  it("contains exactly 5 categories", () => {
+    expect(POI_CATEGORIES).toHaveLength(5);
+  });
 
-  it('has no duplicates', () => {
-    const unique = new Set(POI_CATEGORIES)
-    expect(unique.size).toBe(POI_CATEGORIES.length)
-  })
+  it("has no duplicates", () => {
+    const unique = new Set(POI_CATEGORIES);
+    expect(unique.size).toBe(POI_CATEGORIES.length);
+  });
 
-  it('contains the expected category slugs', () => {
+  it("contains the expected category slugs", () => {
     expect(POI_CATEGORIES).toEqual([
-      'food_drink',
-      'nightlife',
-      'culture',
-      'study_spots',
-      'hidden_gems',
-    ])
-  })
-})
+      "food_drink",
+      "nightlife",
+      "culture",
+      "study_spots",
+      "hidden_gems",
+    ]);
+  });
+});
 
-describe('CATEGORY_LABELS', () => {
-  it('has a label for every category in POI_CATEGORIES', () => {
+describe("CATEGORY_LABELS", () => {
+  it("has a label for every category in POI_CATEGORIES", () => {
     for (const category of POI_CATEGORIES) {
-      expect(CATEGORY_LABELS).toHaveProperty(category)
-      expect(typeof CATEGORY_LABELS[category]).toBe('string')
-      expect(CATEGORY_LABELS[category].length).toBeGreaterThan(0)
+      expect(CATEGORY_LABELS).toHaveProperty(category);
+      expect(typeof CATEGORY_LABELS[category]).toBe("string");
+      expect(CATEGORY_LABELS[category].length).toBeGreaterThan(0);
     }
-  })
+  });
 
-  it('has no extra keys beyond POI_CATEGORIES', () => {
-    expect(Object.keys(CATEGORY_LABELS)).toHaveLength(POI_CATEGORIES.length)
-  })
-})
+  it("has no extra keys beyond POI_CATEGORIES", () => {
+    expect(Object.keys(CATEGORY_LABELS)).toHaveLength(POI_CATEGORIES.length);
+  });
+});
 
 // Minimal POI shape needed for filter tests
-type FilterPoi = { category: PoiCategory }
+type FilterPoi = { category: PoiCategory };
 
 function filterByActiveCategories(
   pois: FilterPoi[],
-  active: Record<PoiCategory, boolean>
+  active: Record<PoiCategory, boolean>,
 ): FilterPoi[] {
-  return pois.filter((p) => active[p.category])
+  return pois.filter((p) => active[p.category]);
 }
 
-const ALL_ACTIVE = Object.fromEntries(
-  POI_CATEGORIES.map((c) => [c, true])
-) as Record<PoiCategory, boolean>
+const ALL_ACTIVE = Object.fromEntries(POI_CATEGORIES.map((c) => [c, true])) as Record<
+  PoiCategory,
+  boolean
+>;
 
-describe('category filter logic', () => {
+describe("category filter logic", () => {
   const samplePois: FilterPoi[] = [
-    { category: 'food_drink' },
-    { category: 'food_drink' },
-    { category: 'nightlife' },
-    { category: 'culture' },
-    { category: 'study_spots' },
-    { category: 'hidden_gems' },
-  ]
+    { category: "food_drink" },
+    { category: "food_drink" },
+    { category: "nightlife" },
+    { category: "culture" },
+    { category: "study_spots" },
+    { category: "hidden_gems" },
+  ];
 
-  it('returns all POIs when all categories are active', () => {
-    expect(filterByActiveCategories(samplePois, ALL_ACTIVE)).toHaveLength(6)
-  })
+  it("returns all POIs when all categories are active", () => {
+    expect(filterByActiveCategories(samplePois, ALL_ACTIVE)).toHaveLength(6);
+  });
 
-  it('returns an empty array when the input is empty', () => {
-    expect(filterByActiveCategories([], ALL_ACTIVE)).toHaveLength(0)
-  })
+  it("returns an empty array when the input is empty", () => {
+    expect(filterByActiveCategories([], ALL_ACTIVE)).toHaveLength(0);
+  });
 
-  it('returns no POIs when all categories are inactive', () => {
-    const noneActive = Object.fromEntries(
-      POI_CATEGORIES.map((c) => [c, false])
-    ) as Record<PoiCategory, boolean>
-    expect(filterByActiveCategories(samplePois, noneActive)).toHaveLength(0)
-  })
+  it("returns no POIs when all categories are inactive", () => {
+    const noneActive = Object.fromEntries(POI_CATEGORIES.map((c) => [c, false])) as Record<
+      PoiCategory,
+      boolean
+    >;
+    expect(filterByActiveCategories(samplePois, noneActive)).toHaveLength(0);
+  });
 
-  it('excludes all POIs for a toggled-off category, including duplicates', () => {
-    const filter = { ...ALL_ACTIVE, food_drink: false }
-    const result = filterByActiveCategories(samplePois, filter)
-    expect(result).toHaveLength(4)
-    expect(result.every((p) => p.category !== 'food_drink')).toBe(true)
-  })
+  it("excludes all POIs for a toggled-off category, including duplicates", () => {
+    const filter = { ...ALL_ACTIVE, food_drink: false };
+    const result = filterByActiveCategories(samplePois, filter);
+    expect(result).toHaveLength(4);
+    expect(result.every((p) => p.category !== "food_drink")).toBe(true);
+  });
 
-  it('restores all POIs when a category is toggled back on', () => {
-    const withoutFood = { ...ALL_ACTIVE, food_drink: false }
-    const withFood = { ...withoutFood, food_drink: true }
-    expect(filterByActiveCategories(samplePois, withoutFood)).toHaveLength(4)
-    expect(filterByActiveCategories(samplePois, withFood)).toHaveLength(6)
-  })
+  it("restores all POIs when a category is toggled back on", () => {
+    const withoutFood = { ...ALL_ACTIVE, food_drink: false };
+    const withFood = { ...withoutFood, food_drink: true };
+    expect(filterByActiveCategories(samplePois, withoutFood)).toHaveLength(4);
+    expect(filterByActiveCategories(samplePois, withFood)).toHaveLength(6);
+  });
 
-  it('can filter to a single category', () => {
+  it("can filter to a single category", () => {
     const onlyFood = Object.fromEntries(
-      POI_CATEGORIES.map((c) => [c, c === 'food_drink'])
-    ) as Record<PoiCategory, boolean>
-    const result = filterByActiveCategories(samplePois, onlyFood)
-    expect(result).toHaveLength(2)
-    expect(result.every((p) => p.category === 'food_drink')).toBe(true)
-  })
-})
+      POI_CATEGORIES.map((c) => [c, c === "food_drink"]),
+    ) as Record<PoiCategory, boolean>;
+    const result = filterByActiveCategories(samplePois, onlyFood);
+    expect(result).toHaveLength(2);
+    expect(result.every((p) => p.category === "food_drink")).toBe(true);
+  });
+});
 
-describe('isPoiCategory', () => {
-  it('returns true for every valid category', () => {
+describe("isPoiCategory", () => {
+  it("returns true for every valid category", () => {
     for (const category of POI_CATEGORIES) {
-      expect(isPoiCategory(category)).toBe(true)
+      expect(isPoiCategory(category)).toBe(true);
     }
-  })
+  });
 
-  it('returns false for an arbitrary string', () => {
-    expect(isPoiCategory('restaurants')).toBe(false)
-  })
+  it("returns false for an arbitrary string", () => {
+    expect(isPoiCategory("restaurants")).toBe(false);
+  });
 
-  it('returns false for an empty string', () => {
-    expect(isPoiCategory('')).toBe(false)
-  })
+  it("returns false for an empty string", () => {
+    expect(isPoiCategory("")).toBe(false);
+  });
 
-  it('returns false for null', () => {
-    expect(isPoiCategory(null)).toBe(false)
-  })
+  it("returns false for null", () => {
+    expect(isPoiCategory(null)).toBe(false);
+  });
 
-  it('returns false for undefined', () => {
-    expect(isPoiCategory(undefined)).toBe(false)
-  })
+  it("returns false for undefined", () => {
+    expect(isPoiCategory(undefined)).toBe(false);
+  });
 
-  it('returns false for a number', () => {
-    expect(isPoiCategory(42)).toBe(false)
-  })
-})
+  it("returns false for a number", () => {
+    expect(isPoiCategory(42)).toBe(false);
+  });
+});

--- a/lib/__tests__/presence.test.ts
+++ b/lib/__tests__/presence.test.ts
@@ -1,197 +1,198 @@
-import { broadcastPresence, dismissPresence } from '../presence'
-import { SupabaseClient } from '@supabase/supabase-js'
-import { Database } from '../../types/supabase'
+import { broadcastPresence, dismissPresence } from "../presence";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "../../types/supabase";
 
-const MOCK_USER_ID = 'user-123'
-const MOCK_POI_ID = 'poi-456'
-const MOCK_PRESENCE_ID = 'presence-789'
+const MOCK_USER_ID = "user-123";
+const MOCK_POI_ID = "poi-456";
+const MOCK_PRESENCE_ID = "presence-789";
 
 const MOCK_PRESENCE_ROW = {
   id: MOCK_PRESENCE_ID,
   poi_id: MOCK_POI_ID,
-  message: 'grabbing coffee',
-  visible_to: 'friends' as const,
-}
+  message: "grabbing coffee",
+  visible_to: "friends" as const,
+};
 
 type MockSupabase = {
-  from: jest.Mock
-  auth: { getUser: jest.Mock }
-}
+  from: jest.Mock;
+  auth: { getUser: jest.Mock };
+};
 
 function makeMockSupabase({
   updateResult = { error: null },
   insertResult = { data: MOCK_PRESENCE_ROW, error: null },
 }: {
-  updateResult?: { error: { message: string } | null }
-  insertResult?: { data: typeof MOCK_PRESENCE_ROW | null; error: { message: string } | null }
+  updateResult?: { error: { message: string } | null };
+  insertResult?: { data: typeof MOCK_PRESENCE_ROW | null; error: { message: string } | null };
 } = {}): MockSupabase {
-  const single = jest.fn().mockResolvedValue(insertResult)
-  const select = jest.fn().mockReturnValue({ single })
-  const insert = jest.fn().mockReturnValue({ select })
+  const single = jest.fn().mockResolvedValue(insertResult);
+  const select = jest.fn().mockReturnValue({ single });
+  const insert = jest.fn().mockReturnValue({ select });
 
-  const is = jest.fn().mockResolvedValue(updateResult)
-  const eqUser = jest.fn().mockReturnValue({ is })
-  const eqId = jest.fn().mockReturnValue({ eq: eqUser, is: jest.fn().mockResolvedValue(updateResult) })
-  const update = jest.fn().mockReturnValue({ eq: eqId })
+  const is = jest.fn().mockResolvedValue(updateResult);
+  const eqUser = jest.fn().mockReturnValue({ is });
+  const eqId = jest
+    .fn()
+    .mockReturnValue({ eq: eqUser, is: jest.fn().mockResolvedValue(updateResult) });
+  const update = jest.fn().mockReturnValue({ eq: eqId });
 
-  const from = jest.fn().mockReturnValue({ update, insert })
+  const from = jest.fn().mockReturnValue({ update, insert });
   const getUser = jest.fn().mockResolvedValue({
     data: { user: { id: MOCK_USER_ID } },
     error: null,
-  })
+  });
 
-  return { from, auth: { getUser } }
+  return { from, auth: { getUser } };
 }
 
 function asClient(mock: MockSupabase): SupabaseClient<Database> {
-  return mock as unknown as SupabaseClient<Database>
+  return mock as unknown as SupabaseClient<Database>;
 }
 
-describe('broadcastPresence', () => {
-  const baseArgs = { poiId: MOCK_POI_ID, message: 'grabbing coffee', visibleTo: 'friends' as const }
+describe("broadcastPresence", () => {
+  const baseArgs = {
+    poiId: MOCK_POI_ID,
+    message: "grabbing coffee",
+    visibleTo: "friends" as const,
+  };
 
-  it('inserts the correct fields', async () => {
-    const mock = makeMockSupabase()
-    await broadcastPresence(asClient(mock), baseArgs)
+  it("inserts the correct fields", async () => {
+    const mock = makeMockSupabase();
+    await broadcastPresence(asClient(mock), baseArgs);
 
-    expect(mock.from).toHaveBeenCalledWith('live_presence')
-    const fromInstance = mock.from.mock.results[mock.from.mock.calls.findIndex(
-      (c: string[]) => c[0] === 'live_presence'
-    )].value
+    expect(mock.from).toHaveBeenCalledWith("live_presence");
+    const fromInstance =
+      mock.from.mock.results[
+        mock.from.mock.calls.findIndex((c: string[]) => c[0] === "live_presence")
+      ].value;
     expect(fromInstance.insert).toHaveBeenCalledWith({
       poi_id: MOCK_POI_ID,
       user_id: MOCK_USER_ID,
-      message: 'grabbing coffee',
-      visible_to: 'friends',
-    })
-  })
+      message: "grabbing coffee",
+      visible_to: "friends",
+    });
+  });
 
   // Fix 2: assert that update was called with the correct dismissed_at payload
-  it('calls update to auto-dismiss previous broadcast before insert', async () => {
-    const mock = makeMockSupabase()
-    await broadcastPresence(asClient(mock), baseArgs)
+  it("calls update to auto-dismiss previous broadcast before insert", async () => {
+    const mock = makeMockSupabase();
+    await broadcastPresence(asClient(mock), baseArgs);
 
     // update is called on live_presence to dismiss old broadcast
-    expect(mock.from).toHaveBeenCalledWith('live_presence')
-    const fromCalls = mock.from.mock.results
-    const hasUpdate = fromCalls.some((r) => r.value?.update)
-    expect(hasUpdate).toBe(true)
+    expect(mock.from).toHaveBeenCalledWith("live_presence");
+    const fromCalls = mock.from.mock.results;
+    const hasUpdate = fromCalls.some((r) => r.value?.update);
+    expect(hasUpdate).toBe(true);
 
     // Assert update was called with a dismissed_at ISO string
-    const fromInstance = mock.from.mock.results[0].value
-    expect(fromInstance.update).toHaveBeenCalledWith({ dismissed_at: expect.any(String) })
-  })
+    const fromInstance = mock.from.mock.results[0].value;
+    expect(fromInstance.update).toHaveBeenCalledWith({ dismissed_at: expect.any(String) });
+  });
 
-  it('passes null message when message is an empty string', async () => {
-    const mock = makeMockSupabase()
-    await broadcastPresence(asClient(mock), { poiId: MOCK_POI_ID, message: '' })
+  it("passes null message when message is an empty string", async () => {
+    const mock = makeMockSupabase();
+    await broadcastPresence(asClient(mock), { poiId: MOCK_POI_ID, message: "" });
 
-    const fromInstance = mock.from.mock.results[mock.from.mock.calls.findIndex(
-      (c: string[]) => c[0] === 'live_presence'
-    )].value
-    expect(fromInstance.insert).toHaveBeenCalledWith(
-      expect.objectContaining({ message: null })
-    )
-  })
+    const fromInstance =
+      mock.from.mock.results[
+        mock.from.mock.calls.findIndex((c: string[]) => c[0] === "live_presence")
+      ].value;
+    expect(fromInstance.insert).toHaveBeenCalledWith(expect.objectContaining({ message: null }));
+  });
 
-  it('passes null message when message is only whitespace', async () => {
-    const mock = makeMockSupabase()
-    await broadcastPresence(asClient(mock), { poiId: MOCK_POI_ID, message: '   ' })
+  it("passes null message when message is only whitespace", async () => {
+    const mock = makeMockSupabase();
+    await broadcastPresence(asClient(mock), { poiId: MOCK_POI_ID, message: "   " });
 
-    const fromInstance = mock.from.mock.results[mock.from.mock.calls.findIndex(
-      (c: string[]) => c[0] === 'live_presence'
-    )].value
-    expect(fromInstance.insert).toHaveBeenCalledWith(
-      expect.objectContaining({ message: null })
-    )
-  })
+    const fromInstance =
+      mock.from.mock.results[
+        mock.from.mock.calls.findIndex((c: string[]) => c[0] === "live_presence")
+      ].value;
+    expect(fromInstance.insert).toHaveBeenCalledWith(expect.objectContaining({ message: null }));
+  });
 
-  it('passes null message when message is omitted', async () => {
-    const mock = makeMockSupabase()
-    await broadcastPresence(asClient(mock), { poiId: MOCK_POI_ID })
+  it("passes null message when message is omitted", async () => {
+    const mock = makeMockSupabase();
+    await broadcastPresence(asClient(mock), { poiId: MOCK_POI_ID });
 
-    const fromInstance = mock.from.mock.results[mock.from.mock.calls.findIndex(
-      (c: string[]) => c[0] === 'live_presence'
-    )].value
-    expect(fromInstance.insert).toHaveBeenCalledWith(
-      expect.objectContaining({ message: null })
-    )
-  })
+    const fromInstance =
+      mock.from.mock.results[
+        mock.from.mock.calls.findIndex((c: string[]) => c[0] === "live_presence")
+      ].value;
+    expect(fromInstance.insert).toHaveBeenCalledWith(expect.objectContaining({ message: null }));
+  });
 
   it("defaults visible_to to 'friends' when omitted", async () => {
-    const mock = makeMockSupabase()
-    await broadcastPresence(asClient(mock), { poiId: MOCK_POI_ID })
+    const mock = makeMockSupabase();
+    await broadcastPresence(asClient(mock), { poiId: MOCK_POI_ID });
 
-    const fromInstance = mock.from.mock.results[mock.from.mock.calls.findIndex(
-      (c: string[]) => c[0] === 'live_presence'
-    )].value
+    const fromInstance =
+      mock.from.mock.results[
+        mock.from.mock.calls.findIndex((c: string[]) => c[0] === "live_presence")
+      ].value;
     expect(fromInstance.insert).toHaveBeenCalledWith(
-      expect.objectContaining({ visible_to: 'friends' })
-    )
-  })
+      expect.objectContaining({ visible_to: "friends" }),
+    );
+  });
 
-  it('throws when message exceeds 140 characters', async () => {
-    const mock = makeMockSupabase()
-    const longMessage = 'a'.repeat(141)
+  it("throws when message exceeds 140 characters", async () => {
+    const mock = makeMockSupabase();
+    const longMessage = "a".repeat(141);
     await expect(
-      broadcastPresence(asClient(mock), { poiId: MOCK_POI_ID, message: longMessage })
-    ).rejects.toThrow('Message must be 140 characters or less')
-    expect(mock.from).not.toHaveBeenCalled()
-  })
+      broadcastPresence(asClient(mock), { poiId: MOCK_POI_ID, message: longMessage }),
+    ).rejects.toThrow("Message must be 140 characters or less");
+    expect(mock.from).not.toHaveBeenCalled();
+  });
 
-  it('throws when user is not authenticated', async () => {
-    const mock = makeMockSupabase()
-    mock.auth.getUser.mockResolvedValue({ data: { user: null }, error: null })
-    await expect(
-      broadcastPresence(asClient(mock), baseArgs)
-    ).rejects.toThrow('Not authenticated')
-  })
+  it("throws when user is not authenticated", async () => {
+    const mock = makeMockSupabase();
+    mock.auth.getUser.mockResolvedValue({ data: { user: null }, error: null });
+    await expect(broadcastPresence(asClient(mock), baseArgs)).rejects.toThrow("Not authenticated");
+  });
 
-  it('throws with Supabase error message when insert fails', async () => {
+  it("throws with Supabase error message when insert fails", async () => {
     const mock = makeMockSupabase({
-      insertResult: { data: null, error: { message: 'insert failed' } },
-    })
-    await expect(
-      broadcastPresence(asClient(mock), baseArgs)
-    ).rejects.toThrow('insert failed')
-  })
-})
+      insertResult: { data: null, error: { message: "insert failed" } },
+    });
+    await expect(broadcastPresence(asClient(mock), baseArgs)).rejects.toThrow("insert failed");
+  });
+});
 
-describe('dismissPresence', () => {
-  it('throws when user is not authenticated', async () => {
-    const mock = makeMockSupabase()
-    mock.auth.getUser.mockResolvedValue({ data: { user: null }, error: null })
-    await expect(
-      dismissPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
-    ).rejects.toThrow('Not authenticated')
-  })
+describe("dismissPresence", () => {
+  it("throws when user is not authenticated", async () => {
+    const mock = makeMockSupabase();
+    mock.auth.getUser.mockResolvedValue({ data: { user: null }, error: null });
+    await expect(dismissPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })).rejects.toThrow(
+      "Not authenticated",
+    );
+  });
 
-  it('throws with Supabase error message when update fails', async () => {
+  it("throws with Supabase error message when update fails", async () => {
     const mock = makeMockSupabase({
-      updateResult: { error: { message: 'update failed' } },
-    })
-    await expect(
-      dismissPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
-    ).rejects.toThrow('update failed')
-  })
+      updateResult: { error: { message: "update failed" } },
+    });
+    await expect(dismissPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })).rejects.toThrow(
+      "update failed",
+    );
+  });
 
   // Fix 7: verify that eq is called with the correct presenceId and user_id filter args
-  it('calls update with correct presenceId and user_id', async () => {
-    const mock = makeMockSupabase()
-    await dismissPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
+  it("calls update with correct presenceId and user_id", async () => {
+    const mock = makeMockSupabase();
+    await dismissPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID });
 
     // Chain: .from('live_presence').update({dismissed_at:…}).eq('id', presenceId).eq('user_id', userId).is('dismissed_at', null)
-    const fromInstance = mock.from.mock.results[0].value
+    const fromInstance = mock.from.mock.results[0].value;
 
     // update should have been called with a dismissed_at string
-    expect(fromInstance.update).toHaveBeenCalledWith({ dismissed_at: expect.any(String) })
+    expect(fromInstance.update).toHaveBeenCalledWith({ dismissed_at: expect.any(String) });
 
     // First .eq call is .eq('id', presenceId)
-    const updateResult = fromInstance.update.mock.results[0].value
-    expect(updateResult.eq).toHaveBeenCalledWith('id', MOCK_PRESENCE_ID)
+    const updateResult = fromInstance.update.mock.results[0].value;
+    expect(updateResult.eq).toHaveBeenCalledWith("id", MOCK_PRESENCE_ID);
 
     // Second .eq call is .eq('user_id', userId) — called on the result of the first eq
-    const firstEqResult = updateResult.eq.mock.results[0].value
-    expect(firstEqResult.eq).toHaveBeenCalledWith('user_id', MOCK_USER_ID)
-  })
-})
+    const firstEqResult = updateResult.eq.mock.results[0].value;
+    expect(firstEqResult.eq).toHaveBeenCalledWith("user_id", MOCK_USER_ID);
+  });
+});

--- a/lib/__tests__/presenceJoins.test.ts
+++ b/lib/__tests__/presenceJoins.test.ts
@@ -1,69 +1,72 @@
-import { joinPresence, cancelJoin, confirmJoins } from '../presenceJoins'
-import { SupabaseClient } from '@supabase/supabase-js'
-import { Database } from '../../types/supabase'
+import { joinPresence, cancelJoin, confirmJoins } from "../presenceJoins";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "../../types/supabase";
 
-const MOCK_USER_ID = 'user-123'
-const MOCK_PRESENCE_ID = 'presence-456'
-const MOCK_JOIN_ID = 'join-789'
+const MOCK_USER_ID = "user-123";
+const MOCK_PRESENCE_ID = "presence-456";
+const MOCK_JOIN_ID = "join-789";
 
 const MOCK_JOIN_ROW = {
   id: MOCK_JOIN_ID,
   presence_id: MOCK_PRESENCE_ID,
   joiner_user_id: MOCK_USER_ID,
-  joined_at: '2026-01-01T00:00:00Z',
+  joined_at: "2026-01-01T00:00:00Z",
   confirmed: false,
-}
+};
 
 type MockSupabase = {
-  from: jest.Mock
-  auth: { getUser: jest.Mock }
-}
+  from: jest.Mock;
+  auth: { getUser: jest.Mock };
+};
 
 function makeJoinMock({
   insertResult = { data: MOCK_JOIN_ROW, error: null },
 }: {
-  insertResult?: { data: typeof MOCK_JOIN_ROW | null; error: { message: string; code?: string } | null }
+  insertResult?: {
+    data: typeof MOCK_JOIN_ROW | null;
+    error: { message: string; code?: string } | null;
+  };
 } = {}): MockSupabase {
-  const single = jest.fn().mockResolvedValue(insertResult)
-  const select = jest.fn().mockReturnValue({ single })
-  const insert = jest.fn().mockReturnValue({ select })
-  const from = jest.fn().mockReturnValue({ insert })
+  const single = jest.fn().mockResolvedValue(insertResult);
+  const select = jest.fn().mockReturnValue({ single });
+  const insert = jest.fn().mockReturnValue({ select });
+  const from = jest.fn().mockReturnValue({ insert });
   const getUser = jest.fn().mockResolvedValue({
     data: { user: { id: MOCK_USER_ID } },
     error: null,
-  })
-  return { from, auth: { getUser } }
+  });
+  return { from, auth: { getUser } };
 }
 
 function makeCancelMock({
   deleteResult = { count: 1, error: null },
 }: {
-  deleteResult?: { count: number | null; error: { message: string } | null }
+  deleteResult?: { count: number | null; error: { message: string } | null };
 } = {}): MockSupabase {
-  const eqUser = jest.fn().mockResolvedValue(deleteResult)
-  const eqId = jest.fn().mockReturnValue({ eq: eqUser })
-  const del = jest.fn().mockReturnValue({ eq: eqId })
-  const from = jest.fn().mockReturnValue({ delete: del })
+  const eqUser = jest.fn().mockResolvedValue(deleteResult);
+  const eqId = jest.fn().mockReturnValue({ eq: eqUser });
+  const del = jest.fn().mockReturnValue({ eq: eqId });
+  const from = jest.fn().mockReturnValue({ delete: del });
   const getUser = jest.fn().mockResolvedValue({
     data: { user: { id: MOCK_USER_ID } },
     error: null,
-  })
-  return { from, auth: { getUser } }
+  });
+  return { from, auth: { getUser } };
 }
 
 function asClient(mock: MockSupabase): SupabaseClient<Database> {
-  return mock as unknown as SupabaseClient<Database>
+  return mock as unknown as SupabaseClient<Database>;
 }
 
-const MOCK_POI_ID = 'poi-001'
-const MOCK_PRESENCE_IDS = ['presence-1', 'presence-2']
+const MOCK_POI_ID = "poi-001";
+const MOCK_PRESENCE_IDS = ["presence-1", "presence-2"];
 
 type ConfirmMockOptions = {
-  authUser?: { id: string } | null
-  authError?: { message: string } | null
-  presencesResult?: { data: { id: string }[] | null; error: { message: string } | null }
-  updateResult?: { error: { message: string } | null }
-}
+  authUser?: { id: string } | null;
+  authError?: { message: string } | null;
+  presencesResult?: { data: { id: string }[] | null; error: { message: string } | null };
+  updateResult?: { error: { message: string } | null };
+};
 
 function makeConfirmMock({
   authUser = { id: MOCK_USER_ID },
@@ -71,229 +74,237 @@ function makeConfirmMock({
   presencesResult = { data: MOCK_PRESENCE_IDS.map((id) => ({ id })), error: null },
   updateResult = { error: null },
 }: ConfirmMockOptions = {}): MockSupabase {
-  const getUser = jest.fn().mockResolvedValue({ data: { user: authUser }, error: authError })
+  const getUser = jest.fn().mockResolvedValue({ data: { user: authUser }, error: authError });
 
   // Step 1 chain: from('live_presence').select('id').eq(...).is(...)
-  const isPresence = jest.fn().mockResolvedValue(presencesResult)
-  const eqPresence = jest.fn().mockReturnValue({ is: isPresence })
-  const selectPresence = jest.fn().mockReturnValue({ eq: eqPresence })
+  const isPresence = jest.fn().mockResolvedValue(presencesResult);
+  const eqPresence = jest.fn().mockReturnValue({ is: isPresence });
+  const selectPresence = jest.fn().mockReturnValue({ eq: eqPresence });
 
   // Step 2 chain: from('presence_joins').update({...}).eq(...).eq(...).in(...)
-  const inJoins = jest.fn().mockResolvedValue(updateResult)
-  const eqConfirmed = jest.fn().mockReturnValue({ in: inJoins })
-  const eqJoinerId = jest.fn().mockReturnValue({ eq: eqConfirmed })
-  const updateJoins = jest.fn().mockReturnValue({ eq: eqJoinerId })
+  const inJoins = jest.fn().mockResolvedValue(updateResult);
+  const eqConfirmed = jest.fn().mockReturnValue({ in: inJoins });
+  const eqJoinerId = jest.fn().mockReturnValue({ eq: eqConfirmed });
+  const updateJoins = jest.fn().mockReturnValue({ eq: eqJoinerId });
 
   const from = jest.fn().mockImplementation((table: string) => {
-    if (table === 'live_presence') return { select: selectPresence }
-    if (table === 'presence_joins') return { update: updateJoins }
-    return {}
-  })
+    if (table === "live_presence") return { select: selectPresence };
+    if (table === "presence_joins") return { update: updateJoins };
+    return {};
+  });
 
-  return { from, auth: { getUser } }
+  return { from, auth: { getUser } };
 }
 
-describe('joinPresence', () => {
-  it('inserts with correct fields', async () => {
-    const mock = makeJoinMock()
-    await joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
+describe("joinPresence", () => {
+  it("inserts with correct fields", async () => {
+    const mock = makeJoinMock();
+    await joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID });
 
-    expect(mock.from).toHaveBeenCalledWith('presence_joins')
-    const fromInstance = mock.from.mock.results[0].value
+    expect(mock.from).toHaveBeenCalledWith("presence_joins");
+    const fromInstance = mock.from.mock.results[0].value;
     expect(fromInstance.insert).toHaveBeenCalledWith({
       presence_id: MOCK_PRESENCE_ID,
       joiner_user_id: MOCK_USER_ID,
-    })
-  })
+    });
+  });
 
-  it('returns the created join row', async () => {
-    const mock = makeJoinMock()
-    const result = await joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
-    expect(result).toEqual(MOCK_JOIN_ROW)
-  })
+  it("returns the created join row", async () => {
+    const mock = makeJoinMock();
+    const result = await joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID });
+    expect(result).toEqual(MOCK_JOIN_ROW);
+  });
 
-  it('throws when user is not authenticated', async () => {
-    const mock = makeJoinMock()
-    mock.auth.getUser.mockResolvedValue({ data: { user: null }, error: null })
-    await expect(
-      joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
-    ).rejects.toThrow('Not authenticated')
-  })
+  it("throws when user is not authenticated", async () => {
+    const mock = makeJoinMock();
+    mock.auth.getUser.mockResolvedValue({ data: { user: null }, error: null });
+    await expect(joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })).rejects.toThrow(
+      "Not authenticated",
+    );
+  });
 
-  it('throws when getUser returns an auth error even with user present', async () => {
-    const mock = makeJoinMock()
+  it("throws when getUser returns an auth error even with user present", async () => {
+    const mock = makeJoinMock();
     mock.auth.getUser.mockResolvedValue({
       data: { user: { id: MOCK_USER_ID } },
-      error: { message: 'session expired' },
-    })
-    await expect(
-      joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
-    ).rejects.toThrow('Not authenticated')
-  })
+      error: { message: "session expired" },
+    });
+    await expect(joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })).rejects.toThrow(
+      "Not authenticated",
+    );
+  });
 
-  it('throws user-friendly message on unique constraint violation', async () => {
+  it("throws user-friendly message on unique constraint violation", async () => {
     const mock = makeJoinMock({
-      insertResult: { data: null, error: { message: 'duplicate key value', code: '23505' } },
-    })
-    await expect(
-      joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
-    ).rejects.toThrow('You have already joined this person.')
-  })
+      insertResult: { data: null, error: { message: "duplicate key value", code: "23505" } },
+    });
+    await expect(joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })).rejects.toThrow(
+      "You have already joined this person.",
+    );
+  });
 
-  it('throws with Supabase error message when insert fails with other error', async () => {
+  it("throws with Supabase error message when insert fails with other error", async () => {
     const mock = makeJoinMock({
-      insertResult: { data: null, error: { message: 'insert failed' } },
-    })
-    await expect(
-      joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
-    ).rejects.toThrow('insert failed')
-  })
+      insertResult: { data: null, error: { message: "insert failed" } },
+    });
+    await expect(joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })).rejects.toThrow(
+      "insert failed",
+    );
+  });
 
-  it('logs push notification stub', async () => {
-    const spy = jest.spyOn(console, 'log').mockImplementation(() => {})
-    const mock = makeJoinMock()
-    await joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID })
-    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Push stub'))
-    spy.mockRestore()
-  })
-})
+  it("logs push notification stub", async () => {
+    const spy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const mock = makeJoinMock();
+    await joinPresence(asClient(mock), { presenceId: MOCK_PRESENCE_ID });
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("Push stub"));
+    spy.mockRestore();
+  });
+});
 
-describe('cancelJoin', () => {
-  it('deletes with correct joinId and user filter', async () => {
-    const mock = makeCancelMock()
-    await cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })
+describe("cancelJoin", () => {
+  it("deletes with correct joinId and user filter", async () => {
+    const mock = makeCancelMock();
+    await cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID });
 
-    expect(mock.from).toHaveBeenCalledWith('presence_joins')
-    const fromInstance = mock.from.mock.results[0].value
-    expect(fromInstance.delete).toHaveBeenCalled()
+    expect(mock.from).toHaveBeenCalledWith("presence_joins");
+    const fromInstance = mock.from.mock.results[0].value;
+    expect(fromInstance.delete).toHaveBeenCalled();
 
-    const deleteResult = fromInstance.delete.mock.results[0].value
-    expect(deleteResult.eq).toHaveBeenCalledWith('id', MOCK_JOIN_ID)
+    const deleteResult = fromInstance.delete.mock.results[0].value;
+    expect(deleteResult.eq).toHaveBeenCalledWith("id", MOCK_JOIN_ID);
 
-    const firstEqResult = deleteResult.eq.mock.results[0].value
-    expect(firstEqResult.eq).toHaveBeenCalledWith('joiner_user_id', MOCK_USER_ID)
-  })
+    const firstEqResult = deleteResult.eq.mock.results[0].value;
+    expect(firstEqResult.eq).toHaveBeenCalledWith("joiner_user_id", MOCK_USER_ID);
+  });
 
-  it('throws when user is not authenticated', async () => {
-    const mock = makeCancelMock()
-    mock.auth.getUser.mockResolvedValue({ data: { user: null }, error: null })
-    await expect(
-      cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })
-    ).rejects.toThrow('Not authenticated')
-  })
+  it("throws when user is not authenticated", async () => {
+    const mock = makeCancelMock();
+    mock.auth.getUser.mockResolvedValue({ data: { user: null }, error: null });
+    await expect(cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })).rejects.toThrow(
+      "Not authenticated",
+    );
+  });
 
-  it('throws when getUser returns an auth error even with user present', async () => {
-    const mock = makeCancelMock()
+  it("throws when getUser returns an auth error even with user present", async () => {
+    const mock = makeCancelMock();
     mock.auth.getUser.mockResolvedValue({
       data: { user: { id: MOCK_USER_ID } },
-      error: { message: 'session expired' },
-    })
-    await expect(
-      cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })
-    ).rejects.toThrow('Not authenticated')
-  })
+      error: { message: "session expired" },
+    });
+    await expect(cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })).rejects.toThrow(
+      "Not authenticated",
+    );
+  });
 
-  it('throws with Supabase error message when delete fails', async () => {
+  it("throws with Supabase error message when delete fails", async () => {
     const mock = makeCancelMock({
-      deleteResult: { count: null, error: { message: 'delete failed' } },
-    })
-    await expect(
-      cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })
-    ).rejects.toThrow('delete failed')
-  })
+      deleteResult: { count: null, error: { message: "delete failed" } },
+    });
+    await expect(cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })).rejects.toThrow(
+      "delete failed",
+    );
+  });
 
-  it('throws when join is not found (zero rows deleted)', async () => {
-    const mock = makeCancelMock({ deleteResult: { count: 0, error: null } })
-    await expect(
-      cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })
-    ).rejects.toThrow('Join not found or already cancelled')
-  })
+  it("throws when join is not found (zero rows deleted)", async () => {
+    const mock = makeCancelMock({ deleteResult: { count: 0, error: null } });
+    await expect(cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })).rejects.toThrow(
+      "Join not found or already cancelled",
+    );
+  });
 
-  it('logs push notification stub', async () => {
-    const spy = jest.spyOn(console, 'log').mockImplementation(() => {})
-    const mock = makeCancelMock()
-    await cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID })
-    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Push stub'))
-    spy.mockRestore()
-  })
-})
+  it("logs push notification stub", async () => {
+    const spy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const mock = makeCancelMock();
+    await cancelJoin(asClient(mock), { joinId: MOCK_JOIN_ID });
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("Push stub"));
+    spy.mockRestore();
+  });
+});
 
-describe('confirmJoins', () => {
-  it('throws when not authenticated', async () => {
-    const mock = makeConfirmMock({ authUser: null })
-    await expect(confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow('Not authenticated')
-  })
+describe("confirmJoins", () => {
+  it("throws when not authenticated", async () => {
+    const mock = makeConfirmMock({ authUser: null });
+    await expect(confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow(
+      "Not authenticated",
+    );
+  });
 
-  it('throws when getUser returns an auth error', async () => {
-    const mock = makeConfirmMock({ authError: { message: 'session expired' } })
-    await expect(confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow('Not authenticated')
-  })
+  it("throws when getUser returns an auth error", async () => {
+    const mock = makeConfirmMock({ authError: { message: "session expired" } });
+    await expect(confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow(
+      "Not authenticated",
+    );
+  });
 
-  it('returns early without calling update when no active presences at POI', async () => {
-    const mock = makeConfirmMock({ presencesResult: { data: [], error: null } })
-    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })
+  it("returns early without calling update when no active presences at POI", async () => {
+    const mock = makeConfirmMock({ presencesResult: { data: [], error: null } });
+    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID });
     // update should never be called
-    expect(mock.from).not.toHaveBeenCalledWith('presence_joins')
-  })
+    expect(mock.from).not.toHaveBeenCalledWith("presence_joins");
+  });
 
-  it('returns early when presences data is null', async () => {
-    const mock = makeConfirmMock({ presencesResult: { data: null, error: null } })
-    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })
-    expect(mock.from).not.toHaveBeenCalledWith('presence_joins')
-  })
+  it("returns early when presences data is null", async () => {
+    const mock = makeConfirmMock({ presencesResult: { data: null, error: null } });
+    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID });
+    expect(mock.from).not.toHaveBeenCalledWith("presence_joins");
+  });
 
-  it('queries live_presence with correct poi_id and dismissed_at filters', async () => {
-    const mock = makeConfirmMock()
-    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })
+  it("queries live_presence with correct poi_id and dismissed_at filters", async () => {
+    const mock = makeConfirmMock();
+    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID });
 
-    expect(mock.from).toHaveBeenCalledWith('live_presence')
+    expect(mock.from).toHaveBeenCalledWith("live_presence");
     const lpFrom = mock.from.mock.results.find(
-      (r: any) => typeof r.value.select === 'function'
-    )!.value
-    expect(lpFrom.select).toHaveBeenCalledWith('id')
-    const eqResult = lpFrom.select.mock.results[0].value
-    expect(eqResult.eq).toHaveBeenCalledWith('poi_id', MOCK_POI_ID)
-    const isResult = eqResult.eq.mock.results[0].value
-    expect(isResult.is).toHaveBeenCalledWith('dismissed_at', null)
-  })
+      (r: any) => typeof r.value.select === "function",
+    )!.value;
+    expect(lpFrom.select).toHaveBeenCalledWith("id");
+    const eqResult = lpFrom.select.mock.results[0].value;
+    expect(eqResult.eq).toHaveBeenCalledWith("poi_id", MOCK_POI_ID);
+    const isResult = eqResult.eq.mock.results[0].value;
+    expect(isResult.is).toHaveBeenCalledWith("dismissed_at", null);
+  });
 
-  it('calls update on presence_joins with correct filters', async () => {
-    const mock = makeConfirmMock()
-    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })
+  it("calls update on presence_joins with correct filters", async () => {
+    const mock = makeConfirmMock();
+    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID });
 
-    expect(mock.from).toHaveBeenCalledWith('presence_joins')
+    expect(mock.from).toHaveBeenCalledWith("presence_joins");
     const pjFrom = mock.from.mock.results.find(
-      (r: any) => typeof r.value.update === 'function'
-    )!.value
-    expect(pjFrom.update).toHaveBeenCalledWith({ confirmed: true }, { count: 'exact' })
+      (r: any) => typeof r.value.update === "function",
+    )!.value;
+    expect(pjFrom.update).toHaveBeenCalledWith({ confirmed: true }, { count: "exact" });
 
-    const eqJoiner = pjFrom.update.mock.results[0].value
-    expect(eqJoiner.eq).toHaveBeenCalledWith('joiner_user_id', MOCK_USER_ID)
+    const eqJoiner = pjFrom.update.mock.results[0].value;
+    expect(eqJoiner.eq).toHaveBeenCalledWith("joiner_user_id", MOCK_USER_ID);
 
-    const eqConfirmed = eqJoiner.eq.mock.results[0].value
-    expect(eqConfirmed.eq).toHaveBeenCalledWith('confirmed', false)
+    const eqConfirmed = eqJoiner.eq.mock.results[0].value;
+    expect(eqConfirmed.eq).toHaveBeenCalledWith("confirmed", false);
 
-    const inResult = eqConfirmed.eq.mock.results[0].value
-    expect(inResult.in).toHaveBeenCalledWith('presence_id', MOCK_PRESENCE_IDS)
-  })
+    const inResult = eqConfirmed.eq.mock.results[0].value;
+    expect(inResult.in).toHaveBeenCalledWith("presence_id", MOCK_PRESENCE_IDS);
+  });
 
-  it('throws when live_presence query fails', async () => {
+  it("throws when live_presence query fails", async () => {
     const mock = makeConfirmMock({
-      presencesResult: { data: null, error: { message: 'network error' } },
-    })
-    await expect(confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow('network error')
-  })
+      presencesResult: { data: null, error: { message: "network error" } },
+    });
+    await expect(confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow(
+      "network error",
+    );
+  });
 
-  it('throws when presence_joins update fails', async () => {
-    const mock = makeConfirmMock({ updateResult: { error: { message: 'update failed' } } })
-    await expect(confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow('update failed')
-  })
+  it("throws when presence_joins update fails", async () => {
+    const mock = makeConfirmMock({ updateResult: { error: { message: "update failed" } } });
+    await expect(confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow(
+      "update failed",
+    );
+  });
 
-  it('logs push stub after successful update', async () => {
-    const spy = jest.spyOn(console, 'log').mockImplementation(() => {})
-    const mock = makeConfirmMock()
-    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID })
-    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Push stub'), MOCK_POI_ID)
-    spy.mockRestore()
-  })
-})
+  it("logs push stub after successful update", async () => {
+    const spy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const mock = makeConfirmMock();
+    await confirmJoins(asClient(mock), { poiId: MOCK_POI_ID });
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("Push stub"), MOCK_POI_ID);
+    spy.mockRestore();
+  });
+});

--- a/lib/__tests__/submitRating.test.ts
+++ b/lib/__tests__/submitRating.test.ts
@@ -1,112 +1,114 @@
-import { submitRating } from '../ratings'
-import { SupabaseClient } from '@supabase/supabase-js'
-import { Database } from '../../types/supabase'
+import { submitRating } from "../ratings";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "../../types/supabase";
 
-const MOCK_USER_ID = 'user-456'
+const MOCK_USER_ID = "user-456";
 
 type MockSupabase = {
-  from: jest.Mock
-  insert: jest.Mock
-  auth: { getUser: jest.Mock }
-}
+  from: jest.Mock;
+  insert: jest.Mock;
+  auth: { getUser: jest.Mock };
+};
 
-function makeMockSupabase(insertResult: { error: { message: string; code?: string } | null }): MockSupabase {
-  const insert = jest.fn().mockResolvedValue(insertResult)
-  const from = jest.fn().mockReturnValue({ insert })
-  const getUser = jest.fn().mockResolvedValue({ data: { user: { id: MOCK_USER_ID } }, error: null })
-  return { from, insert, auth: { getUser } }
+function makeMockSupabase(insertResult: {
+  error: { message: string; code?: string } | null;
+}): MockSupabase {
+  const insert = jest.fn().mockResolvedValue(insertResult);
+  const from = jest.fn().mockReturnValue({ insert });
+  const getUser = jest
+    .fn()
+    .mockResolvedValue({ data: { user: { id: MOCK_USER_ID } }, error: null });
+  return { from, insert, auth: { getUser } };
 }
 
 function asClient(mock: MockSupabase): SupabaseClient<Database> {
-  return mock as unknown as SupabaseClient<Database>
+  return mock as unknown as SupabaseClient<Database>;
 }
 
-describe('submitRating', () => {
-  const baseArgs = { poiId: 'poi-123', rating: 4, comment: 'Great spot!' }
+describe("submitRating", () => {
+  const baseArgs = { poiId: "poi-123", rating: 4, comment: "Great spot!" };
 
-  it('inserts the correct fields', async () => {
-    const mock = makeMockSupabase({ error: null })
-    await submitRating(asClient(mock), baseArgs)
+  it("inserts the correct fields", async () => {
+    const mock = makeMockSupabase({ error: null });
+    await submitRating(asClient(mock), baseArgs);
 
-    expect(mock.from).toHaveBeenCalledWith('poi_ratings')
+    expect(mock.from).toHaveBeenCalledWith("poi_ratings");
     expect(mock.insert).toHaveBeenCalledWith({
-      poi_id: 'poi-123',
+      poi_id: "poi-123",
       user_id: MOCK_USER_ID,
       rating: 4,
-      comment: 'Great spot!',
-    })
-  })
+      comment: "Great spot!",
+    });
+  });
 
-  it('succeeds when rating is 1 (lower boundary)', async () => {
-    const mock = makeMockSupabase({ error: null })
-    await expect(submitRating(asClient(mock), { ...baseArgs, rating: 1 })).resolves.not.toThrow()
-    expect(mock.insert).toHaveBeenCalledWith(expect.objectContaining({ rating: 1 }))
-  })
+  it("succeeds when rating is 1 (lower boundary)", async () => {
+    const mock = makeMockSupabase({ error: null });
+    await expect(submitRating(asClient(mock), { ...baseArgs, rating: 1 })).resolves.not.toThrow();
+    expect(mock.insert).toHaveBeenCalledWith(expect.objectContaining({ rating: 1 }));
+  });
 
-  it('succeeds when rating is 5 (upper boundary)', async () => {
-    const mock = makeMockSupabase({ error: null })
-    await expect(submitRating(asClient(mock), { ...baseArgs, rating: 5 })).resolves.not.toThrow()
-    expect(mock.insert).toHaveBeenCalledWith(expect.objectContaining({ rating: 5 }))
-  })
+  it("succeeds when rating is 5 (upper boundary)", async () => {
+    const mock = makeMockSupabase({ error: null });
+    await expect(submitRating(asClient(mock), { ...baseArgs, rating: 5 })).resolves.not.toThrow();
+    expect(mock.insert).toHaveBeenCalledWith(expect.objectContaining({ rating: 5 }));
+  });
 
-  it('passes null comment when comment is an empty string', async () => {
-    const mock = makeMockSupabase({ error: null })
-    await submitRating(asClient(mock), { ...baseArgs, comment: '' })
-
-    expect(mock.insert).toHaveBeenCalledWith({
-      poi_id: 'poi-123',
-      user_id: MOCK_USER_ID,
-      rating: 4,
-      comment: null,
-    })
-  })
-
-  it('passes null comment when comment is only whitespace', async () => {
-    const mock = makeMockSupabase({ error: null })
-    await submitRating(asClient(mock), { ...baseArgs, comment: '   ' })
+  it("passes null comment when comment is an empty string", async () => {
+    const mock = makeMockSupabase({ error: null });
+    await submitRating(asClient(mock), { ...baseArgs, comment: "" });
 
     expect(mock.insert).toHaveBeenCalledWith({
-      poi_id: 'poi-123',
+      poi_id: "poi-123",
       user_id: MOCK_USER_ID,
       rating: 4,
       comment: null,
-    })
-  })
+    });
+  });
 
-  it('passes null comment when comment is omitted', async () => {
-    const mock = makeMockSupabase({ error: null })
-    await submitRating(asClient(mock), { poiId: 'poi-123', rating: 4 })
+  it("passes null comment when comment is only whitespace", async () => {
+    const mock = makeMockSupabase({ error: null });
+    await submitRating(asClient(mock), { ...baseArgs, comment: "   " });
 
     expect(mock.insert).toHaveBeenCalledWith({
-      poi_id: 'poi-123',
+      poi_id: "poi-123",
       user_id: MOCK_USER_ID,
       rating: 4,
       comment: null,
-    })
-  })
+    });
+  });
 
-  it('throws when rating is below 1', async () => {
-    const mock = makeMockSupabase({ error: null })
-    await expect(
-      submitRating(asClient(mock), { ...baseArgs, rating: 0 })
-    ).rejects.toThrow('Rating must be between 1 and 5')
-    expect(mock.from).not.toHaveBeenCalled()
-  })
+  it("passes null comment when comment is omitted", async () => {
+    const mock = makeMockSupabase({ error: null });
+    await submitRating(asClient(mock), { poiId: "poi-123", rating: 4 });
 
-  it('throws when rating is above 5', async () => {
-    const mock = makeMockSupabase({ error: null })
-    await expect(
-      submitRating(asClient(mock), { ...baseArgs, rating: 6 })
-    ).rejects.toThrow('Rating must be between 1 and 5')
-    expect(mock.from).not.toHaveBeenCalled()
-  })
+    expect(mock.insert).toHaveBeenCalledWith({
+      poi_id: "poi-123",
+      user_id: MOCK_USER_ID,
+      rating: 4,
+      comment: null,
+    });
+  });
 
-  it('throws with the Supabase error message when insert fails', async () => {
-    const mock = makeMockSupabase({ error: { message: 'duplicate key violation', code: '23505' } })
-    await expect(
-      submitRating(asClient(mock), baseArgs)
-    ).rejects.toThrow('duplicate key violation')
-    expect(mock.from).toHaveBeenCalledWith('poi_ratings')
-    expect(mock.insert).toHaveBeenCalled()
-  })
-})
+  it("throws when rating is below 1", async () => {
+    const mock = makeMockSupabase({ error: null });
+    await expect(submitRating(asClient(mock), { ...baseArgs, rating: 0 })).rejects.toThrow(
+      "Rating must be between 1 and 5",
+    );
+    expect(mock.from).not.toHaveBeenCalled();
+  });
+
+  it("throws when rating is above 5", async () => {
+    const mock = makeMockSupabase({ error: null });
+    await expect(submitRating(asClient(mock), { ...baseArgs, rating: 6 })).rejects.toThrow(
+      "Rating must be between 1 and 5",
+    );
+    expect(mock.from).not.toHaveBeenCalled();
+  });
+
+  it("throws with the Supabase error message when insert fails", async () => {
+    const mock = makeMockSupabase({ error: { message: "duplicate key violation", code: "23505" } });
+    await expect(submitRating(asClient(mock), baseArgs)).rejects.toThrow("duplicate key violation");
+    expect(mock.from).toHaveBeenCalledWith("poi_ratings");
+    expect(mock.insert).toHaveBeenCalled();
+  });
+});

--- a/lib/authErrors.ts
+++ b/lib/authErrors.ts
@@ -1,22 +1,22 @@
 export function isEduEmail(email: string): boolean {
-  const trimmed = email.trim().toLowerCase()
-  const atIndex = trimmed.indexOf('@')
-  return atIndex > 0 && trimmed.endsWith('.edu')
+  const trimmed = email.trim().toLowerCase();
+  const atIndex = trimmed.indexOf("@");
+  return atIndex > 0 && trimmed.endsWith(".edu");
 }
 
 const AUTH_ERROR_MESSAGES: Record<string, string> = {
-  'Invalid login credentials': 'Incorrect email or password.',
-  'Email not confirmed': 'Please confirm your email before signing in.',
-  'User already registered': 'An account with this email already exists.',
-  'Password should be at least 6 characters': 'Password must be at least 6 characters.',
-  'signup_disabled': 'Sign ups are currently disabled.',
-  'email rate limit exceeded': 'Too many attempts. Please try again later.',
-  'over_email_send_rate_limit': 'Too many attempts. Please try again later.',
-}
+  "Invalid login credentials": "Incorrect email or password.",
+  "Email not confirmed": "Please confirm your email before signing in.",
+  "User already registered": "An account with this email already exists.",
+  "Password should be at least 6 characters": "Password must be at least 6 characters.",
+  signup_disabled: "Sign ups are currently disabled.",
+  "email rate limit exceeded": "Too many attempts. Please try again later.",
+  over_email_send_rate_limit: "Too many attempts. Please try again later.",
+};
 
 export function friendlyAuthError(message: string): string {
   for (const [key, friendly] of Object.entries(AUTH_ERROR_MESSAGES)) {
-    if (message.toLowerCase().includes(key.toLowerCase())) return friendly
+    if (message.toLowerCase().includes(key.toLowerCase())) return friendly;
   }
-  return 'Something went wrong. Please try again.'
+  return "Something went wrong. Please try again.";
 }

--- a/lib/backgroundGeofences.ts
+++ b/lib/backgroundGeofences.ts
@@ -1,55 +1,55 @@
-import { Platform } from 'react-native'
-import * as TaskManager from 'expo-task-manager'
-import * as Location from 'expo-location'
-import * as Notifications from 'expo-notifications'
-import AsyncStorage from '@react-native-async-storage/async-storage'
-import { getDistanceMeters } from '@/lib/geo'
-import { CHECKIN_CATEGORY } from '@/lib/notifications'
+import { Platform } from "react-native";
+import * as TaskManager from "expo-task-manager";
+import * as Location from "expo-location";
+import * as Notifications from "expo-notifications";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { getDistanceMeters } from "@/lib/geo";
+import { CHECKIN_CATEGORY } from "@/lib/notifications";
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-export const GEOFENCE_TASK = 'dispatch-geofence-task'
-export const SLC_TASK = 'dispatch-slc-task'
+export const GEOFENCE_TASK = "dispatch-geofence-task";
+export const SLC_TASK = "dispatch-slc-task";
 
-const COOLDOWN_MS = 2 * 60 * 60 * 1000
-const GEOFENCE_RADIUS = 100
-const COPENHAGEN_CENTER = { latitude: 55.6761, longitude: 12.5683 }
-const SLC_REREGISTER_THRESHOLD = 500
-const SLC_LAST_LOC_KEY = 'geofence-slc-last-loc'
+const COOLDOWN_MS = 2 * 60 * 60 * 1000;
+const GEOFENCE_RADIUS = 100;
+const COPENHAGEN_CENTER = { latitude: 55.6761, longitude: 12.5683 };
+const SLC_REREGISTER_THRESHOLD = 500;
+const SLC_LAST_LOC_KEY = "geofence-slc-last-loc";
 
 // iOS CLLocationManager hard cap: 20 regions. Google Play Services cap: 100.
 // If POI count exceeds ANDROID_GEOFENCE_LIMIT, the Android early-return in the
 // background location task must be removed to enable re-registration on Android.
-const IOS_GEOFENCE_LIMIT = 20
-const ANDROID_GEOFENCE_LIMIT = 100
+const IOS_GEOFENCE_LIMIT = 20;
+const ANDROID_GEOFENCE_LIMIT = 100;
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export type PoiSlim = { id: string; name: string; lat: number; lng: number }
+export type PoiSlim = { id: string; name: string; lat: number; lng: number };
 
 // ---------------------------------------------------------------------------
 // Pure helpers
 // ---------------------------------------------------------------------------
 
 export function getGeofenceLimit(): number {
-  return Platform.OS === 'ios' ? IOS_GEOFENCE_LIMIT : ANDROID_GEOFENCE_LIMIT
+  return Platform.OS === "ios" ? IOS_GEOFENCE_LIMIT : ANDROID_GEOFENCE_LIMIT;
 }
 
 export function getNearestPois(
   pois: PoiSlim[],
   latitude: number,
   longitude: number,
-  limit: number
+  limit: number,
 ): PoiSlim[] {
   return [...pois]
     .map((p) => ({ poi: p, dist: getDistanceMeters(latitude, longitude, p.lat, p.lng) }))
     .sort((a, b) => a.dist - b.dist)
     .slice(0, limit)
-    .map((entry) => entry.poi)
+    .map((entry) => entry.poi);
 }
 
 // ---------------------------------------------------------------------------
@@ -58,20 +58,20 @@ export function getNearestPois(
 
 async function isCoolingDown(poiId: string): Promise<boolean> {
   try {
-    const stored = await AsyncStorage.getItem(`geofence-cooldown:${poiId}`)
-    if (!stored) return false
-    return Date.now() - parseInt(stored, 10) < COOLDOWN_MS
+    const stored = await AsyncStorage.getItem(`geofence-cooldown:${poiId}`);
+    if (!stored) return false;
+    return Date.now() - parseInt(stored, 10) < COOLDOWN_MS;
   } catch {
     // If AsyncStorage fails, allow the notification rather than silently blocking.
-    return false
+    return false;
   }
 }
 
 async function setCooldown(poiId: string): Promise<void> {
   try {
-    await AsyncStorage.setItem(`geofence-cooldown:${poiId}`, Date.now().toString())
+    await AsyncStorage.setItem(`geofence-cooldown:${poiId}`, Date.now().toString());
   } catch (err) {
-    console.error('[Geofence] failed to set cooldown:', err)
+    console.error("[Geofence] failed to set cooldown:", err);
   }
 }
 
@@ -87,37 +87,41 @@ export async function registerGeofenceRegions(pois: PoiSlim[]): Promise<void> {
     radius: GEOFENCE_RADIUS,
     notifyOnEnter: true,
     notifyOnExit: false,
-  }))
-  await Location.startGeofencingAsync(GEOFENCE_TASK, regions)
+  }));
+  await Location.startGeofencingAsync(GEOFENCE_TASK, regions);
 }
 
 export async function registerGeofences(
   pois: PoiSlim[],
-  currentLocation?: { latitude: number; longitude: number }
+  currentLocation?: { latitude: number; longitude: number },
 ): Promise<void> {
   // Stop any stale geofence and location-update tasks from a previous session.
   // Without stopping the geofence task first, startGeofencingAsync may deliver
   // queued/pending Enter events from the old registration alongside the new one,
   // causing duplicate notifications for the same POI.
-  try { await Location.stopGeofencingAsync(GEOFENCE_TASK) } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err)
-    if (!msg.includes('not registered') && !msg.includes('not found')) {
-      console.error('[registerGeofences] unexpected error stopping stale geofence task:', err)
+  try {
+    await Location.stopGeofencingAsync(GEOFENCE_TASK);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.includes("not registered") && !msg.includes("not found")) {
+      console.error("[registerGeofences] unexpected error stopping stale geofence task:", err);
     }
   }
-  try { await Location.stopLocationUpdatesAsync(SLC_TASK) } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err)
-    if (!msg.includes('not registered') && !msg.includes('not found')) {
-      console.error('[registerGeofences] unexpected error stopping stale SLC task:', err)
+  try {
+    await Location.stopLocationUpdatesAsync(SLC_TASK);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.includes("not registered") && !msg.includes("not found")) {
+      console.error("[registerGeofences] unexpected error stopping stale SLC task:", err);
     }
   }
 
-  const loc = currentLocation ?? COPENHAGEN_CENTER
-  const limit = getGeofenceLimit()
-  const nearest = getNearestPois(pois, loc.latitude, loc.longitude, limit)
-  await registerGeofenceRegions(nearest)
+  const loc = currentLocation ?? COPENHAGEN_CENTER;
+  const limit = getGeofenceLimit();
+  const nearest = getNearestPois(pois, loc.latitude, loc.longitude, limit);
+  await registerGeofenceRegions(nearest);
 
-  await AsyncStorage.setItem(SLC_LAST_LOC_KEY, JSON.stringify(loc))
+  await AsyncStorage.setItem(SLC_LAST_LOC_KEY, JSON.stringify(loc));
 
   // Start background location monitoring. On Android, the foreground service
   // keeps the process alive so geofence PendingIntents are delivered in the
@@ -129,27 +133,31 @@ export async function registerGeofences(
     activityType: Location.ActivityType.Other,
     deferredUpdatesDistance: SLC_REREGISTER_THRESHOLD,
     deferredUpdatesInterval: 0,
-    ...(Platform.OS === 'android' && {
+    ...(Platform.OS === "android" && {
       foregroundService: {
-        notificationTitle: 'Dispatch is running',
-        notificationBody: 'Monitoring nearby places for check-ins',
-        notificationColor: '#1a73e8',
+        notificationTitle: "Dispatch is running",
+        notificationBody: "Monitoring nearby places for check-ins",
+        notificationColor: "#1a73e8",
       },
     }),
-  })
+  });
 }
 
 export async function stopGeofences(): Promise<void> {
-  try { await Location.stopGeofencingAsync(GEOFENCE_TASK) } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err)
-    if (!msg.includes('not registered') && !msg.includes('not found')) {
-      console.error('[stopGeofences] unexpected error stopping geofence task:', err)
+  try {
+    await Location.stopGeofencingAsync(GEOFENCE_TASK);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.includes("not registered") && !msg.includes("not found")) {
+      console.error("[stopGeofences] unexpected error stopping geofence task:", err);
     }
   }
-  try { await Location.stopLocationUpdatesAsync(SLC_TASK) } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err)
-    if (!msg.includes('not registered') && !msg.includes('not found')) {
-      console.error('[stopGeofences] unexpected error stopping SLC task:', err)
+  try {
+    await Location.stopLocationUpdatesAsync(SLC_TASK);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.includes("not registered") && !msg.includes("not found")) {
+      console.error("[stopGeofences] unexpected error stopping SLC task:", err);
     }
   }
 }
@@ -160,22 +168,22 @@ export async function stopGeofences(): Promise<void> {
 
 TaskManager.defineTask(GEOFENCE_TASK, async ({ data, error }) => {
   if (error) {
-    console.error('[Geofence task] error:', error.message)
-    return
+    console.error("[Geofence task] error:", error.message);
+    return;
   }
 
   const { eventType, region } = data as {
-    eventType: Location.LocationGeofencingEventType
-    region: Location.LocationRegion
-  }
+    eventType: Location.LocationGeofencingEventType;
+    region: Location.LocationRegion;
+  };
 
-  if (eventType !== Location.LocationGeofencingEventType.Enter) return
-  if (!region.identifier) return
+  if (eventType !== Location.LocationGeofencingEventType.Enter) return;
+  if (!region.identifier) return;
 
-  const [poiId, ...nameParts] = region.identifier.split('::')
-  const poiName = nameParts.join('::')
+  const [poiId, ...nameParts] = region.identifier.split("::");
+  const poiName = nameParts.join("::");
 
-  if (await isCoolingDown(poiId)) return
+  if (await isCoolingDown(poiId)) return;
 
   try {
     await Notifications.scheduleNotificationAsync({
@@ -186,21 +194,26 @@ TaskManager.defineTask(GEOFENCE_TASK, async ({ data, error }) => {
       identifier: `geofence-checkin:${poiId}`,
       content: {
         title: `You're at ${poiName}`,
-        body: 'Are you here? Tap to check in!',
+        body: "Are you here? Tap to check in!",
         categoryIdentifier: CHECKIN_CATEGORY,
         data: { poiId, poiName },
       },
-      trigger: Platform.OS === 'android'
-        ? { type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL, seconds: 1, channelId: 'checkin' }
-        : null,
-    })
+      trigger:
+        Platform.OS === "android"
+          ? {
+              type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
+              seconds: 1,
+              channelId: "checkin",
+            }
+          : null,
+    });
     // Set cooldown only after successful notification — a transient failure
     // should not burn the 2h window and silently block future prompts.
-    await setCooldown(poiId)
+    await setCooldown(poiId);
   } catch (err) {
-    console.error('[Geofence task] failed to schedule notification:', err)
+    console.error("[Geofence task] failed to schedule notification:", err);
   }
-})
+});
 
 // ---------------------------------------------------------------------------
 // Background task: low-accuracy location updates → re-register nearest N
@@ -210,8 +223,8 @@ TaskManager.defineTask(GEOFENCE_TASK, async ({ data, error }) => {
 
 TaskManager.defineTask(SLC_TASK, async ({ data, error }) => {
   if (error) {
-    console.error('[SLC task] error:', error.message)
-    return
+    console.error("[SLC task] error:", error.message);
+    return;
   }
 
   // On Android, the 100-region limit accommodates all V1 POIs. The background
@@ -219,49 +232,51 @@ TaskManager.defineTask(SLC_TASK, async ({ data, error }) => {
   // re-registration needed. If POI count exceeds ANDROID_GEOFENCE_LIMIT, this
   // early-return must be removed to enable re-registration on Android as well.
   // On iOS (20-region limit), re-register the nearest 20 when the user moves 500m+.
-  if (Platform.OS === 'android') return
+  if (Platform.OS === "android") return;
 
-  const { locations } = data as { locations: Location.LocationObject[] }
-  if (!locations || locations.length === 0) return
+  const { locations } = data as { locations: Location.LocationObject[] };
+  if (!locations || locations.length === 0) return;
 
-  const current = locations[locations.length - 1]
+  const current = locations[locations.length - 1];
 
   try {
-    const stored = await AsyncStorage.getItem(SLC_LAST_LOC_KEY)
+    const stored = await AsyncStorage.getItem(SLC_LAST_LOC_KEY);
     if (stored) {
-      const last = JSON.parse(stored) as { latitude: number; longitude: number }
+      const last = JSON.parse(stored) as { latitude: number; longitude: number };
       const dist = getDistanceMeters(
-        last.latitude, last.longitude,
-        current.coords.latitude, current.coords.longitude
-      )
-      if (dist < SLC_REREGISTER_THRESHOLD) return
+        last.latitude,
+        last.longitude,
+        current.coords.latitude,
+        current.coords.longitude,
+      );
+      if (dist < SLC_REREGISTER_THRESHOLD) return;
     }
 
-    const { supabase } = require('@/lib/supabase')
+    const { supabase } = require("@/lib/supabase");
     const { data: pois, error: poisError } = await supabase
-      .from('pois')
-      .select('id, name, lat, lng')
+      .from("pois")
+      .select("id, name, lat, lng");
 
     if (poisError) {
-      console.error('[SLC task] failed to fetch POIs:', poisError.message)
-      return
+      console.error("[SLC task] failed to fetch POIs:", poisError.message);
+      return;
     }
 
-    if (!pois || pois.length === 0) return
+    if (!pois || pois.length === 0) return;
 
-    const limit = getGeofenceLimit()
+    const limit = getGeofenceLimit();
     const nearest = getNearestPois(
       pois as PoiSlim[],
       current.coords.latitude,
       current.coords.longitude,
-      limit
-    )
-    await registerGeofenceRegions(nearest)
+      limit,
+    );
+    await registerGeofenceRegions(nearest);
     await AsyncStorage.setItem(
       SLC_LAST_LOC_KEY,
-      JSON.stringify({ latitude: current.coords.latitude, longitude: current.coords.longitude })
-    )
+      JSON.stringify({ latitude: current.coords.latitude, longitude: current.coords.longitude }),
+    );
   } catch (err) {
-    console.error('[SLC task] failed to re-register geofences:', err)
+    console.error("[SLC task] failed to re-register geofences:", err);
   }
-})
+});

--- a/lib/checkIns.ts
+++ b/lib/checkIns.ts
@@ -1,31 +1,32 @@
-import { SupabaseClient } from '@supabase/supabase-js'
-import { Database } from '@/types/supabase'
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "@/types/supabase";
 
 export async function insertCheckIn(
   supabase: SupabaseClient<Database>,
-  { poiId }: { poiId: string }
+  { poiId }: { poiId: string },
 ): Promise<void> {
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Not authenticated')
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error("Not authenticated");
 
   const { data: profile, error: profileError } = await supabase
-    .from('profiles')
-    .select('semester_id')
-    .eq('id', user.id)
-    .single()
-  if (profileError) throw new Error(profileError.message)
+    .from("profiles")
+    .select("semester_id")
+    .eq("id", user.id)
+    .single();
+  if (profileError) throw new Error(profileError.message);
 
-  const { error } = await supabase
-    .from('check_ins')
-    .insert({
-      user_id: user.id,
-      poi_id: poiId,
-      semester_id: profile.semester_id,
-    })
+  const { error } = await supabase.from("check_ins").insert({
+    user_id: user.id,
+    poi_id: poiId,
+    semester_id: profile.semester_id,
+  });
   if (error) {
     // Exclusion constraint: duplicate check-in at same POI within 5 minutes.
     // Treat as success — the first check-in already exists.
-    if (error.code === '23P01') return
-    throw new Error(error.message)
+    if (error.code === "23P01") return;
+    throw new Error(error.message);
   }
 }

--- a/lib/friends.ts
+++ b/lib/friends.ts
@@ -1,33 +1,36 @@
-import { SupabaseClient } from '@supabase/supabase-js'
-import { Database } from '@/types/supabase'
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "@/types/supabase";
 
 export type SearchUser = {
-  id: string
-  display_name: string
-  avatar_url: string | null
-}
+  id: string;
+  display_name: string;
+  avatar_url: string | null;
+};
 
 // Escape ILIKE special characters so user input is treated as a literal string.
 function escapeIlike(s: string): string {
-  return s.replace(/[%_\\]/g, '\\$&')
+  return s.replace(/[%_\\]/g, "\\$&");
 }
 
 export async function searchUsers(
   supabase: SupabaseClient<Database>,
-  { query }: { query: string }
+  { query }: { query: string },
 ): Promise<SearchUser[]> {
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Not authenticated')
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error("Not authenticated");
 
   // Prefix match (query%) — uses the index on display_name; change to %query% for
   // substring matching at the cost of a full scan.
   const { data, error } = await supabase
-    .from('profiles')
-    .select('id, display_name, avatar_url')
-    .ilike('display_name', `${escapeIlike(query)}%`)
-    .neq('id', user.id)
-    .limit(20)
+    .from("profiles")
+    .select("id, display_name, avatar_url")
+    .ilike("display_name", `${escapeIlike(query)}%`)
+    .neq("id", user.id)
+    .limit(20);
 
-  if (error) throw new Error(error.message)
-  return (data as SearchUser[]) ?? []
+  if (error) throw new Error(error.message);
+  return (data as SearchUser[]) ?? [];
 }

--- a/lib/friendships.ts
+++ b/lib/friendships.ts
@@ -1,117 +1,137 @@
-import { SupabaseClient } from '@supabase/supabase-js'
-import { Database, Tables } from '@/types/supabase'
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database, Tables } from "@/types/supabase";
 
-export type FriendshipStatus = 'none' | 'pending_sent' | 'pending_received' | 'accepted'
+export type FriendshipStatus = "none" | "pending_sent" | "pending_received" | "accepted";
 
-export type ProfileSummary = Pick<Tables<'profiles'>, 'id' | 'display_name' | 'avatar_url'>
+export type ProfileSummary = Pick<Tables<"profiles">, "id" | "display_name" | "avatar_url">;
 
-export type FriendshipRow = Tables<'friendships'>
+export type FriendshipRow = Tables<"friendships">;
 
 export type FriendshipWithProfiles = FriendshipRow & {
-  requester: ProfileSummary
-  addressee: ProfileSummary
-}
+  requester: ProfileSummary;
+  addressee: ProfileSummary;
+};
 
-type Supabase = SupabaseClient<Database>
+type Supabase = SupabaseClient<Database>;
 
 export async function fetchFriendships(supabase: Supabase): Promise<FriendshipWithProfiles[]> {
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Not authenticated')
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error("Not authenticated");
 
   const { data, error } = await supabase
-    .from('friendships')
-    .select(`
+    .from("friendships")
+    .select(
+      `
       *,
       requester:requester_id(id, display_name, avatar_url),
       addressee:addressee_id(id, display_name, avatar_url)
-    `)
-    .or(`requester_id.eq.${user.id},addressee_id.eq.${user.id}`)
+    `,
+    )
+    .or(`requester_id.eq.${user.id},addressee_id.eq.${user.id}`);
 
-  if (error) throw new Error(error.message)
-  return (data as unknown as FriendshipWithProfiles[]) ?? []
+  if (error) throw new Error(error.message);
+  return (data as unknown as FriendshipWithProfiles[]) ?? [];
 }
 
 export async function sendRequest(
   supabase: Supabase,
-  { addresseeId }: { addresseeId: string }
+  { addresseeId }: { addresseeId: string },
 ): Promise<FriendshipRow> {
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Not authenticated')
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error("Not authenticated");
 
   const { data, error } = await supabase
-    .from('friendships')
-    .insert({ requester_id: user.id, addressee_id: addresseeId, status: 'pending' })
-    .select('*')
-    .single()
+    .from("friendships")
+    .insert({ requester_id: user.id, addressee_id: addresseeId, status: "pending" })
+    .select("*")
+    .single();
 
   if (error) {
     // Postgres unique-constraint violation (23505) — most likely the LEAST/GREATEST pair index
-    if (error.code === '23505') throw new Error('Friend request already exists')
-    throw new Error(error.message)
+    if (error.code === "23505") throw new Error("Friend request already exists");
+    throw new Error(error.message);
   }
-  return data
+  return data;
 }
 
 export async function cancelRequest(
   supabase: Supabase,
-  { friendshipId }: { friendshipId: string }
+  { friendshipId }: { friendshipId: string },
 ): Promise<void> {
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Not authenticated')
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error("Not authenticated");
 
   const { count, error } = await supabase
-    .from('friendships')
-    .delete({ count: 'exact' })
-    .eq('id', friendshipId)
+    .from("friendships")
+    .delete({ count: "exact" })
+    .eq("id", friendshipId);
 
-  if (error) throw new Error(error.message)
-  if (count === 0) throw new Error('Request not found or already cancelled')
+  if (error) throw new Error(error.message);
+  if (count === 0) throw new Error("Request not found or already cancelled");
 }
 
 export async function acceptRequest(
   supabase: Supabase,
-  { friendshipId }: { friendshipId: string }
+  { friendshipId }: { friendshipId: string },
 ): Promise<void> {
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Not authenticated')
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error("Not authenticated");
 
   const { count, error } = await supabase
-    .from('friendships')
-    .update({ status: 'accepted' }, { count: 'exact' })
-    .eq('id', friendshipId)
+    .from("friendships")
+    .update({ status: "accepted" }, { count: "exact" })
+    .eq("id", friendshipId);
 
-  if (error) throw new Error(error.message)
-  if (count === 0) throw new Error('Request not found or already handled')
+  if (error) throw new Error(error.message);
+  if (count === 0) throw new Error("Request not found or already handled");
 }
 
 export async function declineRequest(
   supabase: Supabase,
-  { friendshipId }: { friendshipId: string }
+  { friendshipId }: { friendshipId: string },
 ): Promise<void> {
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Not authenticated')
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error("Not authenticated");
 
   const { count, error } = await supabase
-    .from('friendships')
-    .delete({ count: 'exact' })
-    .eq('id', friendshipId)
+    .from("friendships")
+    .delete({ count: "exact" })
+    .eq("id", friendshipId);
 
-  if (error) throw new Error(error.message)
-  if (count === 0) throw new Error('Request not found or already declined')
+  if (error) throw new Error(error.message);
+  if (count === 0) throw new Error("Request not found or already declined");
 }
 
 export async function unfriend(
   supabase: Supabase,
-  { friendshipId }: { friendshipId: string }
+  { friendshipId }: { friendshipId: string },
 ): Promise<void> {
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Not authenticated')
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error("Not authenticated");
 
   const { count, error } = await supabase
-    .from('friendships')
-    .delete({ count: 'exact' })
-    .eq('id', friendshipId)
+    .from("friendships")
+    .delete({ count: "exact" })
+    .eq("id", friendshipId);
 
-  if (error) throw new Error(error.message)
-  if (count === 0) throw new Error('Friendship not found')
+  if (error) throw new Error(error.message);
+  if (count === 0) throw new Error("Friendship not found");
 }

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -1,17 +1,14 @@
 // Haversine formula — returns distance in metres between two lat/lng points.
-export function getDistanceMeters(
-  lat1: number, lng1: number,
-  lat2: number, lng2: number
-): number {
-  const R = 6_371_000 // Earth radius in metres
-  const toRad = (deg: number) => (deg * Math.PI) / 180
+export function getDistanceMeters(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6_371_000; // Earth radius in metres
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
 
-  const dLat = toRad(lat2 - lat1)
-  const dLng = toRad(lng2 - lng1)
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
 
   const a =
     Math.sin(dLat / 2) ** 2 +
-    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
 
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }

--- a/lib/geofence.ts
+++ b/lib/geofence.ts
@@ -6,4 +6,4 @@
 //
 // This namespace must never change — altering it would invalidate all
 // existing POI UUIDs and break geofence re-registration.
-export const DISPATCH_GEOFENCE_NS = '9a8b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d'
+export const DISPATCH_GEOFENCE_NS = "9a8b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d";

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,18 +1,18 @@
-import { Platform } from 'react-native'
-import * as Notifications from 'expo-notifications'
+import { Platform } from "react-native";
+import * as Notifications from "expo-notifications";
 
-export const CHECKIN_CATEGORY = 'geofence-checkin'
-export const ACTION_CONFIRM = 'confirm-checkin'
-export const ACTION_DISMISS = 'dismiss-checkin'
+export const CHECKIN_CATEGORY = "geofence-checkin";
+export const ACTION_CONFIRM = "confirm-checkin";
+export const ACTION_DISMISS = "dismiss-checkin";
 
 export async function setupNotificationCategories(): Promise<void> {
-  if (Platform.OS === 'android') {
-    await Notifications.setNotificationChannelAsync('checkin', {
-      name: 'Check-in notifications',
+  if (Platform.OS === "android") {
+    await Notifications.setNotificationChannelAsync("checkin", {
+      name: "Check-in notifications",
       importance: Notifications.AndroidImportance.HIGH,
       vibrationPattern: [0, 250, 250, 250],
       enableVibrate: true,
-    })
+    });
   }
 
   await Notifications.setNotificationCategoryAsync(CHECKIN_CATEGORY, [
@@ -23,10 +23,10 @@ export async function setupNotificationCategories(): Promise<void> {
     },
     {
       identifier: ACTION_DISMISS,
-      buttonTitle: 'No',
+      buttonTitle: "No",
       options: { opensAppToForeground: false },
     },
-  ])
+  ]);
 }
 
 // Module-level side effect (intentional): create the Android notification
@@ -36,8 +36,8 @@ export async function setupNotificationCategories(): Promise<void> {
 // non-existent channel and silently failed. Fire-and-forget — errors are
 // logged but must not crash the module import chain.
 setupNotificationCategories().catch((err) => {
-  console.warn('[notifications] setupNotificationCategories failed at module scope:', err)
-})
+  console.warn("[notifications] setupNotificationCategories failed at module scope:", err);
+});
 
 // Module-level side effect (intentional): setNotificationHandler must be
 // registered early, before any notification arrives. Imported via index.js to
@@ -52,4 +52,4 @@ Notifications.setNotificationHandler({
     shouldPlaySound: false,
     shouldSetBadge: false,
   }),
-})
+});

--- a/lib/poiCategories.ts
+++ b/lib/poiCategories.ts
@@ -1,31 +1,31 @@
-import { Database } from '@/types/supabase'
+import { Database } from "@/types/supabase";
 
-export type PoiCategory = Database['public']['Enums']['poi_category']
+export type PoiCategory = Database["public"]["Enums"]["poi_category"];
 
 export const POI_CATEGORIES: PoiCategory[] = [
-  'food_drink',
-  'nightlife',
-  'culture',
-  'study_spots',
-  'hidden_gems',
-]
+  "food_drink",
+  "nightlife",
+  "culture",
+  "study_spots",
+  "hidden_gems",
+];
 
 export const CATEGORY_LABELS: Record<PoiCategory, string> = {
-  food_drink: 'Food & Drink',
-  nightlife: 'Nightlife',
-  culture: 'Culture',
-  study_spots: 'Study Spots',
-  hidden_gems: 'Hidden Gems',
-}
+  food_drink: "Food & Drink",
+  nightlife: "Nightlife",
+  culture: "Culture",
+  study_spots: "Study Spots",
+  hidden_gems: "Hidden Gems",
+};
 
 export const CATEGORY_COLORS: Record<PoiCategory, string> = {
-  food_drink:   '#FF8C00',
-  nightlife:    '#7B2FBE',
-  culture:      '#0066FF',
-  study_spots:  '#2D8A4E',
-  hidden_gems:  '#E51E1E',
-}
+  food_drink: "#FF8C00",
+  nightlife: "#7B2FBE",
+  culture: "#0066FF",
+  study_spots: "#2D8A4E",
+  hidden_gems: "#E51E1E",
+};
 
 export function isPoiCategory(value: unknown): value is PoiCategory {
-  return POI_CATEGORIES.includes(value as PoiCategory)
+  return POI_CATEGORIES.includes(value as PoiCategory);
 }

--- a/lib/presence.ts
+++ b/lib/presence.ts
@@ -1,68 +1,74 @@
-import { SupabaseClient } from '@supabase/supabase-js'
-import { Database } from '@/types/supabase'
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "@/types/supabase";
 
-export type VisibilityType = Database['public']['Enums']['visibility_type']
+export type VisibilityType = Database["public"]["Enums"]["visibility_type"];
 
 export type ActivePresence = {
-  id: string
-  poi_id: string
-  message: string | null
-  visible_to: VisibilityType
-}
+  id: string;
+  poi_id: string;
+  message: string | null;
+  visible_to: VisibilityType;
+};
 
 export async function broadcastPresence(
   supabase: SupabaseClient<Database>,
   {
     poiId,
     message,
-    visibleTo = 'friends',
-  }: { poiId: string; message?: string; visibleTo?: VisibilityType }
+    visibleTo = "friends",
+  }: { poiId: string; message?: string; visibleTo?: VisibilityType },
 ) {
   // Also enforced at DB level: CHECK (char_length(message) <= 140)
-  const trimmedMessage = message?.trim() || null
+  const trimmedMessage = message?.trim() || null;
   if (trimmedMessage && trimmedMessage.length > 140) {
-    throw new Error('Message must be 140 characters or less')
+    throw new Error("Message must be 140 characters or less");
   }
 
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Not authenticated')
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error("Not authenticated");
 
   // Auto-dismiss any existing active broadcast (no-op if none exists)
   const { error: dismissError } = await supabase
-    .from('live_presence')
+    .from("live_presence")
     .update({ dismissed_at: new Date().toISOString() })
-    .eq('user_id', user.id)
-    .is('dismissed_at', null)
-  if (dismissError) throw new Error(dismissError.message)
+    .eq("user_id", user.id)
+    .is("dismissed_at", null);
+  if (dismissError) throw new Error(dismissError.message);
 
   const { data, error } = await supabase
-    .from('live_presence')
+    .from("live_presence")
     .insert({
       poi_id: poiId,
       user_id: user.id,
       message: trimmedMessage,
       visible_to: visibleTo,
     })
-    .select('id, poi_id, message, visible_to')
-    .single()
+    .select("id, poi_id, message, visible_to")
+    .single();
 
-  if (error) throw new Error(error.message)
-  return data
+  if (error) throw new Error(error.message);
+  return data;
 }
 
 export async function dismissPresence(
   supabase: SupabaseClient<Database>,
-  { presenceId }: { presenceId: string }
+  { presenceId }: { presenceId: string },
 ): Promise<void> {
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Not authenticated')
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error("Not authenticated");
 
   const { error } = await supabase
-    .from('live_presence')
+    .from("live_presence")
     .update({ dismissed_at: new Date().toISOString() })
-    .eq('id', presenceId)
-    .eq('user_id', user.id)
-    .is('dismissed_at', null)
+    .eq("id", presenceId)
+    .eq("user_id", user.id)
+    .is("dismissed_at", null);
 
-  if (error) throw new Error(error.message)
+  if (error) throw new Error(error.message);
 }

--- a/lib/presenceJoins.ts
+++ b/lib/presenceJoins.ts
@@ -1,59 +1,65 @@
-import { SupabaseClient } from '@supabase/supabase-js'
-import { Database, Tables } from '@/types/supabase'
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database, Tables } from "@/types/supabase";
 
 // Use the generated type so it stays in sync with the DB schema automatically.
-export type PresenceJoin = Tables<'presence_joins'>
+export type PresenceJoin = Tables<"presence_joins">;
 
 export async function joinPresence(
   supabase: SupabaseClient<Database>,
-  { presenceId }: { presenceId: string }
+  { presenceId }: { presenceId: string },
 ): Promise<PresenceJoin> {
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Not authenticated')
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error("Not authenticated");
 
   const { data, error } = await supabase
-    .from('presence_joins')
+    .from("presence_joins")
     .insert({ presence_id: presenceId, joiner_user_id: user.id })
-    .select('*')
-    .single()
+    .select("*")
+    .single();
 
   if (error) {
-    if (error.code === '23505') throw new Error('You have already joined this person.')
-    throw new Error(error.message)
+    if (error.code === "23505") throw new Error("You have already joined this person.");
+    throw new Error(error.message);
   }
 
   try {
     // Push notification stub — replace with Expo Push when infra is built in Phase 7
-    console.log('[Push stub] join notification queued')
+    console.log("[Push stub] join notification queued");
   } catch (pushErr) {
-    console.error('[Push stub] Failed to send join notification:', pushErr)
+    console.error("[Push stub] Failed to send join notification:", pushErr);
     // Join succeeded — push failure is non-fatal
   }
 
-  return data as PresenceJoin
+  return data as PresenceJoin;
 }
 
 export async function cancelJoin(
   supabase: SupabaseClient<Database>,
-  { joinId }: { joinId: string }
+  { joinId }: { joinId: string },
 ): Promise<void> {
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Not authenticated')
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error("Not authenticated");
 
   const { count, error } = await supabase
-    .from('presence_joins')
-    .delete({ count: 'exact' })
-    .eq('id', joinId)
-    .eq('joiner_user_id', user.id)
+    .from("presence_joins")
+    .delete({ count: "exact" })
+    .eq("id", joinId)
+    .eq("joiner_user_id", user.id);
 
-  if (error) throw new Error(error.message)
-  if ((count ?? 0) === 0) throw new Error('Join not found or already cancelled')
+  if (error) throw new Error(error.message);
+  if ((count ?? 0) === 0) throw new Error("Join not found or already cancelled");
 
   try {
     // Push notification stub — replace with Expo Push when infra is built in Phase 7
-    console.log('[Push stub] cancel notification queued')
+    console.log("[Push stub] cancel notification queued");
   } catch (pushErr) {
-    console.error('[Push stub] Failed to send cancel notification:', pushErr)
+    console.error("[Push stub] Failed to send cancel notification:", pushErr);
     // Cancel succeeded — push failure is non-fatal
   }
 }
@@ -65,39 +71,43 @@ export async function cancelJoin(
 // the POI, step 2 updates only the joiner's unconfirmed rows for those presences.
 export async function confirmJoins(
   supabase: SupabaseClient<Database>,
-  { poiId }: { poiId: string }
+  { poiId }: { poiId: string },
 ): Promise<void> {
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Not authenticated')
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error("Not authenticated");
 
   // Step 1: find active presences at this POI
   const { data: presences, error: presenceError } = await supabase
-    .from('live_presence')
-    .select('id')
-    .eq('poi_id', poiId)
-    .is('dismissed_at', null)
+    .from("live_presence")
+    .select("id")
+    .eq("poi_id", poiId)
+    .is("dismissed_at", null);
 
-  if (presenceError) throw new Error(presenceError.message)
-  if (!presences || presences.length === 0) return
+  if (presenceError) throw new Error(presenceError.message);
+  if (!presences || presences.length === 0) return;
 
-  const presenceIds = presences.map((p) => p.id)
+  const presenceIds = presences.map((p) => p.id);
 
   // Step 2: confirm the joiner's pending joins for those presences
   const { error: updateError, count } = await supabase
-    .from('presence_joins')
-    .update({ confirmed: true }, { count: 'exact' })
-    .eq('joiner_user_id', user.id)
-    .eq('confirmed', false)
-    .in('presence_id', presenceIds)
+    .from("presence_joins")
+    .update({ confirmed: true }, { count: "exact" })
+    .eq("joiner_user_id", user.id)
+    .eq("confirmed", false)
+    .in("presence_id", presenceIds);
 
-  if (updateError) throw new Error(updateError.message)
-  if (count === 0) console.log('[confirmJoins] No joins updated — joiner has no pending joins at poi:', poiId)
+  if (updateError) throw new Error(updateError.message);
+  if (count === 0)
+    console.log("[confirmJoins] No joins updated — joiner has no pending joins at poi:", poiId);
 
   try {
     // Push notification stub — replace with Expo Push when infra is built in Phase 7
-    console.log('[Push stub] arrival notification queued for broadcasters at poi:', poiId)
+    console.log("[Push stub] arrival notification queued for broadcasters at poi:", poiId);
   } catch (pushErr) {
-    console.error('[Push stub] Failed to queue arrival notification:', pushErr)
+    console.error("[Push stub] Failed to queue arrival notification:", pushErr);
     // Confirmation succeeded — push failure is non-fatal
   }
 }

--- a/lib/ratings.ts
+++ b/lib/ratings.ts
@@ -1,31 +1,30 @@
-import { SupabaseClient } from '@supabase/supabase-js'
-import { Database } from '@/types/supabase'
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "@/types/supabase";
 
-type RatingInsert = Database['public']['Tables']['poi_ratings']['Insert']
+type RatingInsert = Database["public"]["Tables"]["poi_ratings"]["Insert"];
 
 export async function submitRating(
   supabase: SupabaseClient<Database>,
-  {
-    poiId,
-    rating,
-    comment,
-  }: { poiId: string; rating: number; comment?: string }
+  { poiId, rating, comment }: { poiId: string; rating: number; comment?: string },
 ) {
   // Also enforced at the DB level: CHECK (rating BETWEEN 1 AND 5) on poi_ratings.rating
   if (rating < 1 || rating > 5) {
-    throw new Error('Rating must be between 1 and 5')
+    throw new Error("Rating must be between 1 and 5");
   }
 
-  const { data: { user }, error: authError } = await supabase.auth.getUser()
-  if (authError || !user) throw new Error('Not authenticated')
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) throw new Error("Not authenticated");
 
   const row: RatingInsert = {
     poi_id: poiId,
     user_id: user.id,
     rating,
     comment: comment?.trim() || null,
-  }
+  };
 
-  const { error } = await supabase.from('poi_ratings').insert(row)
-  if (error) throw new Error(error.message)
+  const { error } = await supabase.from("poi_ratings").insert(row);
+  if (error) throw new Error(error.message);
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,13 +1,15 @@
-import 'react-native-url-polyfill/auto'
-import AsyncStorage from '@react-native-async-storage/async-storage'
-import { createClient } from '@supabase/supabase-js'
-import { Database } from '@/types/supabase'
+import "react-native-url-polyfill/auto";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { createClient } from "@supabase/supabase-js";
+import { Database } from "@/types/supabase";
 
-const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL
-const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing EXPO_PUBLIC_SUPABASE_URL or EXPO_PUBLIC_SUPABASE_ANON_KEY environment variables')
+  throw new Error(
+    "Missing EXPO_PUBLIC_SUPABASE_URL or EXPO_PUBLIC_SUPABASE_ANON_KEY environment variables",
+  );
 }
 
 export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
@@ -17,4 +19,4 @@ export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
     persistSession: true,
     detectSessionInUrl: false,
   },
-})
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@types/react-test-renderer": "^19.1.0",
         "jest": "^29.7.0",
         "jest-expo": "^55.0.11",
+        "prettier": "^3.8.3",
         "typescript": "~5.9.2"
       }
     },
@@ -9864,6 +9865,22 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/pretty-format": {
       "version": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/react-test-renderer": "^19.1.0",
     "jest": "^29.7.0",
     "jest-expo": "^55.0.11",
+    "prettier": "^3.8.3",
     "typescript": "~5.9.2"
   },
   "jest": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,7 @@
     "strict": true,
     "types": ["jest"],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
   "include": [

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1,499 +1,486 @@
-export type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json | undefined }
-  | Json[]
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
 export type Database = {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "14.4"
-  }
+    PostgrestVersion: "14.4";
+  };
   graphql_public: {
     Tables: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
       graphql: {
         Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
+          extensions?: Json;
+          operationName?: string;
+          query?: string;
+          variables?: Json;
+        };
+        Returns: Json;
+      };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
+      [_ in never]: never;
+    };
+  };
   public: {
     Tables: {
       check_ins: {
         Row: {
-          checked_in_at: string
-          id: string
-          poi_id: string
-          semester_id: string | null
-          user_id: string
-        }
+          checked_in_at: string;
+          id: string;
+          poi_id: string;
+          semester_id: string | null;
+          user_id: string;
+        };
         Insert: {
-          checked_in_at?: string
-          id?: string
-          poi_id: string
-          semester_id?: string | null
-          user_id: string
-        }
+          checked_in_at?: string;
+          id?: string;
+          poi_id: string;
+          semester_id?: string | null;
+          user_id: string;
+        };
         Update: {
-          checked_in_at?: string
-          id?: string
-          poi_id?: string
-          semester_id?: string | null
-          user_id?: string
-        }
+          checked_in_at?: string;
+          id?: string;
+          poi_id?: string;
+          semester_id?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "check_ins_poi_id_fkey"
-            columns: ["poi_id"]
-            isOneToOne: false
-            referencedRelation: "pois"
-            referencedColumns: ["id"]
+            foreignKeyName: "check_ins_poi_id_fkey";
+            columns: ["poi_id"];
+            isOneToOne: false;
+            referencedRelation: "pois";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "check_ins_semester_id_fkey"
-            columns: ["semester_id"]
-            isOneToOne: false
-            referencedRelation: "semesters"
-            referencedColumns: ["id"]
+            foreignKeyName: "check_ins_semester_id_fkey";
+            columns: ["semester_id"];
+            isOneToOne: false;
+            referencedRelation: "semesters";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       friendships: {
         Row: {
-          addressee_id: string
-          created_at: string
-          id: string
-          requester_id: string
-          status: Database["public"]["Enums"]["friendship_status"]
-        }
+          addressee_id: string;
+          created_at: string;
+          id: string;
+          requester_id: string;
+          status: Database["public"]["Enums"]["friendship_status"];
+        };
         Insert: {
-          addressee_id: string
-          created_at?: string
-          id?: string
-          requester_id: string
-          status: Database["public"]["Enums"]["friendship_status"]
-        }
+          addressee_id: string;
+          created_at?: string;
+          id?: string;
+          requester_id: string;
+          status: Database["public"]["Enums"]["friendship_status"];
+        };
         Update: {
-          addressee_id?: string
-          created_at?: string
-          id?: string
-          requester_id?: string
-          status?: Database["public"]["Enums"]["friendship_status"]
-        }
+          addressee_id?: string;
+          created_at?: string;
+          id?: string;
+          requester_id?: string;
+          status?: Database["public"]["Enums"]["friendship_status"];
+        };
         Relationships: [
           {
-            foreignKeyName: "friendships_addressee_id_fkey"
-            columns: ["addressee_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "friendships_addressee_id_fkey";
+            columns: ["addressee_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "friendships_requester_id_fkey"
-            columns: ["requester_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "friendships_requester_id_fkey";
+            columns: ["requester_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       live_presence: {
         Row: {
-          created_at: string
-          dismissed_at: string | null
-          id: string
-          message: string | null
-          poi_id: string
-          user_id: string
-          visible_to: Database["public"]["Enums"]["visibility_type"]
-        }
+          created_at: string;
+          dismissed_at: string | null;
+          id: string;
+          message: string | null;
+          poi_id: string;
+          user_id: string;
+          visible_to: Database["public"]["Enums"]["visibility_type"];
+        };
         Insert: {
-          created_at?: string
-          dismissed_at?: string | null
-          id?: string
-          message?: string | null
-          poi_id: string
-          user_id: string
-          visible_to?: Database["public"]["Enums"]["visibility_type"]
-        }
+          created_at?: string;
+          dismissed_at?: string | null;
+          id?: string;
+          message?: string | null;
+          poi_id: string;
+          user_id: string;
+          visible_to?: Database["public"]["Enums"]["visibility_type"];
+        };
         Update: {
-          created_at?: string
-          dismissed_at?: string | null
-          id?: string
-          message?: string | null
-          poi_id?: string
-          user_id?: string
-          visible_to?: Database["public"]["Enums"]["visibility_type"]
-        }
+          created_at?: string;
+          dismissed_at?: string | null;
+          id?: string;
+          message?: string | null;
+          poi_id?: string;
+          user_id?: string;
+          visible_to?: Database["public"]["Enums"]["visibility_type"];
+        };
         Relationships: [
           {
-            foreignKeyName: "live_presence_poi_id_fkey"
-            columns: ["poi_id"]
-            isOneToOne: false
-            referencedRelation: "pois"
-            referencedColumns: ["id"]
+            foreignKeyName: "live_presence_poi_id_fkey";
+            columns: ["poi_id"];
+            isOneToOne: false;
+            referencedRelation: "pois";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "live_presence_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "live_presence_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       poi_ratings: {
         Row: {
-          comment: string | null
-          created_at: string | null
-          id: string
-          poi_id: string
-          rating: number
-          user_id: string
-        }
+          comment: string | null;
+          created_at: string | null;
+          id: string;
+          poi_id: string;
+          rating: number;
+          user_id: string;
+        };
         Insert: {
-          comment?: string | null
-          created_at?: string | null
-          id?: string
-          poi_id: string
-          rating: number
-          user_id: string
-        }
+          comment?: string | null;
+          created_at?: string | null;
+          id?: string;
+          poi_id: string;
+          rating: number;
+          user_id: string;
+        };
         Update: {
-          comment?: string | null
-          created_at?: string | null
-          id?: string
-          poi_id?: string
-          rating?: number
-          user_id?: string
-        }
+          comment?: string | null;
+          created_at?: string | null;
+          id?: string;
+          poi_id?: string;
+          rating?: number;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "poi_ratings_poi_id_fkey"
-            columns: ["poi_id"]
-            isOneToOne: false
-            referencedRelation: "pois"
-            referencedColumns: ["id"]
+            foreignKeyName: "poi_ratings_poi_id_fkey";
+            columns: ["poi_id"];
+            isOneToOne: false;
+            referencedRelation: "pois";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "poi_ratings_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "poi_ratings_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       pois: {
         Row: {
-          category: Database["public"]["Enums"]["poi_category"]
-          created_at: string | null
-          created_by: string | null
-          description: string
-          id: string
-          lat: number
-          lng: number
-          name: string
-        }
+          category: Database["public"]["Enums"]["poi_category"];
+          created_at: string | null;
+          created_by: string | null;
+          description: string;
+          id: string;
+          lat: number;
+          lng: number;
+          name: string;
+        };
         Insert: {
-          category: Database["public"]["Enums"]["poi_category"]
-          created_at?: string | null
-          created_by?: string | null
-          description: string
-          id: string
-          lat: number
-          lng: number
-          name: string
-        }
+          category: Database["public"]["Enums"]["poi_category"];
+          created_at?: string | null;
+          created_by?: string | null;
+          description: string;
+          id: string;
+          lat: number;
+          lng: number;
+          name: string;
+        };
         Update: {
-          category?: Database["public"]["Enums"]["poi_category"]
-          created_at?: string | null
-          created_by?: string | null
-          description?: string
-          id?: string
-          lat?: number
-          lng?: number
-          name?: string
-        }
+          category?: Database["public"]["Enums"]["poi_category"];
+          created_at?: string | null;
+          created_by?: string | null;
+          description?: string;
+          id?: string;
+          lat?: number;
+          lng?: number;
+          name?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "pois_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "pois_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       presence_joins: {
         Row: {
-          confirmed: boolean
-          id: string
-          joined_at: string
-          joiner_user_id: string
-          presence_id: string
-        }
+          confirmed: boolean;
+          id: string;
+          joined_at: string;
+          joiner_user_id: string;
+          presence_id: string;
+        };
         Insert: {
-          confirmed?: boolean
-          id?: string
-          joined_at?: string
-          joiner_user_id: string
-          presence_id: string
-        }
+          confirmed?: boolean;
+          id?: string;
+          joined_at?: string;
+          joiner_user_id: string;
+          presence_id: string;
+        };
         Update: {
-          confirmed?: boolean
-          id?: string
-          joined_at?: string
-          joiner_user_id?: string
-          presence_id?: string
-        }
+          confirmed?: boolean;
+          id?: string;
+          joined_at?: string;
+          joiner_user_id?: string;
+          presence_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "presence_joins_joiner_user_id_fkey"
-            columns: ["joiner_user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "presence_joins_joiner_user_id_fkey";
+            columns: ["joiner_user_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "presence_joins_presence_id_fkey"
-            columns: ["presence_id"]
-            isOneToOne: false
-            referencedRelation: "live_presence"
-            referencedColumns: ["id"]
+            foreignKeyName: "presence_joins_presence_id_fkey";
+            columns: ["presence_id"];
+            isOneToOne: false;
+            referencedRelation: "live_presence";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       profiles: {
         Row: {
-          avatar_url: string | null
-          created_at: string | null
-          display_name: string
-          id: string
-          semester_id: string | null
-        }
+          avatar_url: string | null;
+          created_at: string | null;
+          display_name: string;
+          id: string;
+          semester_id: string | null;
+        };
         Insert: {
-          avatar_url?: string | null
-          created_at?: string | null
-          display_name: string
-          id: string
-          semester_id?: string | null
-        }
+          avatar_url?: string | null;
+          created_at?: string | null;
+          display_name: string;
+          id: string;
+          semester_id?: string | null;
+        };
         Update: {
-          avatar_url?: string | null
-          created_at?: string | null
-          display_name?: string
-          id?: string
-          semester_id?: string | null
-        }
+          avatar_url?: string | null;
+          created_at?: string | null;
+          display_name?: string;
+          id?: string;
+          semester_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "profiles_semester_id_fkey"
-            columns: ["semester_id"]
-            isOneToOne: false
-            referencedRelation: "semesters"
-            referencedColumns: ["id"]
+            foreignKeyName: "profiles_semester_id_fkey";
+            columns: ["semester_id"];
+            isOneToOne: false;
+            referencedRelation: "semesters";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       semesters: {
         Row: {
-          created_at: string | null
-          end_date: string
-          id: string
-          name: string
-          start_date: string
-        }
+          created_at: string | null;
+          end_date: string;
+          id: string;
+          name: string;
+          start_date: string;
+        };
         Insert: {
-          created_at?: string | null
-          end_date: string
-          id?: string
-          name: string
-          start_date: string
-        }
+          created_at?: string | null;
+          end_date: string;
+          id?: string;
+          name: string;
+          start_date: string;
+        };
         Update: {
-          created_at?: string | null
-          end_date?: string
-          id?: string
-          name?: string
-          start_date?: string
-        }
-        Relationships: []
-      }
-    }
+          created_at?: string | null;
+          end_date?: string;
+          id?: string;
+          name?: string;
+          start_date?: string;
+        };
+        Relationships: [];
+      };
+    };
     Views: {
       poi_avg_ratings: {
         Row: {
-          avg_rating: number | null
-          poi_id: string | null
-          rating_count: number | null
-        }
+          avg_rating: number | null;
+          poi_id: string | null;
+          rating_count: number | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "poi_ratings_poi_id_fkey"
-            columns: ["poi_id"]
-            isOneToOne: false
-            referencedRelation: "pois"
-            referencedColumns: ["id"]
+            foreignKeyName: "poi_ratings_poi_id_fkey";
+            columns: ["poi_id"];
+            isOneToOne: false;
+            referencedRelation: "pois";
+            referencedColumns: ["id"];
           },
-        ]
-      }
-    }
+        ];
+      };
+    };
     Functions: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Enums: {
-      friendship_status: "pending" | "accepted"
-      poi_category:
-        | "food_drink"
-        | "nightlife"
-        | "culture"
-        | "study_spots"
-        | "hidden_gems"
-      visibility_type: "friends" | "community"
-    }
+      friendship_status: "pending" | "accepted";
+      poi_category: "food_drink" | "nightlife" | "culture" | "study_spots" | "hidden_gems";
+      visibility_type: "friends" | "community";
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">];
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
         DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
       DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+      Row: infer R;
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] & DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R;
       }
       ? R
       : never
-    : never
+    : never;
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+      Insert: infer I;
     }
     ? I
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
+        Insert: infer I;
       }
       ? I
       : never
-    : never
+    : never;
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+      Update: infer U;
     }
     ? U
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
+        Update: infer U;
       }
       ? U
       : never
-    : never
+    : never;
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
     | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
     ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+    : never;
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+    : never;
 
 export const Constants = {
   graphql_public: {
@@ -502,14 +489,8 @@ export const Constants = {
   public: {
     Enums: {
       friendship_status: ["pending", "accepted"],
-      poi_category: [
-        "food_drink",
-        "nightlife",
-        "culture",
-        "study_spots",
-        "hidden_gems",
-      ],
+      poi_category: ["food_drink", "nightlife", "culture", "study_spots", "hidden_gems"],
       visibility_type: ["friends", "community"],
     },
   },
-} as const
+} as const;


### PR DESCRIPTION
## Summary

- Install prettier 3.8.3 as a devDependency
- Add `.prettierrc.json` (double quotes, semicolons, trailing commas, 100-char print width)
- Add `.claude/hooks/prettier-format.sh` — runs `prettier --write` on the edited file after every `Write`/`Edit`/`NotebookEdit` tool use; non-blocking, never fails a tool call
- Wire hook into `.claude/settings.json` `PostToolUse` (runs before `tsc-check`)
- Format all existing source files in one pass

## Test plan

- [ ] Edit any `.ts`/`.tsx` file — confirm prettier runs automatically and the file is reformatted on save
- [ ] Confirm `tsc-check` still runs after prettier (both hooks fire in sequence)
- [ ] Confirm tests still pass: `npx jest`