### PR TITLE
fix(auth): tier handle_new_user semester fallback

### DIFF
--- a/supabase/migrations/028_fix_handle_new_user_semester_fallback.sql
+++ b/supabase/migrations/028_fix_handle_new_user_semester_fallback.sql
@@ -1,0 +1,50 @@
+-- Fix handle_new_user to handle gaps between semesters.
+-- Previously, signups during gaps (e.g. pre-semester arrival window) left
+-- profile.semester_id = NULL, which broke downstream check-in logic
+-- (lib/checkIns.ts throws "No active semester for user").
+--
+-- New tiered lookup:
+--   1. Active semester (covers today)
+--   2. Next upcoming semester (students typically sign up 1-4 weeks before arrival)
+--   3. Most recent past semester (graceful fallback)
+--   4. If no semesters exist at all, warn and leave NULL.
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS trigger AS $$
+DECLARE
+  resolved_semester_id uuid;
+BEGIN
+  -- 1. Active semester
+  SELECT id INTO resolved_semester_id
+  FROM public.semesters
+  WHERE start_date <= CURRENT_DATE AND end_date >= CURRENT_DATE
+  LIMIT 1;
+
+  -- 2. Next upcoming semester
+  IF resolved_semester_id IS NULL THEN
+    SELECT id INTO resolved_semester_id
+    FROM public.semesters
+    WHERE start_date > CURRENT_DATE
+    ORDER BY start_date ASC
+    LIMIT 1;
+  END IF;
+
+  -- 3. Most recent past semester
+  IF resolved_semester_id IS NULL THEN
+    SELECT id INTO resolved_semester_id
+    FROM public.semesters
+    WHERE end_date < CURRENT_DATE
+    ORDER BY end_date DESC
+    LIMIT 1;
+  END IF;
+
+  -- 4. No semesters exist
+  IF resolved_semester_id IS NULL THEN
+    RAISE WARNING 'No semesters exist in database for new user %. semester_id will be null.', new.id;
+  END IF;
+
+  INSERT INTO public.profiles (id, display_name, semester_id)
+  VALUES (new.id, new.raw_user_meta_data->>'display_name', resolved_semester_id);
+
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- `handle_new_user` previously only assigned `profile.semester_id` when `CURRENT_DATE` fell inside an active semester window. Between semesters (e.g. signing up on 2026-04-18 before Summer 2026 starts 2026-05-15) it left `semester_id = NULL`, which then caused `lib/checkIns.ts` to throw `"No active semester for user"` — effectively dead accounts.
- Migration 028 replaces the function with a tiered lookup: active → next upcoming → most recent past. Only falls back to NULL if no semester rows exist at all.
- `SECURITY DEFINER` preserved, INSERT shape unchanged, no email coalesce (consistent with migration 002).

## Test plan
- [x] Sign up today (between-semester gap) — verify `profile.semester_id` resolves to Summer 2026 (next upcoming).
- [x] Confirm existing signups mid-semester still resolve to the active semester.
- [x] Confirm check-in flow works for users onboarded via the new fallback path.