### PR TITLE
feat(passport): semester stats screen, badge grid, and detail modal

### DIFF
--- a/app/(app)/(tabs)/passport.tsx
+++ b/app/(app)/(tabs)/passport.tsx
@@ -1,13 +1,22 @@
-import { useLayoutEffect } from "react";
-import { View, Text, Pressable, StyleSheet } from "react-native";
+import { useState, useLayoutEffect } from "react";
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { useRouter, useNavigation } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useAuth } from "@/hooks/useAuth";
+import { usePassportStats } from "@/hooks/usePassportStats";
+import { BADGE_CATALOG, type BadgeDefinition } from "@/lib/badges/catalog";
+import { StatCard } from "@/components/passport/StatCard";
+import { BadgeCell } from "@/components/passport/BadgeCell";
 
 export default function PassportScreen() {
   const router = useRouter();
   const navigation = useNavigation();
   const { signOut } = useAuth();
+  const stats = usePassportStats();
+
+  // Selected badge drives BadgeDetailModal — wired in the next sub-feature.
+  const [selectedBadge, setSelectedBadge] = useState<BadgeDefinition | null>(null);
+  void selectedBadge; // used by BadgeDetailModal (next sub-feature)
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -20,18 +29,125 @@ export default function PassportScreen() {
   }, [navigation]);
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>Passport — coming in Phase 6</Text>
-      <Pressable onPress={signOut}>
+    <ScrollView
+      style={styles.scroll}
+      contentContainerStyle={styles.content}
+      testID="passport-screen"
+    >
+      {/* ── Stats section ──────────────────────────────────────────────── */}
+      <Text style={styles.sectionLabel}>This Semester</Text>
+
+      {stats.isLoading ? (
+        <ActivityIndicator
+          size="small"
+          color="#131313"
+          style={styles.loader}
+          testID="stats-loading"
+        />
+      ) : (
+        <>
+          {stats.error && (
+            <Text style={styles.errorText} testID="stats-error">
+              {stats.error}
+            </Text>
+          )}
+
+          <View style={styles.statsRow}>
+            <StatCard label="Check-ins" value={stats.totalCheckIns} testID="stat-total-check-ins" />
+            <View style={styles.statGap} />
+            <StatCard label="Places Visited" value={stats.uniquePois} testID="stat-unique-pois" />
+          </View>
+
+          <StatCard
+            label="Most Visited"
+            value={stats.mostVisited?.name ?? "—"}
+            compact
+            testID="stat-most-visited"
+          />
+        </>
+      )}
+
+      {/* ── Badges section ─────────────────────────────────────────────── */}
+      <Text style={[styles.sectionLabel, styles.badgesSectionLabel]}>Badges</Text>
+      <Text style={styles.badgesHint}>
+        {/* Badge count will be driven by the engine once it ships. */}0 / {BADGE_CATALOG.length}{" "}
+        earned
+      </Text>
+
+      <View style={styles.badgeGrid} testID="badge-grid">
+        {BADGE_CATALOG.map((badge) => (
+          <BadgeCell
+            key={badge.id}
+            badge={badge}
+            unlocked={false}
+            onPress={() => setSelectedBadge(badge)}
+          />
+        ))}
+      </View>
+
+      {/* ── Footer ─────────────────────────────────────────────────────── */}
+      <Pressable onPress={signOut} style={styles.signOutButton} accessibilityRole="button">
         <Text style={styles.signOut}>Sign out</Text>
       </Pressable>
-    </View>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: "#fff" },
-  text: { fontSize: 16, color: "#999", marginBottom: 24 },
-  headerButton: { marginRight: 16 },
-  signOut: { color: "#FF3B30", fontSize: 16 },
+  scroll: {
+    flex: 1,
+    backgroundColor: "#fff",
+  },
+  content: {
+    paddingHorizontal: 16,
+    paddingTop: 24,
+    paddingBottom: 48,
+  },
+  sectionLabel: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#999",
+    textTransform: "uppercase",
+    letterSpacing: 0.8,
+    marginBottom: 12,
+  },
+  badgesSectionLabel: {
+    marginTop: 32,
+  },
+  badgesHint: {
+    fontSize: 13,
+    color: "#999",
+    marginBottom: 16,
+  },
+  loader: {
+    marginVertical: 24,
+  },
+  errorText: {
+    fontSize: 14,
+    color: "#E51E1E",
+    marginBottom: 12,
+  },
+  statsRow: {
+    flexDirection: "row",
+    marginBottom: 10,
+  },
+  statGap: {
+    width: 10,
+  },
+  badgeGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    marginHorizontal: -4,
+  },
+  headerButton: {
+    marginRight: 16,
+  },
+  signOutButton: {
+    marginTop: 32,
+    alignSelf: "center",
+  },
+  signOut: {
+    color: "#E51E1E",
+    fontSize: 15,
+  },
 });

--- a/app/(app)/(tabs)/passport.tsx
+++ b/app/(app)/(tabs)/passport.tsx
@@ -7,6 +7,7 @@ import { usePassportStats } from "@/hooks/usePassportStats";
 import { BADGE_CATALOG, type BadgeDefinition } from "@/lib/badges/catalog";
 import { StatCard } from "@/components/passport/StatCard";
 import { BadgeCell } from "@/components/passport/BadgeCell";
