### PR TITLE
feat: enforce check_ins.semester_id NOT NULL (migration 026)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 
 # Project planning docs (local only)
 CLAUDE.md
-docs/
+docs/*
+# Generated reference docs are tracked
+!docs/reference/
 
 # Expo
 node_modules/

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -1,0 +1,181 @@
+# Database Schema Reference
+
+Generated from migrations `001` – `026`.
+
+---
+
+## Enums
+
+### `poi_category`
+`food_drink` | `nightlife` | `culture` | `study_spots` | `hidden_gems`
+
+### `visibility_type`
+`friends` | `community`
+
+### `friendship_status`  *(migration 019)*
+See `friendships.status` — stored as `text` with a `CHECK` constraint (`pending` | `accepted`).
+
+---
+
+## Tables
+
+### `semesters`
+Global academic-semester calendar. Every user and check-in is associated with one semester.
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `gen_random_uuid()` |
+| `name` | `text` | NOT NULL |
+| `start_date` | `date` | NOT NULL |
+| `end_date` | `date` | NOT NULL |
+| `created_at` | `timestamptz` | DEFAULT `now()` |
+
+**RLS**: `SELECT` allowed for all authenticated users.
+
+---
+
+### `profiles`
+One row per auth user (created automatically by `handle_new_user` trigger on signup).
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, FK → `auth.users(id)` CASCADE |
+| `display_name` | `text` | NOT NULL, min length 2 (migration 014) |
+| `avatar_url` | `text` | — |
+| `semester_id` | `uuid` | FK → `semesters(id)` |
+| `created_at` | `timestamptz` | DEFAULT `now()` |
+
+**RLS**: all authenticated users can `SELECT`; users can `INSERT` / `UPDATE` their own row.
+
+---
+
+### `pois`
+Points of interest. IDs are deterministic UUIDv5 values (stable across re-registrations).
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK (explicit — no default) |
+| `name` | `text` | NOT NULL |
+| `description` | `text` | NOT NULL |
+| `category` | `poi_category` | NOT NULL |
+| `lat` | `double precision` | NOT NULL |
+| `lng` | `double precision` | NOT NULL |
+| `created_by` | `uuid` | FK → `profiles(id)` SET NULL, DEFAULT system account |
+| `created_at` | `timestamptz` | DEFAULT `now()` |
+
+**RLS**: `SELECT` for all authenticated users; `INSERT` only for the owning user.
+
+---
+
+### `poi_ratings`
+One rating per (user, POI) pair. No `UPDATE` policy — change a rating by deleting and re-inserting.
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `gen_random_uuid()` |
+| `poi_id` | `uuid` | NOT NULL, FK → `pois(id)` CASCADE |
+| `user_id` | `uuid` | NOT NULL, FK → `profiles(id)` CASCADE |
+| `rating` | `smallint` | NOT NULL, CHECK 1–5 |
+| `comment` | `text` | — |
+| `created_at` | `timestamptz` | DEFAULT `now()` |
+
+**Unique**: `(user_id, poi_id)`.
+
+---
+
+### `check_ins`
+Immutable append-only log of passive geofence check-ins. No `UPDATE` or `DELETE` policies.
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `gen_random_uuid()` |
+| `user_id` | `uuid` | NOT NULL, FK → `auth.users(id)` CASCADE |
+| `poi_id` | `uuid` | NOT NULL, FK → `pois(id)` |
+| `checked_in_at` | `timestamptz` | NOT NULL, DEFAULT `now()` |
+| `semester_id` | `uuid` | NOT NULL, FK → `semesters(id)` |
+
+**Exclusion constraint** (`check_ins_no_rapid_duplicates`): prevents duplicate check-ins at the same (user, POI) within a 5-minute window using `btree_gist`.
+
+**RLS**: users can `SELECT` / `INSERT` their own rows only.
+
+---
+
+### `live_presence`
+Active "I'm at X" broadcasts. Expires 2 hours after creation; dismissed by the user or by expiry.
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `gen_random_uuid()` |
+| `user_id` | `uuid` | NOT NULL, FK → `profiles(id)` CASCADE |
+| `poi_id` | `uuid` | NOT NULL, FK → `pois(id)` CASCADE |
+| `message` | `text` | CHECK `char_length <= 140` |
+| `visible_to` | `visibility_type` | NOT NULL, DEFAULT `'friends'` |
+| `created_at` | `timestamptz` | NOT NULL, DEFAULT `now()` |
+| `dismissed_at` | `timestamptz` | — |
+| `expires_at` | `timestamptz` | NOT NULL, DEFAULT `now() + 2h` (set by trigger) |
+
+**Indexes**: partial indexes on `(user_id)` and `(poi_id)` where `dismissed_at IS NULL`; partial index on `expires_at` where `dismissed_at IS NULL`.
+
+**RLS**: `SELECT` for audience (community = all authenticated; friends = friendship required; always visible to own broadcaster); `INSERT` / `UPDATE` / `DELETE` for own rows.
+
+---
+
+### `presence_joins`
+Records a user's intent to join a live presence broadcast. `confirmed` is set to `true` by the broadcaster upon geofence arrival detection.
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `gen_random_uuid()` |
+| `presence_id` | `uuid` | NOT NULL, FK → `live_presence(id)` CASCADE |
+| `joiner_user_id` | `uuid` | NOT NULL, FK → `profiles(id)` CASCADE |
+| `joined_at` | `timestamptz` | NOT NULL, DEFAULT `now()` |
+| `confirmed` | `boolean` | NOT NULL, DEFAULT `false` |
+
+**Unique**: `(presence_id, joiner_user_id)`.
+
+**Realtime**: enabled on this table.
+
+**RLS**: broadcaster and joiner can `SELECT`; joiner can `INSERT`; broadcaster can `UPDATE` (confirm arrival); joiner can `DELETE`.
+
+---
+
+### `friendships`
+Directed friendship requests; normalised to an undirected pair via `LEAST/GREATEST` unique index.
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `gen_random_uuid()` |
+| `requester_id` | `uuid` | NOT NULL, FK → `profiles(id)` CASCADE |
+| `addressee_id` | `uuid` | NOT NULL, FK → `profiles(id)` CASCADE |
+| `status` | `text` | NOT NULL, CHECK `pending` \| `accepted` |
+| `created_at` | `timestamptz` | NOT NULL, DEFAULT `now()` |
+
+**Check**: `requester_id != addressee_id`.  
+**Unique index**: `(LEAST(requester_id, addressee_id), GREATEST(requester_id, addressee_id))` — prevents both A→B and B→A existing simultaneously.
+
+**Realtime**: enabled on this table.
+
+**RLS**: each user sees only friendships they are party to; requester inserts (`status = 'pending'`); addressee accepts (`pending → accepted`); either party can delete.
+
+---
+
+## Views
+
+### `poi_avg_ratings`
+Materialized-style view aggregating average rating and count per POI.
+
+```sql
+SELECT poi_id, AVG(rating) AS avg_rating, COUNT(*) AS rating_count
+FROM public.poi_ratings
+GROUP BY poi_id;
+```
+
+---
+
+## Key triggers & functions
+
+| Name | Table | Purpose |
+|------|-------|---------|
+| `handle_new_user` | `auth.users` (AFTER INSERT) | Auto-creates `profiles` row and assigns active semester |
+| `trg_live_presence_expires_at` | `live_presence` (BEFORE INSERT) | Derives `expires_at = created_at + 2h` |
+| `checkin_window(ts)` | — | `IMMUTABLE` helper returning a 5-minute `tstzrange` for the exclusion constraint |

--- a/lib/__tests__/checkIns.test.ts
+++ b/lib/__tests__/checkIns.test.ts
@@ -61,17 +61,13 @@ describe("insertCheckIn", () => {
     });
   });
 
-  it("handles null semester_id from profile", async () => {
+  it("throws when profile has no semester_id", async () => {
     const mock = makeMockSupabase({
       profileResult: { data: { semester_id: null }, error: null },
     });
-    await insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID });
 
-    const checkInsFrom = mock.from.mock.results.find(
-      (_r: { value: unknown }, i: number) => mock.from.mock.calls[i][0] === "check_ins",
-    )!.value;
-    expect(checkInsFrom.insert).toHaveBeenCalledWith(
-      expect.objectContaining({ semester_id: null }),
+    await expect(insertCheckIn(asClient(mock), { poiId: MOCK_POI_ID })).rejects.toThrow(
+      "No active semester for user",
     );
   });
 

--- a/lib/checkIns.ts
+++ b/lib/checkIns.ts
@@ -17,6 +17,7 @@ export async function insertCheckIn(
     .eq("id", user.id)
     .single();
   if (profileError) throw new Error(profileError.message);
+  if (!profile.semester_id) throw new Error("No active semester for user");
 
   const { error } = await supabase.from("check_ins").insert({
     user_id: user.id,

--- a/supabase/migrations/026_check_ins_semester_id_not_null.sql
+++ b/supabase/migrations/026_check_ins_semester_id_not_null.sql
@@ -1,0 +1,31 @@
+-- Enforce semester_id NOT NULL on check_ins.
+-- Every check-in must belong to a semester; the column was nullable in 021.
+--
+-- Backfill strategy (two passes):
+--   1. Date-window match: assign the semester whose [start_date, end_date]
+--      contains the check-in's checked_in_at date.
+--   2. Profile fallback: for any rows that fell in a gap between semesters
+--      (e.g. test data), use the owning user's current profile.semester_id.
+--   3. Delete any rows that still have no resolvable semester
+--      (should be empty in practice — captures orphaned rows with no profile).
+
+-- 1. Backfill via semester date window.
+UPDATE public.check_ins ci
+SET semester_id = s.id
+FROM public.semesters s
+WHERE ci.semester_id IS NULL
+  AND ci.checked_in_at::date BETWEEN s.start_date AND s.end_date;
+
+-- 2. Fallback: use the owning user's profile semester for rows not in any window.
+UPDATE public.check_ins ci
+SET semester_id = p.semester_id
+FROM public.profiles p
+WHERE ci.semester_id IS NULL
+  AND ci.user_id = p.id
+  AND p.semester_id IS NOT NULL;
+
+-- 3. Drop any remaining unresolvable rows.
+DELETE FROM public.check_ins WHERE semester_id IS NULL;
+
+-- 4. Enforce NOT NULL now that every row has a value.
+ALTER TABLE public.check_ins ALTER COLUMN semester_id SET NOT NULL;


### PR DESCRIPTION
Closes #31

## Changes

- Migration 026: two-pass backfill (date-window + profile fallback), then DELETE unresolvable rows, then SET NOT NULL
- `lib/checkIns.ts`: throw early when `profile.semester_id` is null
- `lib/__tests__/checkIns.test.ts`: update null-semester test to expect the new error
- `docs/reference/schema.md`: generated schema reference (migrations 001–026)
- `.gitignore`: allow `docs/reference/` to be tracked

Generated with [Claude Code](https://claude.ai/code)