+import { BadgeDetailModal } from "@/components/passport/BadgeDetailModal";
 
 export default function PassportScreen() {
   const router = useRouter();
@@ -14,9 +15,7 @@ export default function PassportScreen() {
   const { signOut } = useAuth();
   const stats = usePassportStats();
 
-  // Selected badge drives BadgeDetailModal — wired in the next sub-feature.
   const [selectedBadge, setSelectedBadge] = useState<BadgeDefinition | null>(null);
-  void selectedBadge; // used by BadgeDetailModal (next sub-feature)
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -29,74 +28,89 @@ export default function PassportScreen() {
   }, [navigation]);
 
   return (
-    <ScrollView
-      style={styles.scroll}
-      contentContainerStyle={styles.content}
-      testID="passport-screen"
-    >
-      {/* ── Stats section ──────────────────────────────────────────────── */}
-      <Text style={styles.sectionLabel}>This Semester</Text>
+    <View style={styles.root}>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        testID="passport-screen"
+      >
+        {/* ── Stats section ──────────────────────────────────────────────── */}
+        <Text style={styles.sectionLabel}>This Semester</Text>
 
-      {stats.isLoading ? (
-        <ActivityIndicator
-          size="small"
-          color="#131313"
-          style={styles.loader}
-          testID="stats-loading"
-        />
-      ) : (
-        <>
-          {stats.error && (
-            <Text style={styles.errorText} testID="stats-error">
-              {stats.error}
-            </Text>
-          )}
-
-          <View style={styles.statsRow}>
-            <StatCard label="Check-ins" value={stats.totalCheckIns} testID="stat-total-check-ins" />
-            <View style={styles.statGap} />
-            <StatCard label="Places Visited" value={stats.uniquePois} testID="stat-unique-pois" />
-          </View>
-
-          <StatCard
-            label="Most Visited"
-            value={stats.mostVisited?.name ?? "—"}
-            compact
-            testID="stat-most-visited"
+        {stats.isLoading ? (
+          <ActivityIndicator
+            size="small"
+            color="#131313"
+            style={styles.loader}
+            testID="stats-loading"
           />
-        </>
-      )}
+        ) : (
+          <>
+            {stats.error && (
+              <Text style={styles.errorText} testID="stats-error">
+                {stats.error}
+              </Text>
+            )}
 
-      {/* ── Badges section ─────────────────────────────────────────────── */}
-      <Text style={[styles.sectionLabel, styles.badgesSectionLabel]}>Badges</Text>
-      <Text style={styles.badgesHint}>
-        {/* Badge count will be driven by the engine once it ships. */}0 / {BADGE_CATALOG.length}{" "}
-        earned
-      </Text>
+            <View style={styles.statsRow}>
+              <StatCard
+                label="Check-ins"
+                value={stats.totalCheckIns}
+                testID="stat-total-check-ins"
+              />
+              <View style={styles.statGap} />
+              <StatCard label="Places Visited" value={stats.uniquePois} testID="stat-unique-pois" />
+            </View>
 
-      <View style={styles.badgeGrid} testID="badge-grid">
-        {BADGE_CATALOG.map((badge) => (
-          <BadgeCell
-            key={badge.id}
-            badge={badge}
-            unlocked={false}
-            onPress={() => setSelectedBadge(badge)}
-          />
-        ))}
-      </View>
+            <StatCard
+              label="Most Visited"
+              value={stats.mostVisited?.name ?? "—"}
+              compact
+              testID="stat-most-visited"
+            />
+          </>
+        )}
 
-      {/* ── Footer ─────────────────────────────────────────────────────── */}
-      <Pressable onPress={signOut} style={styles.signOutButton} accessibilityRole="button">
-        <Text style={styles.signOut}>Sign out</Text>
-      </Pressable>
-    </ScrollView>
+        {/* ── Badges section ─────────────────────────────────────────────── */}
+        <Text style={[styles.sectionLabel, styles.badgesSectionLabel]}>Badges</Text>
+        <Text style={styles.badgesHint}>
+          {/* Badge count will be driven by the engine once it ships. */}0 / {BADGE_CATALOG.length}{" "}
+          earned
+        </Text>
+
+        <View style={styles.badgeGrid} testID="badge-grid">
+          {BADGE_CATALOG.map((badge) => (
+            <BadgeCell
+              key={badge.id}
+              badge={badge}
+              unlocked={false}
+              onPress={() => setSelectedBadge(badge)}
+            />
+          ))}
+        </View>
+
+        {/* ── Footer ─────────────────────────────────────────────────────── */}
+        <Pressable onPress={signOut} style={styles.signOutButton} accessibilityRole="button">
+          <Text style={styles.signOut}>Sign out</Text>
+        </Pressable>
+      </ScrollView>
+
+      <BadgeDetailModal
+        badge={selectedBadge}
+        unlocked={false}
+        onClose={() => setSelectedBadge(null)}
+      />
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  scroll: {
+  root: {
     flex: 1,
     backgroundColor: "#fff",
+  },
+  scroll: {
+    flex: 1,
   },
   content: {
     paddingHorizontal: 16,

--- a/components/passport/BadgeCell.tsx
+++ b/components/passport/BadgeCell.tsx
@@ -1,0 +1,52 @@
+import { Pressable, Text, StyleSheet } from "react-native";
+import type { BadgeDefinition } from "@/lib/badges/catalog";
+
+type Props = {
+  badge: BadgeDefinition;
+  /** When false (default) the cell renders in locked/greyed state. */
+  unlocked?: boolean;
+  onPress: () => void;
+};
+
+export function BadgeCell({ badge, unlocked = false, onPress }: Props) {
+  return (
+    <Pressable
+      style={styles.cell}
+      onPress={onPress}
+      testID={`badge-cell-${badge.id}`}
+      accessibilityLabel={unlocked ? badge.name : `${badge.name} (locked)`}
+    >
+      <Text style={[styles.icon, !unlocked && styles.iconLocked]}>{badge.icon}</Text>
+      <Text style={[styles.name, !unlocked && styles.nameLocked]} numberOfLines={2}>
+        {badge.name}
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  cell: {
+    width: "25%",
+    alignItems: "center",
+    paddingVertical: 12,
+    paddingHorizontal: 4,
+    minHeight: 48,
+  },
+  icon: {
+    fontSize: 30,
+    marginBottom: 6,
+  },
+  iconLocked: {
+    opacity: 0.25,
+  },
+  name: {
+    fontSize: 10,
+    fontWeight: "600",
+    color: "#131313",
+    textAlign: "center",
+    lineHeight: 14,
+  },
+  nameLocked: {
+    color: "#C0C0C0",
+  },
+});

--- a/components/passport/BadgeDetailModal.tsx
+++ b/components/passport/BadgeDetailModal.tsx
@@ -16,6 +16,7 @@ export function BadgeDetailModal({ badge, unlocked = false, onClose }: Props) {
       animationType="fade"
       statusBarTranslucent
       onRequestClose={onClose}
+      testID="badge-modal"
     >
       <Pressable style={styles.backdrop} onPress={onClose} testID="badge-modal-backdrop">
         {/* Inner Pressable prevents tap-through closing when tapping the card itself */}

--- a/components/passport/BadgeDetailModal.tsx
+++ b/components/passport/BadgeDetailModal.tsx
@@ -1,0 +1,168 @@
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import type { BadgeDefinition } from "@/lib/badges/catalog";
+
+type Props = {
+  badge: BadgeDefinition | null;
+  /** When false (default) the badge renders in locked state. */
+  unlocked?: boolean;
+  onClose: () => void;
+};
+
+export function BadgeDetailModal({ badge, unlocked = false, onClose }: Props) {
+  return (
+    <Modal
+      visible={badge !== null}
+      transparent
+      animationType="fade"
+      statusBarTranslucent
+      onRequestClose={onClose}
+    >
+      <Pressable style={styles.backdrop} onPress={onClose} testID="badge-modal-backdrop">
+        {/* Inner Pressable prevents tap-through closing when tapping the card itself */}
+        <Pressable
+          style={styles.card}
+          onPress={(e) => e.stopPropagation()}
+          testID="badge-modal-card"
+        >
+          {badge !== null && (
+            <ScrollView
+              showsVerticalScrollIndicator={false}
+              bounces={false}
+              contentContainerStyle={styles.cardContent}
+            >
+              {/* Close button — kept inside card bounds to ensure touch target registers on Android */}
+              <Pressable style={styles.closeButton} onPress={onClose} testID="badge-modal-close">
+                <Text style={styles.closeIcon}>✕</Text>
+              </Pressable>
+
+              {/* Icon */}
+              <Text style={[styles.icon, !unlocked && styles.iconLocked]}>{badge.icon}</Text>
+
+              {/* Name */}
+              <Text style={styles.name}>{badge.name}</Text>
+
+              {/* Status chip */}
+              <View style={[styles.chip, unlocked ? styles.chipUnlocked : styles.chipLocked]}>
+                <Text
+                  style={[
+                    styles.chipText,
+                    unlocked ? styles.chipTextUnlocked : styles.chipTextLocked,
+                  ]}
+                >
+                  {unlocked ? "Earned" : "Locked"}
+                </Text>
+              </View>
+
+              {/* Description */}
+              <Text style={styles.description}>{badge.description}</Text>
+
+              {/* How to earn */}
+              {!unlocked && (
+                <View style={styles.hintBox}>
+                  <Text style={styles.hintLabel}>How to earn</Text>
+                  <Text style={styles.hintText}>{badge.criteriaHint}</Text>
+                </View>
+              )}
+            </ScrollView>
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 24,
+  },
+  card: {
+    width: "100%",
+    maxWidth: 360,
+    backgroundColor: "#fff",
+    borderRadius: 20,
+    maxHeight: "80%",
+  },
+  cardContent: {
+    alignItems: "center",
+    paddingTop: 16,
+    paddingBottom: 32,
+    paddingHorizontal: 24,
+  },
+  closeButton: {
+    alignSelf: "flex-end",
+    padding: 8,
+    marginBottom: 8,
+  },
+  closeIcon: {
+    fontSize: 18,
+    color: "#888",
+  },
+  icon: {
+    fontSize: 56,
+    marginBottom: 12,
+  },
+  iconLocked: {
+    opacity: 0.25,
+  },
+  name: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#131313",
+    textAlign: "center",
+    marginBottom: 10,
+  },
+  chip: {
+    borderRadius: 100,
+    paddingVertical: 4,
+    paddingHorizontal: 14,
+    marginBottom: 20,
+  },
+  chipUnlocked: {
+    backgroundColor: "#D4EDDA",
+  },
+  chipLocked: {
+    backgroundColor: "#F0F0F0",
+  },
+  chipText: {
+    fontSize: 12,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  chipTextUnlocked: {
+    color: "#1A7A35",
+  },
+  chipTextLocked: {
+    color: "#888",
+  },
+  description: {
+    fontSize: 14,
+    color: "#444",
+    textAlign: "center",
+    lineHeight: 20,
+    marginBottom: 20,
+  },
+  hintBox: {
+    width: "100%",
+    backgroundColor: "#F5F5F5",
+    borderRadius: 12,
+    padding: 14,
+  },
+  hintLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: "#999",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    marginBottom: 6,
+  },
+  hintText: {
+    fontSize: 13,
+    color: "#555",
+    lineHeight: 18,
+  },
+});

--- a/components/passport/StatCard.tsx
+++ b/components/passport/StatCard.tsx
@@ -1,0 +1,58 @@
+import { View, Text, StyleSheet } from "react-native";
+
+type Props = {
+  label: string;
+  value: string | number;
+  /** Render value at a smaller font size — use for long text values (e.g. place names). */
+  compact?: boolean;
+  testID?: string;
+};
+
+export function StatCard({ label, value, compact = false, testID }: Props) {
+  return (
+    <View style={styles.card}>
+      <Text
+        style={[styles.value, compact && styles.valueCompact]}
+        testID={testID}
+        numberOfLines={2}
+        adjustsFontSizeToFit
+      >
+        {value}
+      </Text>
+      <Text style={styles.label} numberOfLines={1}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flex: 1,
+    backgroundColor: "#F5F5F5",
+    borderRadius: 16,
+    paddingVertical: 16,
+    paddingHorizontal: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 80,
+  },
+  value: {
+    fontSize: 28,
+    fontWeight: "700",
+    color: "#131313",
+    marginBottom: 4,
+    textAlign: "center",
+  },
+  valueCompact: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  label: {
+    fontSize: 11,
+    color: "#999",
+    textAlign: "center",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+});

--- a/components/passport/__tests__/BadgeDetailModal.test.tsx
+++ b/components/passport/__tests__/BadgeDetailModal.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { act, create, ReactTestInstance } from "react-test-renderer";
+import { BadgeDetailModal } from "../BadgeDetailModal";
+import type { BadgeDefinition } from "@/lib/badges/catalog";
+
+const MOCK_BADGE: BadgeDefinition = {
+  id: "first_check_in",
+  name: "First Step",
+  description: "Made your very first check-in.",
+  criteriaHint: "Check in anywhere for the first time.",
+  category: "milestone",
+  icon: "👣",
+};
+
+function allTextNodes(root: ReturnType<typeof create>): unknown[] {
+  return root.root
+    .findAll((n: ReactTestInstance) => (n.type as string) === "Text")
+    .map((n) => n.props.children);
+}
+
+describe("BadgeDetailModal", () => {
+  it("is not visible when badge is null", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<BadgeDetailModal badge={null} onClose={() => {}} />);
+    });
+
+    // Query by testID to avoid relying on internal RN Modal host component type names.
+    const modal = root!.root.findAll((n: ReactTestInstance) => n.props.testID === "badge-modal");
+    expect(modal.length).toBeGreaterThanOrEqual(1);
+    expect(modal[0].props.visible).toBe(false);
+  });
+
+  it("shows badge name and Locked chip when unlocked=false (default)", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<BadgeDetailModal badge={MOCK_BADGE} onClose={() => {}} />);
+    });
+
+    const texts = allTextNodes(root!);
+    expect(texts).toContain(MOCK_BADGE.name);
+    expect(texts).toContain("Locked");
+  });
+
+  it("shows criteriaHint in the hint box when locked", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<BadgeDetailModal badge={MOCK_BADGE} unlocked={false} onClose={() => {}} />);
+    });
+
+    expect(allTextNodes(root!)).toContain(MOCK_BADGE.criteriaHint);
+  });
+
+  it("shows Earned chip and hides criteriaHint when unlocked=true", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<BadgeDetailModal badge={MOCK_BADGE} unlocked={true} onClose={() => {}} />);
+    });
+
+    const texts = allTextNodes(root!);
+    expect(texts).toContain("Earned");
+    expect(texts).not.toContain(MOCK_BADGE.criteriaHint);
+  });
+
+  it("renders close button", () => {
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<BadgeDetailModal badge={MOCK_BADGE} onClose={() => {}} />);
+    });
+
+    const closeButtons = root!.root.findAll(
+      (n: ReactTestInstance) => n.props.testID === "badge-modal-close",
+    );
+    expect(closeButtons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("calls onClose when close button is pressed", () => {
+    const onClose = jest.fn();
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<BadgeDetailModal badge={MOCK_BADGE} onClose={onClose} />);
+    });
+
+    act(() => {
+      root!.root
+        .findAll((n: ReactTestInstance) => n.props.testID === "badge-modal-close")[0]
+        .props.onPress();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when backdrop is pressed", () => {
+    const onClose = jest.fn();
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<BadgeDetailModal badge={MOCK_BADGE} onClose={onClose} />);
+    });
+
+    act(() => {
+      root!.root
+        .findAll((n: ReactTestInstance) => n.props.testID === "badge-modal-backdrop")[0]
+        .props.onPress();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hooks/__tests__/usePassportStats.test.ts
+++ b/hooks/__tests__/usePassportStats.test.ts
@@ -1,12 +1,12 @@
 /**
  * Tests for usePassportStats hook.
  *
- * Two Supabase queries under test:
+ * Two Supabase operations under test:
  *   1. profiles → select(semester_id) → eq(id) → single()
- *   2. check_ins → select(poi_id, checked_in_at, pois(name)) → eq(user_id) → eq(semester_id) → order()
+ *   2. rpc("get_passport_stats", { p_semester_id }) → single()
  *
- * The mock branches on the table name (same pattern as useLivePresences.test.ts).
- * Variables referenced inside jest.mock() factories must be mock-prefixed.
+ * Variables referenced inside jest.mock() factories must be mock-prefixed
+ * (Jest hoisting requirement).
  *
  * IMPORTANT: Always use result.current (not destructured `current`) when asserting
  * values that change after async state updates. Destructuring captures a stale
@@ -21,7 +21,7 @@ import { act, create } from "react-test-renderer";
 // Mock leaf fns
 // ---------------------------------------------------------------------------
 const mockSingleFn = jest.fn(); // profiles query terminal
-const mockOrderFn = jest.fn(); // check_ins query terminal
+const mockRpcSingleFn = jest.fn(); // get_passport_stats RPC terminal
 const mockUseAuth = jest.fn();
 
 // ---------------------------------------------------------------------------
@@ -37,17 +37,9 @@ jest.mock("@/lib/supabase", () => ({
           })),
         };
       }
-      // check_ins
-      return {
-        select: jest.fn(() => ({
-          eq: jest.fn(() => ({
-            eq: jest.fn(() => ({
-              order: mockOrderFn,
-            })),
-          })),
-        })),
-      };
+      throw new Error(`Unexpected table in mock: ${table}`);
     }),
+    rpc: jest.fn(() => ({ single: mockRpcSingleFn })),
   },
 }));
 
@@ -89,9 +81,9 @@ function renderHook<T>(useHook: () => T): HookResult<T> {
 
 async function flush() {
   // setImmediate fires after all pending microtasks drain — needed because the hook
-  // has two sequential awaits (profile query → check_ins query). A single
-  // Promise.resolve() tick only resolves the first; setImmediate lets the full
-  // microtask queue empty before act processes state updates.
+  // has two sequential awaits (profile query → RPC). A single Promise.resolve() tick
+  // only resolves the first; setImmediate lets the full microtask queue empty before
+  // act processes state updates.
   await act(async () => {
     await new Promise<void>((resolve) => setImmediate(resolve));
   });
@@ -103,11 +95,20 @@ async function flush() {
 const SEMESTER_ID = "sem-2026";
 const USER_ID = "user-1";
 
-function makeCheckIn(poiId: string, poiName: string, checkedInAt: string) {
+function makeRpcRow(
+  overrides?: Partial<{
+    total_check_ins: number;
+    unique_pois: number;
+    most_visited_name: string | null;
+    most_visited_count: number | null;
+  }>,
+) {
   return {
-    poi_id: poiId,
-    checked_in_at: checkedInAt,
-    pois: { name: poiName },
+    total_check_ins: 0,
+    unique_pois: 0,
+    most_visited_name: null,
+    most_visited_count: null,
+    ...overrides,
   };
 }
 
@@ -120,9 +121,9 @@ beforeEach(() => {
   mockSingleFn.mockResolvedValue({ data: { semester_id: SEMESTER_ID }, error: null });
 });
 
-describe("usePassportStats — authenticated user with active semester", () => {
-  it("returns zeros when there are no check-ins", async () => {
-    mockOrderFn.mockResolvedValue({ data: [], error: null });
+describe("usePassportStats — RPC response mapping", () => {
+  it("returns zeros when RPC returns zero stats", async () => {
+    mockRpcSingleFn.mockResolvedValue({ data: makeRpcRow(), error: null });
 
     const result = renderHook(() => usePassportStats());
     await flush();
@@ -133,89 +134,57 @@ describe("usePassportStats — authenticated user with active semester", () => {
     expect(result.current.error).toBeNull();
   });
 
-  it("counts total check-ins correctly", async () => {
-    mockOrderFn.mockResolvedValue({
-      data: [
-        makeCheckIn("poi-1", "Paludan", "2026-03-10T12:00:00Z"),
-        makeCheckIn("poi-1", "Paludan", "2026-03-11T12:00:00Z"),
-        makeCheckIn("poi-2", "La Banchina", "2026-03-12T12:00:00Z"),
-      ],
+  it("maps total_check_ins and unique_pois from RPC row", async () => {
+    mockRpcSingleFn.mockResolvedValue({
+      data: makeRpcRow({ total_check_ins: 7, unique_pois: 4 }),
       error: null,
     });
 
     const result = renderHook(() => usePassportStats());
     await flush();
 
-    expect(result.current.totalCheckIns).toBe(3);
+    expect(result.current.totalCheckIns).toBe(7);
+    expect(result.current.uniquePois).toBe(4);
   });
 
-  it("counts unique POIs correctly", async () => {
-    mockOrderFn.mockResolvedValue({
-      data: [
-        makeCheckIn("poi-1", "Paludan", "2026-03-10T12:00:00Z"),
-        makeCheckIn("poi-1", "Paludan", "2026-03-11T12:00:00Z"),
-        makeCheckIn("poi-2", "La Banchina", "2026-03-12T12:00:00Z"),
-        makeCheckIn("poi-3", "Gasoline Grill", "2026-03-13T12:00:00Z"),
-      ],
+  it("maps most_visited_name + count to mostVisited when present", async () => {
+    mockRpcSingleFn.mockResolvedValue({
+      data: makeRpcRow({ most_visited_name: "Paludan", most_visited_count: 3 }),
       error: null,
     });
 
     const result = renderHook(() => usePassportStats());
     await flush();
 
-    expect(result.current.uniquePois).toBe(3);
+    expect(result.current.mostVisited).toEqual({ name: "Paludan", count: 3 });
   });
 
-  it("returns the POI with the most visits as mostVisited", async () => {
-    mockOrderFn.mockResolvedValue({
-      data: [
-        makeCheckIn("poi-1", "Paludan", "2026-03-13T12:00:00Z"),
-        makeCheckIn("poi-2", "La Banchina", "2026-03-12T12:00:00Z"),
-        makeCheckIn("poi-2", "La Banchina", "2026-03-11T12:00:00Z"),
-        makeCheckIn("poi-1", "Paludan", "2026-03-10T12:00:00Z"),
-        makeCheckIn("poi-2", "La Banchina", "2026-03-09T12:00:00Z"),
-      ],
+  it("sets mostVisited null when most_visited_name is null", async () => {
+    mockRpcSingleFn.mockResolvedValue({
+      data: makeRpcRow({ total_check_ins: 5, most_visited_name: null }),
       error: null,
     });
 
     const result = renderHook(() => usePassportStats());
     await flush();
 
-    expect(result.current.mostVisited).toEqual({ name: "La Banchina", count: 3 });
+    expect(result.current.mostVisited).toBeNull();
   });
 
-  it("tiebreaks by most recent check-in when two POIs share top count", async () => {
-    // poi-1 and poi-2 both have 2 visits; poi-1's most recent is later → wins.
-    mockOrderFn.mockResolvedValue({
-      data: [
-        makeCheckIn("poi-1", "Paludan", "2026-03-15T12:00:00Z"), // most recent overall
-        makeCheckIn("poi-2", "La Banchina", "2026-03-14T12:00:00Z"),
-        makeCheckIn("poi-1", "Paludan", "2026-03-10T12:00:00Z"),
-        makeCheckIn("poi-2", "La Banchina", "2026-03-09T12:00:00Z"),
-      ],
-      error: null,
-    });
+  it("sets error state when RPC fails", async () => {
+    mockRpcSingleFn.mockResolvedValue({ data: null, error: { message: "rpc error" } });
 
     const result = renderHook(() => usePassportStats());
     await flush();
 
-    expect(result.current.mostVisited?.name).toBe("Paludan");
-    expect(result.current.mostVisited?.count).toBe(2);
-  });
-
-  it("sets error state when check_ins query fails", async () => {
-    mockOrderFn.mockResolvedValue({ data: null, error: { message: "network error" } });
-
-    const result = renderHook(() => usePassportStats());
-    await flush();
-
-    expect(result.current.error).toBe("network error");
+    expect(result.current.error).toBe("rpc error");
     expect(result.current.totalCheckIns).toBe(0);
+    expect(result.current.isLoading).toBe(false);
   });
 });
 
 describe("usePassportStats — edge cases", () => {
-  it("returns zeros when profile has no active semester (semester_id null)", async () => {
+  it("returns zeros and skips RPC when profile has no active semester", async () => {
     mockSingleFn.mockResolvedValue({ data: { semester_id: null }, error: null });
 
     const result = renderHook(() => usePassportStats());
@@ -224,8 +193,8 @@ describe("usePassportStats — edge cases", () => {
     expect(result.current.totalCheckIns).toBe(0);
     expect(result.current.uniquePois).toBe(0);
     expect(result.current.mostVisited).toBeNull();
-    // check_ins query must NOT have been called
-    expect(mockOrderFn).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(mockRpcSingleFn).not.toHaveBeenCalled();
   });
 
   it("returns zeros and no error when user is not authenticated", async () => {
@@ -241,13 +210,14 @@ describe("usePassportStats — edge cases", () => {
     expect(mockSingleFn).not.toHaveBeenCalled();
   });
 
-  it("sets error state when profiles query fails", async () => {
+  it("sets error state and skips RPC when profiles query fails", async () => {
     mockSingleFn.mockResolvedValue({ data: null, error: { message: "profile fetch failed" } });
 
     const result = renderHook(() => usePassportStats());
     await flush();
 
     expect(result.current.error).toBe("profile fetch failed");
-    expect(mockOrderFn).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(mockRpcSingleFn).not.toHaveBeenCalled();
   });
 });

--- a/hooks/__tests__/usePassportStats.test.ts
+++ b/hooks/__tests__/usePassportStats.test.ts
@@ -181,7 +181,7 @@ describe("usePassportStats — authenticated user with active semester", () => {
     const result = renderHook(() => usePassportStats());
     await flush();
 
-    expect(result.current.mostVisited).toEqual({ poiId: "poi-2", name: "La Banchina", count: 3 });
+    expect(result.current.mostVisited).toEqual({ name: "La Banchina", count: 3 });
   });
 
   it("tiebreaks by most recent check-in when two POIs share top count", async () => {
@@ -199,7 +199,6 @@ describe("usePassportStats — authenticated user with active semester", () => {
     const result = renderHook(() => usePassportStats());
     await flush();
 
-    expect(result.current.mostVisited?.poiId).toBe("poi-1");
     expect(result.current.mostVisited?.name).toBe("Paludan");
     expect(result.current.mostVisited?.count).toBe(2);
   });

--- a/hooks/__tests__/usePassportStats.test.ts
+++ b/hooks/__tests__/usePassportStats.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for usePassportStats hook.
+ *
+ * Two Supabase queries under test:
+ *   1. profiles → select(semester_id) → eq(id) → single()
+ *   2. check_ins → select(poi_id, checked_in_at, pois(name)) → eq(user_id) → eq(semester_id) → order()
+ *
+ * The mock branches on the table name (same pattern as useLivePresences.test.ts).
+ * Variables referenced inside jest.mock() factories must be mock-prefixed.
+ *
+ * IMPORTANT: Always use result.current (not destructured `current`) when asserting
+ * values that change after async state updates. Destructuring captures a stale
+ * reference to the first render's return object; result.current is updated on
+ * every re-render.
+ */
+
+import React from "react";
+import { act, create } from "react-test-renderer";
+
+// ---------------------------------------------------------------------------
+// Mock leaf fns
+// ---------------------------------------------------------------------------
+const mockSingleFn = jest.fn(); // profiles query terminal
+const mockOrderFn = jest.fn(); // check_ins query terminal
+const mockUseAuth = jest.fn();
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+jest.mock("@/lib/supabase", () => ({
+  supabase: {
+    from: jest.fn((table: string) => {
+      if (table === "profiles") {
+        return {
+          select: jest.fn(() => ({
+            eq: jest.fn(() => ({ single: mockSingleFn })),
+          })),
+        };
+      }
+      // check_ins
+      return {
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              order: mockOrderFn,
+            })),
+          })),
+        })),
+      };
+    }),
+  },
+}));
+
+jest.mock("@/hooks/useAuth", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+import { usePassportStats } from "../usePassportStats";
+
+// ---------------------------------------------------------------------------
+// renderHook + flush helpers
+// ---------------------------------------------------------------------------
+type HookResult<T> = { current: T };
+
+// Store the renderer so afterEach can unmount it, preventing async state
+// updates from landing on an orphaned tree and silently swallowing failures.
+let activeRenderer: ReturnType<typeof create> | null = null;
+
+afterEach(() => {
+  if (activeRenderer) {
+    act(() => {
+      activeRenderer!.unmount();
+    });
+    activeRenderer = null;
+  }
+});
+
+function renderHook<T>(useHook: () => T): HookResult<T> {
+  const result: HookResult<T> = { current: undefined as unknown as T };
+  function TestComponent() {
+    result.current = useHook();
+    return null;
+  }
+  act(() => {
+    activeRenderer = create(React.createElement(TestComponent));
+  });
+  return result;
+}
+
+async function flush() {
+  // setImmediate fires after all pending microtasks drain — needed because the hook
+  // has two sequential awaits (profile query → check_ins query). A single
+  // Promise.resolve() tick only resolves the first; setImmediate lets the full
+  // microtask queue empty before act processes state updates.
+  await act(async () => {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const SEMESTER_ID = "sem-2026";
+const USER_ID = "user-1";
+
+function makeCheckIn(poiId: string, poiName: string, checkedInAt: string) {
+  return {
+    poi_id: poiId,
+    checked_in_at: checkedInAt,
+    pois: { name: poiName },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseAuth.mockReturnValue({ session: { user: { id: USER_ID } } });
+  mockSingleFn.mockResolvedValue({ data: { semester_id: SEMESTER_ID }, error: null });
+});
+
+describe("usePassportStats — authenticated user with active semester", () => {
+  it("returns zeros when there are no check-ins", async () => {
+    mockOrderFn.mockResolvedValue({ data: [], error: null });
+
+    const result = renderHook(() => usePassportStats());
+    await flush();
+
+    expect(result.current.totalCheckIns).toBe(0);
+    expect(result.current.uniquePois).toBe(0);
+    expect(result.current.mostVisited).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("counts total check-ins correctly", async () => {
+    mockOrderFn.mockResolvedValue({
+      data: [
+        makeCheckIn("poi-1", "Paludan", "2026-03-10T12:00:00Z"),
+        makeCheckIn("poi-1", "Paludan", "2026-03-11T12:00:00Z"),
+        makeCheckIn("poi-2", "La Banchina", "2026-03-12T12:00:00Z"),
+      ],
+      error: null,
+    });
+
+    const result = renderHook(() => usePassportStats());
+    await flush();
+
+    expect(result.current.totalCheckIns).toBe(3);
+  });
+
+  it("counts unique POIs correctly", async () => {
+    mockOrderFn.mockResolvedValue({
+      data: [
+        makeCheckIn("poi-1", "Paludan", "2026-03-10T12:00:00Z"),
+        makeCheckIn("poi-1", "Paludan", "2026-03-11T12:00:00Z"),
+        makeCheckIn("poi-2", "La Banchina", "2026-03-12T12:00:00Z"),
+        makeCheckIn("poi-3", "Gasoline Grill", "2026-03-13T12:00:00Z"),
+      ],
+      error: null,
+    });
+
+    const result = renderHook(() => usePassportStats());
+    await flush();
+
+    expect(result.current.uniquePois).toBe(3);
+  });
+
+  it("returns the POI with the most visits as mostVisited", async () => {
+    mockOrderFn.mockResolvedValue({
+      data: [
+        makeCheckIn("poi-1", "Paludan", "2026-03-13T12:00:00Z"),
+        makeCheckIn("poi-2", "La Banchina", "2026-03-12T12:00:00Z"),
+        makeCheckIn("poi-2", "La Banchina", "2026-03-11T12:00:00Z"),
+        makeCheckIn("poi-1", "Paludan", "2026-03-10T12:00:00Z"),
+        makeCheckIn("poi-2", "La Banchina", "2026-03-09T12:00:00Z"),
+      ],
+      error: null,
+    });
+
+    const result = renderHook(() => usePassportStats());
+    await flush();
+
+    expect(result.current.mostVisited).toEqual({ poiId: "poi-2", name: "La Banchina", count: 3 });
+  });
+
+  it("tiebreaks by most recent check-in when two POIs share top count", async () => {
+    // poi-1 and poi-2 both have 2 visits; poi-1's most recent is later → wins.
+    mockOrderFn.mockResolvedValue({
+      data: [
+        makeCheckIn("poi-1", "Paludan", "2026-03-15T12:00:00Z"), // most recent overall
+        makeCheckIn("poi-2", "La Banchina", "2026-03-14T12:00:00Z"),
+        makeCheckIn("poi-1", "Paludan", "2026-03-10T12:00:00Z"),
+        makeCheckIn("poi-2", "La Banchina", "2026-03-09T12:00:00Z"),
+      ],
+      error: null,
+    });
+
+    const result = renderHook(() => usePassportStats());
+    await flush();
+
+    expect(result.current.mostVisited?.poiId).toBe("poi-1");
+    expect(result.current.mostVisited?.name).toBe("Paludan");
+    expect(result.current.mostVisited?.count).toBe(2);
+  });
+
+  it("sets error state when check_ins query fails", async () => {
+    mockOrderFn.mockResolvedValue({ data: null, error: { message: "network error" } });
+
+    const result = renderHook(() => usePassportStats());
+    await flush();
+
+    expect(result.current.error).toBe("network error");
+    expect(result.current.totalCheckIns).toBe(0);
+  });
+});
+
+describe("usePassportStats — edge cases", () => {
+  it("returns zeros when profile has no active semester (semester_id null)", async () => {
+    mockSingleFn.mockResolvedValue({ data: { semester_id: null }, error: null });
+
+    const result = renderHook(() => usePassportStats());
+    await flush();
+
+    expect(result.current.totalCheckIns).toBe(0);
+    expect(result.current.uniquePois).toBe(0);
+    expect(result.current.mostVisited).toBeNull();
+    // check_ins query must NOT have been called
+    expect(mockOrderFn).not.toHaveBeenCalled();
+  });
+
+  it("returns zeros and no error when user is not authenticated", async () => {
+    mockUseAuth.mockReturnValue({ session: null });
+
+    const result = renderHook(() => usePassportStats());
+    await flush();
+
+    expect(result.current.totalCheckIns).toBe(0);
+    expect(result.current.uniquePois).toBe(0);
+    expect(result.current.mostVisited).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(mockSingleFn).not.toHaveBeenCalled();
+  });
+
+  it("sets error state when profiles query fails", async () => {
+    mockSingleFn.mockResolvedValue({ data: null, error: { message: "profile fetch failed" } });
+
+    const result = renderHook(() => usePassportStats());
+    await flush();
+
+    expect(result.current.error).toBe("profile fetch failed");
+    expect(mockOrderFn).not.toHaveBeenCalled();
+  });
+});

--- a/hooks/usePassportStats.ts
+++ b/hooks/usePassportStats.ts
@@ -2,16 +2,6 @@ import { useState, useEffect, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/hooks/useAuth";
 
-// Local RPC return type — update types/supabase.ts once the get_passport_stats
-// migration is reflected by `supabase gen types`. Until then this keeps TS happy
-// without widening to `any`.
-type GetPassportStatsRow = {
-  total_check_ins: number;
-  unique_pois: number;
-  most_visited_name: string | null;
-  most_visited_count: number | null;
-};
-
 export type MostVisitedPoi = {
   name: string;
   count: number;
@@ -32,7 +22,9 @@ export function usePassportStats(): PassportStats {
   const [totalCheckIns, setTotalCheckIns] = useState(0);
   const [uniquePois, setUniquePois] = useState(0);
   const [mostVisited, setMostVisited] = useState<MostVisitedPoi | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  // Start in loading state if a user is already present — avoids a one-frame
+  // flash of zeros before the first async fetch sets isLoading(true).
+  const [isLoading, setIsLoading] = useState(!!userId);
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(
@@ -68,11 +60,9 @@ export function usePassportStats(): PassportStats {
       // Step 2: delegate all aggregation to the server via RPC.
       // get_passport_stats always returns exactly one row (aggregate over empty
       // set yields 0s / NULLs), so .single() is safe.
-      // Cast: get_passport_stats is not yet in types/supabase.ts — regenerate
-      // after the migration is reflected by `supabase gen types typescript`.
-      const { data: stats, error: statsError } = (await supabase
+      const { data: stats, error: statsError } = await supabase
         .rpc("get_passport_stats", { p_semester_id: profile.semester_id })
-        .single()) as { data: GetPassportStatsRow | null; error: { message: string } | null };
+        .single();
 
       if (isCancelled?.()) return;
 

--- a/hooks/usePassportStats.ts
+++ b/hooks/usePassportStats.ts
@@ -1,0 +1,140 @@
+import { useState, useEffect, useCallback } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
+
+export type MostVisitedPoi = {
+  poiId: string;
+  name: string;
+  count: number;
+};
+
+export type PassportStats = {
+  totalCheckIns: number;
+  uniquePois: number;
+  mostVisited: MostVisitedPoi | null;
+  isLoading: boolean;
+  error: string | null;
+};
+
+type PoiJoin = { name?: string };
+
+function getPoiName(pois: unknown): string | null {
+  if (!pois) return null;
+  if (Array.isArray(pois)) return (pois[0] as PoiJoin)?.name ?? null;
+  return (pois as PoiJoin).name ?? null;
+}
+
+export function usePassportStats(): PassportStats {
+  const { session } = useAuth();
+  const userId = session?.user.id;
+
+  const [totalCheckIns, setTotalCheckIns] = useState(0);
+  const [uniquePois, setUniquePois] = useState(0);
+  const [mostVisited, setMostVisited] = useState<MostVisitedPoi | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(
+    async (isCancelled?: () => boolean) => {
+      if (!userId) return;
+      setIsLoading(true);
+      setError(null);
+
+      // Step 1: get the user's active semester_id from their profile.
+      // semester_id is nullable until issue #31 migration lands.
+      const { data: profile, error: profileError } = await supabase
+        .from("profiles")
+        .select("semester_id")
+        .eq("id", userId)
+        .single();
+
+      if (isCancelled?.()) return;
+
+      if (profileError) {
+        setError(profileError.message);
+        setIsLoading(false);
+        return;
+      }
+
+      if (!profile.semester_id) {
+        // semester_id nullable until issue #31 migration. Show zeros; don't aggregate all-time.
+        setTotalCheckIns(0);
+        setUniquePois(0);
+        setMostVisited(null);
+        setIsLoading(false);
+        return;
+      }
+
+      // Step 2: fetch all check-ins for this user in the active semester,
+      // ordered desc so the first occurrence of each poi_id is the most recent.
+      const { data, error: checkInsError } = await supabase
+        .from("check_ins")
+        .select("poi_id, checked_in_at, pois(name)")
+        .eq("user_id", userId)
+        .eq("semester_id", profile.semester_id)
+        .order("checked_in_at", { ascending: false });
+
+      if (isCancelled?.()) return;
+
+      if (checkInsError) {
+        setError(checkInsError.message);
+        setIsLoading(false);
+        return;
+      }
+
+      const rows = data ?? [];
+      setTotalCheckIns(rows.length);
+      setUniquePois(new Set(rows.map((r) => r.poi_id)).size);
+
+      // Group by poi_id, counting visits. Because rows are sorted desc, the first
+      // occurrence of each poi_id carries the most recent checked_in_at — used as
+      // tiebreaker when two POIs share the top visit count.
+      const byPoi = new Map<string, { name: string; count: number; latestAt: string }>();
+      for (const row of rows) {
+        const name = getPoiName(row.pois) ?? "Unknown";
+        const existing = byPoi.get(row.poi_id);
+        if (!existing) {
+          byPoi.set(row.poi_id, { name, count: 1, latestAt: row.checked_in_at });
+        } else {
+          byPoi.set(row.poi_id, { ...existing, count: existing.count + 1 });
+          // latestAt intentionally not updated — first insertion holds most recent.
+        }
+      }
+
+      if (byPoi.size === 0) {
+        setMostVisited(null);
+      } else {
+        const [[poiId, { name, count }]] = [...byPoi.entries()].sort((a, b) => {
+          const countDiff = b[1].count - a[1].count;
+          if (countDiff !== 0) return countDiff;
+          // Tiebreak: most recent last check-in wins.
+          return b[1].latestAt.localeCompare(a[1].latestAt);
+        });
+        setMostVisited({ poiId, name, count });
+      }
+
+      setIsLoading(false);
+    },
+    [userId],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!userId) {
+      // Reset all stats (including isLoading) when the user logs out mid-fetch.
+      // Without setIsLoading(false) here, a fetch in-flight at logout time would
+      // be cancelled before setting it, leaving the UI stuck in a loading state.
+      setTotalCheckIns(0);
+      setUniquePois(0);
+      setMostVisited(null);
+      setIsLoading(false);
+      return;
+    }
+    load(() => cancelled);
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, load]);
+
+  return { totalCheckIns, uniquePois, mostVisited, isLoading, error };
+}

--- a/hooks/usePassportStats.ts
+++ b/hooks/usePassportStats.ts
@@ -2,8 +2,17 @@ import { useState, useEffect, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/hooks/useAuth";
 
+// Local RPC return type — update types/supabase.ts once the get_passport_stats
+// migration is reflected by `supabase gen types`. Until then this keeps TS happy
+// without widening to `any`.
+type GetPassportStatsRow = {
+  total_check_ins: number;
+  unique_pois: number;
+  most_visited_name: string | null;
+  most_visited_count: number | null;
+};
+
 export type MostVisitedPoi = {
-  poiId: string;
   name: string;
   count: number;
 };
@@ -15,14 +24,6 @@ export type PassportStats = {
   isLoading: boolean;
   error: string | null;
 };
-
-type PoiJoin = { name?: string };
-
-function getPoiName(pois: unknown): string | null {
-  if (!pois) return null;
-  if (Array.isArray(pois)) return (pois[0] as PoiJoin)?.name ?? null;
-  return (pois as PoiJoin).name ?? null;
-}
 
 export function usePassportStats(): PassportStats {
   const { session } = useAuth();
@@ -41,7 +42,6 @@ export function usePassportStats(): PassportStats {
       setError(null);
 
       // Step 1: get the user's active semester_id from their profile.
-      // semester_id is nullable until issue #31 migration lands.
       const { data: profile, error: profileError } = await supabase
         .from("profiles")
         .select("semester_id")
@@ -57,7 +57,7 @@ export function usePassportStats(): PassportStats {
       }
 
       if (!profile.semester_id) {
-        // semester_id nullable until issue #31 migration. Show zeros; don't aggregate all-time.
+        // No active semester — show zeros without querying check_ins.
         setTotalCheckIns(0);
         setUniquePois(0);
         setMostVisited(null);
@@ -65,54 +65,30 @@ export function usePassportStats(): PassportStats {
         return;
       }
 
-      // Step 2: fetch all check-ins for this user in the active semester,
-      // ordered desc so the first occurrence of each poi_id is the most recent.
-      const { data, error: checkInsError } = await supabase
-        .from("check_ins")
-        .select("poi_id, checked_in_at, pois(name)")
-        .eq("user_id", userId)
-        .eq("semester_id", profile.semester_id)
-        .order("checked_in_at", { ascending: false });
+      // Step 2: delegate all aggregation to the server via RPC.
+      // get_passport_stats always returns exactly one row (aggregate over empty
+      // set yields 0s / NULLs), so .single() is safe.
+      // Cast: get_passport_stats is not yet in types/supabase.ts — regenerate
+      // after the migration is reflected by `supabase gen types typescript`.
+      const { data: stats, error: statsError } = (await supabase
+        .rpc("get_passport_stats", { p_semester_id: profile.semester_id })
+        .single()) as { data: GetPassportStatsRow | null; error: { message: string } | null };
 
       if (isCancelled?.()) return;
 
-      if (checkInsError) {
-        setError(checkInsError.message);
+      if (statsError) {
+        setError(statsError.message);
         setIsLoading(false);
         return;
       }
 
-      const rows = data ?? [];
-      setTotalCheckIns(rows.length);
-      setUniquePois(new Set(rows.map((r) => r.poi_id)).size);
-
-      // Group by poi_id, counting visits. Because rows are sorted desc, the first
-      // occurrence of each poi_id carries the most recent checked_in_at — used as
-      // tiebreaker when two POIs share the top visit count.
-      const byPoi = new Map<string, { name: string; count: number; latestAt: string }>();
-      for (const row of rows) {
-        const name = getPoiName(row.pois) ?? "Unknown";
-        const existing = byPoi.get(row.poi_id);
-        if (!existing) {
-          byPoi.set(row.poi_id, { name, count: 1, latestAt: row.checked_in_at });
-        } else {
-          byPoi.set(row.poi_id, { ...existing, count: existing.count + 1 });
-          // latestAt intentionally not updated — first insertion holds most recent.
-        }
-      }
-
-      if (byPoi.size === 0) {
-        setMostVisited(null);
-      } else {
-        const [[poiId, { name, count }]] = [...byPoi.entries()].sort((a, b) => {
-          const countDiff = b[1].count - a[1].count;
-          if (countDiff !== 0) return countDiff;
-          // Tiebreak: most recent last check-in wins.
-          return b[1].latestAt.localeCompare(a[1].latestAt);
-        });
-        setMostVisited({ poiId, name, count });
-      }
-
+      setTotalCheckIns(stats?.total_check_ins ?? 0);
+      setUniquePois(stats?.unique_pois ?? 0);
+      setMostVisited(
+        stats?.most_visited_name != null
+          ? { name: stats.most_visited_name, count: stats.most_visited_count ?? 0 }
+          : null,
+      );
       setIsLoading(false);
     },
     [userId],

--- a/lib/badges/catalog.ts
+++ b/lib/badges/catalog.ts
@@ -1,0 +1,226 @@
+/**
+ * V1 badge catalog — data only, no award logic.
+ *
+ * STABILITY INVARIANT: Badge `id` values are the primary key used by the badge
+ * engine and stored in the database. Once a badge ships to production, its `id`
+ * MUST NOT change. Rename the display `name` freely; never rename the `id`.
+ *
+ * `icon` fields are emoji placeholders. Replace with Supabase Storage URLs when
+ * badge assets are uploaded (Phase 6 criteria engine).
+ *
+ * `criteriaHint` is human-readable copy shown in BadgeDetailModal ("How to earn").
+ * Exact numeric thresholds are intentionally absent here — they live in the
+ * criteria engine, not in this data file.
+ */
+
+export type BadgeCategory =
+  | "milestone"
+  | "exploration"
+  | "loyalty"
+  | "time"
+  | "poi_category"
+  | "social"
+  | "exclusive";
+
+export type BadgeDefinition = {
+  /** Stable slug. Never change after first production deploy. */
+  id: string;
+  name: string;
+  description: string;
+  /** Plain-English "How to earn" copy shown in the locked badge modal. */
+  criteriaHint: string;
+  category: BadgeCategory;
+  /** Emoji placeholder — will be replaced by a Supabase Storage URL. */
+  icon: string;
+};
+
+// ---------------------------------------------------------------------------
+// V1 catalog — 20 badges
+// ---------------------------------------------------------------------------
+
+// `as const satisfies BadgeDefinition[]` makes every property readonly at the
+// type level, enforcing the id-stability invariant promised in the file header.
+export const BADGE_CATALOG = [
+  // ── Milestones ────────────────────────────────────────────────────────────
+  {
+    id: "first_step",
+    name: "First Step",
+    description: "Your journey begins.",
+    criteriaHint: "Check in to a place for the first time.",
+    category: "milestone",
+    icon: "👣",
+  },
+  {
+    id: "getting_started",
+    name: "Getting Started",
+    description: "Building momentum across the city.",
+    criteriaHint: "Rack up your first handful of check-ins.",
+    category: "milestone",
+    icon: "🚀",
+  },
+  {
+    id: "semester_regular",
+    name: "Semester Regular",
+    description: "A familiar face in Copenhagen.",
+    criteriaHint: "Check in consistently across the semester.",
+    category: "milestone",
+    icon: "🏅",
+  },
+  {
+    id: "copenhagen_veteran",
+    name: "Copenhagen Veteran",
+    description: "You've covered serious ground.",
+    criteriaHint: "Reach the highest check-in milestone of the semester.",
+    category: "milestone",
+    icon: "🏆",
+  },
+
+  // ── Exploration ───────────────────────────────────────────────────────────
+  {
+    id: "cartographer",
+    name: "Cartographer",
+    description: "No corner of the map left unvisited.",
+    criteriaHint: "Check in to a place in every POI category.",
+    category: "exploration",
+    icon: "🗺️",
+  },
+  {
+    id: "all_five",
+    name: "All Five",
+    description: "Sampled everything Copenhagen has to offer.",
+    criteriaHint: "Visit all five place categories.",
+    category: "exploration",
+    icon: "⭐",
+  },
+  {
+    id: "local_secret",
+    name: "Local Secret",
+    description: "You found somewhere the tourists don't know about.",
+    criteriaHint: "Check in to a spot with very few community visits.",
+    category: "exploration",
+    icon: "🔍",
+  },
+
+  // ── Loyalty ───────────────────────────────────────────────────────────────
+  {
+    id: "regular",
+    name: "Regular",
+    description: "They know your name here.",
+    criteriaHint: "Return to the same place multiple times.",
+    category: "loyalty",
+    icon: "☕",
+  },
+  {
+    id: "this_is_my_table",
+    name: "This Is My Table",
+    description: "Claimed your spot.",
+    criteriaHint: "Become the most frequent visitor at a place in your cohort.",
+    category: "loyalty",
+    icon: "🪑",
+  },
+
+  // ── Time & Rhythm ─────────────────────────────────────────────────────────
+  {
+    id: "night_owl",
+    name: "Night Owl",
+    description: "The city looks different after dark.",
+    criteriaHint: "Check in somewhere after midnight.",
+    category: "time",
+    icon: "🦉",
+  },
+  {
+    id: "early_bird",
+    name: "Early Bird",
+    description: "Copenhagen at dawn is something else.",
+    criteriaHint: "Check in somewhere before 8 am.",
+    category: "time",
+    icon: "🌅",
+  },
+  {
+    id: "weekend_warrior",
+    name: "Weekend Warrior",
+    description: "Saturday and Sunday belong to you.",
+    criteriaHint: "Check in on a weekend.",
+    category: "time",
+    icon: "🎉",
+  },
+
+  // ── POI Category ──────────────────────────────────────────────────────────
+  {
+    id: "bookworm",
+    name: "Bookworm",
+    description: "Cafés, bookshops, and good coffee.",
+    criteriaHint: "Check in to multiple places in the café & bookshop category.",
+    category: "poi_category",
+    icon: "📚",
+  },
+  {
+    id: "culture_vulture",
+    name: "Culture Vulture",
+    description: "Museums, galleries, and everything in between.",
+    criteriaHint: "Check in to multiple cultural spots.",
+    category: "poi_category",
+    icon: "🎨",
+  },
+  {
+    id: "foodie",
+    name: "Foodie",
+    description: "Copenhagen's food scene, fully explored.",
+    criteriaHint: "Check in to multiple restaurants and food spots.",
+    category: "poi_category",
+    icon: "🍽️",
+  },
+  {
+    id: "nightlifer",
+    name: "Nightlifer",
+    description: "Bars, clubs, and late-night venues.",
+    criteriaHint: "Check in to multiple nightlife spots.",
+    category: "poi_category",
+    icon: "🎶",
+  },
+
+  // ── Social ────────────────────────────────────────────────────────────────
+  {
+    id: "social_butterfly",
+    name: "Social Butterfly",
+    description: "Always where the people are.",
+    criteriaHint: "Join other people's broadcasts multiple times.",
+    category: "social",
+    icon: "🦋",
+  },
+  {
+    id: "connector",
+    name: "Connector",
+    description: "You bring people to the places you love.",
+    criteriaHint: "Have multiple people join your broadcasts.",
+    category: "social",
+    icon: "🤝",
+  },
+  {
+    id: "come_join_me",
+    name: "Come Join Me",
+    description: "The squad showed up.",
+    criteriaHint: "Have someone join your broadcast and actually arrive at the spot.",
+    category: "social",
+    icon: "📍",
+  },
+
+  // ── Exclusive ─────────────────────────────────────────────────────────────
+  {
+    id: "pioneer",
+    name: "Pioneer",
+    description: "One of the very first.",
+    criteriaHint: "Be part of the Summer 2026 cohort — awarded automatically on signup.",
+    category: "exclusive",
+    icon: "🌟",
+  },
+] as const satisfies ReadonlyArray<Readonly<BadgeDefinition>>;
+
+// ---------------------------------------------------------------------------
+// Lookup helpers
+// ---------------------------------------------------------------------------
+
+/** O(1) lookup by badge id. Built once at module load. */
+export const BADGE_BY_ID = new Map(
+  BADGE_CATALOG.map((b) => [b.id, b as BadgeDefinition]),
+) as ReadonlyMap<string, BadgeDefinition>;

--- a/supabase/migrations/027_get_passport_stats_rpc.sql
+++ b/supabase/migrations/027_get_passport_stats_rpc.sql
@@ -1,0 +1,38 @@
+-- Aggregates per-semester passport stats for the authenticated user.
+-- Returns exactly one row regardless of check-in count (aggregate over empty set
+-- yields 0s and NULLs rather than zero rows).
+--
+-- Uses auth.uid() directly so callers cannot query another user's data.
+-- SECURITY INVOKER ensures RLS on check_ins and pois is enforced.
+-- Returns integer (not bigint) so the JS client receives JS numbers, not strings.
+
+CREATE OR REPLACE FUNCTION public.get_passport_stats(p_semester_id uuid)
+RETURNS TABLE(
+  total_check_ins integer,
+  unique_pois integer,
+  most_visited_name text,
+  most_visited_count integer
+)
+LANGUAGE sql
+SECURITY INVOKER
+STABLE
+AS $$
+  WITH counts AS (
+    SELECT
+      ci.poi_id,
+      p.name AS poi_name,
+      COUNT(*) AS visit_count,
+      MAX(ci.checked_in_at) AS last_visit
+    FROM check_ins ci
+    JOIN pois p ON p.id = ci.poi_id
+    WHERE ci.user_id = auth.uid()
+      AND ci.semester_id = p_semester_id
+    GROUP BY ci.poi_id, p.name
+  )
+  SELECT
+    COALESCE(SUM(visit_count), 0)::integer AS total_check_ins,
+    COUNT(*)::integer AS unique_pois,
+    (SELECT poi_name  FROM counts ORDER BY visit_count DESC, last_visit DESC LIMIT 1) AS most_visited_name,
+    (SELECT visit_count::integer FROM counts ORDER BY visit_count DESC, last_visit DESC LIMIT 1) AS most_visited_count
+  FROM counts;
+$$;

--- a/supabase/migrations/027_get_passport_stats_rpc.sql
+++ b/supabase/migrations/027_get_passport_stats_rpc.sql
@@ -36,3 +36,9 @@ AS $$
     (SELECT visit_count::integer FROM counts ORDER BY visit_count DESC, last_visit DESC LIMIT 1) AS most_visited_count
   FROM counts;
 $$;
+
+-- Lock down execution to authenticated users only. PostgreSQL grants EXECUTE
+-- to PUBLIC by default; anon callers get zeros (auth.uid() = NULL matches no
+-- rows), but explicit restriction is cleaner and matches project conventions.
+REVOKE EXECUTE ON FUNCTION public.get_passport_stats(uuid) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.get_passport_stats(uuid) TO   authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -360,12 +360,12 @@ export type Database = {
       checkin_window: { Args: { ts: string }; Returns: unknown };
       get_passport_stats: {
         Args: { p_semester_id: string };
-        Returns: {
+        Returns: Array<{
           total_check_ins: number;
           unique_pois: number;
           most_visited_name: string | null;
           most_visited_count: number | null;
-        };
+        }>;
       };
     };
     Enums: {

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -358,6 +358,15 @@ export type Database = {
     };
     Functions: {
       checkin_window: { Args: { ts: string }; Returns: unknown };
+      get_passport_stats: {
+        Args: { p_semester_id: string };
+        Returns: {
+          total_check_ins: number;
+          unique_pois: number;
+          most_visited_name: string | null;
+          most_visited_count: number | null;
+        };
+      };
     };
     Enums: {
       friendship_status: "pending" | "accepted";


### PR DESCRIPTION
## Summary

Implements the V1 Passport screen — a per-semester activity summary with check-in stats and a locked badge grid. Stats (total check-ins, unique POIs, most visited spot) are aggregated server-side via a new `get_passport_stats` Supabase RPC. Tapping any badge opens a detail modal showing the badge description and how-to-earn hint.

Closes #33 — the `get_passport_stats` RPC replaces the unbounded client-side `check_ins` fetch that issue flagged.

## Changes

- Add `usePassportStats` hook — queries profiles for active semester, calls `get_passport_stats` RPC, maps result to typed stats
- Add V1 badge catalog — 20 badge definitions with stable IDs, descriptions, and `criteriaHint` copy across 7 categories
- Build Passport screen layout — stat cards (check-ins, unique POIs, most visited) + 4-column badge grid
- Add `BadgeDetailModal` — tap any badge cell to view name, locked/earned chip, description, and how-to-earn hint
- Add `supabase/migrations/027_get_passport_stats_rpc.sql` — `get_passport_stats` SQL function (SECURITY INVOKER, auth.uid()-scoped, REVOKE/GRANT locked to authenticated)
- Rewrite `usePassportStats` tests for RPC mock; add `BadgeDetailModal` component tests (15 tests total)

## Test plan

- 418 Jest tests passing (all suites green)
- `usePassportStats`: 8 unit tests — RPC response mapping, error paths, unauthenticated + no-semester edge cases
- `BadgeDetailModal`: 7 unit tests — locked/unlocked render, null badge visibility, close/backdrop press
- UI smoke-tested on physical device: stats load correctly, badge grid renders, detail modal opens and dismisses