### PR TITLE
feat(badges): criteria engine — DB triggers, Realtime unlock toast, Passport grid

### DIFF
--- a/app/(app)/(tabs)/passport.tsx
+++ b/app/(app)/(tabs)/passport.tsx
@@ -4,6 +4,7 @@ import { useRouter, useNavigation } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useAuth } from "@/hooks/useAuth";
 import { usePassportStats } from "@/hooks/usePassportStats";
+import { useUserBadges } from "@/hooks/useUserBadges";
 import { BADGE_CATALOG, type BadgeDefinition } from "@/lib/badges/catalog";
 import { StatCard } from "@/components/passport/StatCard";
 import { BadgeCell } from "@/components/passport/BadgeCell";
@@ -14,6 +15,7 @@ export default function PassportScreen() {
   const navigation = useNavigation();
   const { signOut } = useAuth();
   const stats = usePassportStats();
+  const badges = useUserBadges();
 
   const [selectedBadge, setSelectedBadge] = useState<BadgeDefinition | null>(null);
 
@@ -73,21 +75,36 @@ export default function PassportScreen() {
 
         {/* ── Badges section ─────────────────────────────────────────────── */}
         <Text style={[styles.sectionLabel, styles.badgesSectionLabel]}>Badges</Text>
-        <Text style={styles.badgesHint}>
-          {/* Badge count will be driven by the engine once it ships. */}0 / {BADGE_CATALOG.length}{" "}
-          earned
-        </Text>
 
-        <View style={styles.badgeGrid} testID="badge-grid">
-          {BADGE_CATALOG.map((badge) => (
-            <BadgeCell
-              key={badge.id}
-              badge={badge}
-              unlocked={false}
-              onPress={() => setSelectedBadge(badge)}
-            />
-          ))}
-        </View>
+        {badges.isLoading ? (
+          <ActivityIndicator
+            size="small"
+            color="#131313"
+            style={styles.loader}
+            testID="badges-loading"
+          />
+        ) : (
+          <>
+            {badges.error && (
+              <Text style={styles.errorText} testID="badges-error">
+                {badges.error}
+              </Text>
+            )}
+            <Text style={styles.badgesHint}>
+              {badges.awardedIds.size} / {BADGE_CATALOG.length} earned
+            </Text>
+            <View style={styles.badgeGrid} testID="badge-grid">
+              {BADGE_CATALOG.map((badge) => (
+                <BadgeCell
+                  key={badge.id}
+                  badge={badge}
+                  unlocked={badges.awardedIds.has(badge.id)}
+                  onPress={() => setSelectedBadge(badge)}
+                />
+              ))}
+            </View>
+          </>
+        )}
 
         {/* ── Footer ─────────────────────────────────────────────────────── */}
         <Pressable onPress={signOut} style={styles.signOutButton} accessibilityRole="button">
@@ -97,7 +114,7 @@ export default function PassportScreen() {
 
       <BadgeDetailModal
         badge={selectedBadge}
-        unlocked={false}
+        unlocked={selectedBadge != null && badges.awardedIds.has(selectedBadge.id)}
         onClose={() => setSelectedBadge(null)}
       />
     </View>

--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -1,10 +1,13 @@
 import { Stack } from "expo-router";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { useGeofenceNotifications } from "@/hooks/useGeofenceNotifications";
+import { useNewBadges } from "@/hooks/useNewBadges";
 import { CheckInToast } from "@/components/CheckInToast";
+import { BadgeUnlockToast } from "@/components/BadgeUnlockToast";
 
 export default function AppLayout() {
   const { toast } = useGeofenceNotifications();
+  const { newBadge, dismiss } = useNewBadges();
 
   return (
     <BottomSheetModalProvider>
@@ -16,6 +19,7 @@ export default function AppLayout() {
         />
       </Stack>
       <CheckInToast visible={toast.visible} message={toast.message} />
+      <BadgeUnlockToast badge={newBadge} onDismiss={dismiss} />
     </BottomSheetModalProvider>
   );
 }

--- a/components/BadgeUnlockToast.tsx
+++ b/components/BadgeUnlockToast.tsx
@@ -37,7 +37,7 @@ export function BadgeUnlockToast({ badge, onDismiss }: Props) {
   }, [badge, opacity, onDismiss]);
 
   return (
-    <Animated.View style={[styles.container, { opacity }]} pointerEvents="none">
+    <Animated.View style={[styles.container, { opacity, pointerEvents: "none" }]}>
       <Text style={styles.icon}>{badge?.icon ?? ""}</Text>
       <Text style={styles.text}>
         Badge unlocked: <Text style={styles.badgeName}>{badge?.name ?? ""}</Text>

--- a/components/BadgeUnlockToast.tsx
+++ b/components/BadgeUnlockToast.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from "react";
+import { Animated, StyleSheet, Text } from "react-native";
+import type { BadgeDefinition } from "@/lib/badges/catalog";
+
+type Props = {
+  badge: BadgeDefinition | null;
+  onDismiss: () => void;
+};
+
+const AUTO_DISMISS_MS = 3000;
+
+export function BadgeUnlockToast({ badge, onDismiss }: Props) {
+  const opacity = useRef(new Animated.Value(0)).current;
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+
+    Animated.timing(opacity, {
+      toValue: badge ? 1 : 0,
+      duration: 250,
+      useNativeDriver: true,
+    }).start();
+
+    if (badge) {
+      timerRef.current = setTimeout(onDismiss, AUTO_DISMISS_MS);
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [badge, opacity, onDismiss]);
+
+  return (
+    <Animated.View style={[styles.container, { opacity }]} pointerEvents="none">
+      <Text style={styles.icon}>{badge?.icon ?? ""}</Text>
+      <Text style={styles.text}>
+        Badge unlocked: <Text style={styles.badgeName}>{badge?.name ?? ""}</Text>
+      </Text>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: "absolute",
+    bottom: 160,
+    left: 24,
+    right: 24,
+    backgroundColor: "rgba(19, 19, 19, 0.92)",
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  icon: {
+    fontSize: 22,
+  },
+  text: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
+    flex: 1,
+  },
+  badgeName: {
+    color: "#FFD700",
+  },
+});

--- a/hooks/__tests__/useUserBadges.test.ts
+++ b/hooks/__tests__/useUserBadges.test.ts
@@ -1,0 +1,179 @@
+import React from "react";
+import { act, create } from "react-test-renderer";
+
+// ---------------------------------------------------------------------------
+// Mock leaf fns
+// ---------------------------------------------------------------------------
+const mockProfileSingleFn = jest.fn();
+const mockBadgesQueryFn = jest.fn();
+const mockUseAuth = jest.fn();
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+jest.mock("@/lib/supabase", () => ({
+  supabase: {
+    from: jest.fn((table: string) => {
+      if (table === "profiles") {
+        return {
+          select: jest.fn(() => ({
+            eq: jest.fn(() => ({ single: mockProfileSingleFn })),
+          })),
+        };
+      }
+      if (table === "user_badges") {
+        return {
+          select: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              eq: jest.fn(() => mockBadgesQueryFn()),
+            })),
+          })),
+        };
+      }
+      throw new Error(`Unexpected table in mock: ${table}`);
+    }),
+  },
+}));
+
+jest.mock("@/hooks/useAuth", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+import { useUserBadges } from "../useUserBadges";
+
+// ---------------------------------------------------------------------------
+// renderHook + flush helpers
+// ---------------------------------------------------------------------------
+type HookResult<T> = { current: T };
+
+let activeRenderer: ReturnType<typeof create> | null = null;
+
+afterEach(() => {
+  if (activeRenderer) {
+    act(() => {
+      activeRenderer!.unmount();
+    });
+    activeRenderer = null;
+  }
+});
+
+function renderHook<T>(useHook: () => T): HookResult<T> {
+  const result: HookResult<T> = { current: undefined as unknown as T };
+  function TestComponent() {
+    result.current = useHook();
+    return null;
+  }
+  act(() => {
+    activeRenderer = create(React.createElement(TestComponent));
+  });
+  return result;
+}
+
+async function flush() {
+  await act(async () => {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+const SEMESTER_ID = "sem-2026";
+const USER_ID = "user-1";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseAuth.mockReturnValue({ session: { user: { id: USER_ID } } });
+  mockProfileSingleFn.mockResolvedValue({ data: { semester_id: SEMESTER_ID }, error: null });
+});
+
+describe("useUserBadges — awarded badges mapping", () => {
+  it("returns empty set when no badges awarded", async () => {
+    mockBadgesQueryFn.mockResolvedValue({ data: [], error: null });
+
+    const result = renderHook(() => useUserBadges());
+    await flush();
+
+    expect(result.current.awardedIds.size).toBe(0);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("maps badge_id rows to a Set", async () => {
+    mockBadgesQueryFn.mockResolvedValue({
+      data: [{ badge_id: "first_step" }, { badge_id: "pioneer" }],
+      error: null,
+    });
+
+    const result = renderHook(() => useUserBadges());
+    await flush();
+
+    expect(result.current.awardedIds.has("first_step")).toBe(true);
+    expect(result.current.awardedIds.has("pioneer")).toBe(true);
+    expect(result.current.awardedIds.has("night_owl")).toBe(false);
+    expect(result.current.awardedIds.size).toBe(2);
+  });
+
+  it("handles null data as empty set", async () => {
+    mockBadgesQueryFn.mockResolvedValue({ data: null, error: null });
+
+    const result = renderHook(() => useUserBadges());
+    await flush();
+
+    expect(result.current.awardedIds.size).toBe(0);
+    expect(result.current.error).toBeNull();
+  });
+});
+
+describe("useUserBadges — edge cases", () => {
+  it("returns empty set and skips user_badges query when semester_id is null", async () => {
+    mockProfileSingleFn.mockResolvedValue({ data: { semester_id: null }, error: null });
+
+    const result = renderHook(() => useUserBadges());
+    await flush();
+
+    expect(result.current.awardedIds.size).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+    expect(mockBadgesQueryFn).not.toHaveBeenCalled();
+  });
+
+  it("returns empty set and no error when unauthenticated", async () => {
+    mockUseAuth.mockReturnValue({ session: null });
+
+    const result = renderHook(() => useUserBadges());
+    await flush();
+
+    expect(result.current.awardedIds.size).toBe(0);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(mockProfileSingleFn).not.toHaveBeenCalled();
+  });
+
+  it("sets error and skips user_badges query when profiles fetch fails", async () => {
+    mockProfileSingleFn.mockResolvedValue({
+      data: null,
+      error: { message: "profile fetch failed" },
+    });
+
+    const result = renderHook(() => useUserBadges());
+    await flush();
+
+    expect(result.current.error).toBe("profile fetch failed");
+    expect(result.current.isLoading).toBe(false);
+    expect(mockBadgesQueryFn).not.toHaveBeenCalled();
+  });
+
+  it("sets error when user_badges query fails", async () => {
+    mockBadgesQueryFn.mockResolvedValue({ data: null, error: { message: "query failed" } });
+
+    const result = renderHook(() => useUserBadges());
+    await flush();
+
+    expect(result.current.error).toBe("query failed");
+    expect(result.current.awardedIds.size).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/hooks/__tests__/useUserBadges.test.ts
+++ b/hooks/__tests__/useUserBadges.test.ts
@@ -11,29 +11,37 @@ const mockUseAuth = jest.fn();
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
-jest.mock("@/lib/supabase", () => ({
-  supabase: {
-    from: jest.fn((table: string) => {
-      if (table === "profiles") {
-        return {
-          select: jest.fn(() => ({
-            eq: jest.fn(() => ({ single: mockProfileSingleFn })),
-          })),
-        };
-      }
-      if (table === "user_badges") {
-        return {
-          select: jest.fn(() => ({
-            eq: jest.fn(() => ({
-              eq: jest.fn(() => mockBadgesQueryFn()),
+jest.mock("@/lib/supabase", () => {
+  const mockChannel = {
+    on: jest.fn().mockReturnThis(),
+    subscribe: jest.fn().mockReturnThis(),
+  };
+  return {
+    supabase: {
+      from: jest.fn((table: string) => {
+        if (table === "profiles") {
+          return {
+            select: jest.fn(() => ({
+              eq: jest.fn(() => ({ single: mockProfileSingleFn })),
             })),
-          })),
-        };
-      }
-      throw new Error(`Unexpected table in mock: ${table}`);
-    }),
-  },
-}));
+          };
+        }
+        if (table === "user_badges") {
+          return {
+            select: jest.fn(() => ({
+              eq: jest.fn(() => ({
+                eq: jest.fn(() => mockBadgesQueryFn()),
+              })),
+            })),
+          };
+        }
+        throw new Error(`Unexpected table in mock: ${table}`);
+      }),
+      channel: jest.fn(() => mockChannel),
+      removeChannel: jest.fn(),
+    },
+  };
+});
 
 jest.mock("@/hooks/useAuth", () => ({
   useAuth: () => mockUseAuth(),

--- a/hooks/useNewBadges.ts
+++ b/hooks/useNewBadges.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect, useCallback } from "react";
+import { AppState } from "react-native";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
+import { BADGE_BY_ID, type BadgeDefinition } from "@/lib/badges/catalog";
+
+export type NewBadgesState = {
+  newBadge: BadgeDefinition | null;
+  dismiss: () => void;
+};
+
+export function useNewBadges(): NewBadgesState {
+  const { session } = useAuth();
+  const userId = session?.user.id;
+  const [newBadge, setNewBadge] = useState<BadgeDefinition | null>(null);
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const channel = supabase
+      .channel(`new-badges-${userId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "user_badges",
+          filter: `user_id=eq.${userId}`,
+        },
+        (payload) => {
+          if (AppState.currentState !== "active") return;
+          const badgeId = (payload.new as { badge_id: string }).badge_id;
+          const badge = BADGE_BY_ID.get(badgeId);
+          if (badge) {
+            setNewBadge(badge);
+          }
+        },
+      )
+      .subscribe((status) => {
+        if (status === "CHANNEL_ERROR" || status === "TIMED_OUT") {
+          console.warn(`useNewBadges: channel ${status} for user ${userId}`);
+        }
+      });
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [userId]);
+
+  const dismiss = useCallback(() => setNewBadge(null), []);
+
+  return { newBadge, dismiss };
+}

--- a/hooks/useUserBadges.ts
+++ b/hooks/useUserBadges.ts
@@ -78,5 +78,33 @@ export function useUserBadges(): UserBadgesState {
     };
   }, [userId, load]);
 
+  useEffect(() => {
+    if (!userId) return;
+
+    const channel = supabase
+      .channel(`user-badges-${userId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "user_badges",
+          filter: `user_id=eq.${userId}`,
+        },
+        () => {
+          load();
+        },
+      )
+      .subscribe((status) => {
+        if (status === "CHANNEL_ERROR" || status === "TIMED_OUT") {
+          console.warn(`useUserBadges: channel ${status} for user ${userId}`);
+        }
+      });
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [userId, load]);
+
   return { awardedIds, isLoading, error };
 }

--- a/hooks/useUserBadges.ts
+++ b/hooks/useUserBadges.ts
@@ -1,0 +1,82 @@
+import { useState, useEffect, useCallback } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/hooks/useAuth";
+
+export type UserBadgesState = {
+  awardedIds: ReadonlySet<string>;
+  isLoading: boolean;
+  error: string | null;
+};
+
+const EMPTY_SET: ReadonlySet<string> = new Set();
+
+export function useUserBadges(): UserBadgesState {
+  const { session } = useAuth();
+  const userId = session?.user.id;
+
+  const [awardedIds, setAwardedIds] = useState<ReadonlySet<string>>(EMPTY_SET);
+  const [isLoading, setIsLoading] = useState(!!userId);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(
+    async (isCancelled?: () => boolean) => {
+      if (!userId) return;
+      setIsLoading(true);
+      setError(null);
+
+      const { data: profile, error: profileError } = await supabase
+        .from("profiles")
+        .select("semester_id")
+        .eq("id", userId)
+        .single();
+
+      if (isCancelled?.()) return;
+
+      if (profileError) {
+        setError(profileError.message);
+        setIsLoading(false);
+        return;
+      }
+
+      if (!profile?.semester_id) {
+        setAwardedIds(EMPTY_SET);
+        setIsLoading(false);
+        return;
+      }
+
+      const { data: badges, error: badgesError } = await supabase
+        .from("user_badges")
+        .select("badge_id")
+        .eq("user_id", userId)
+        .eq("semester_id", profile.semester_id);
+
+      if (isCancelled?.()) return;
+
+      if (badgesError) {
+        setError(badgesError.message);
+        setIsLoading(false);
+        return;
+      }
+
+      setAwardedIds(new Set((badges ?? []).map((b) => b.badge_id)));
+      setIsLoading(false);
+    },
+    [userId],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!userId) {
+      setAwardedIds(EMPTY_SET);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+    load(() => cancelled);
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, load]);
+
+  return { awardedIds, isLoading, error };
+}

--- a/lib/badges/__tests__/catalog.test.ts
+++ b/lib/badges/__tests__/catalog.test.ts
@@ -1,0 +1,122 @@
+import { BADGE_CATALOG, BADGE_BY_ID, type BadgeCategory, type BadgeDefinition } from "../catalog";
+
+// ---------------------------------------------------------------------------
+// Expected badge IDs — exhaustive list. Adding/removing a badge without
+// updating this test is a deliberate breaking change.
+// ---------------------------------------------------------------------------
+const EXPECTED_IDS: readonly string[] = [
+  // Milestones
+  "first_step",
+  "getting_started",
+  "semester_regular",
+  "copenhagen_veteran",
+  // Exploration
+  "cartographer",
+  "all_five",
+  "local_secret",
+  // Loyalty
+  "regular",
+  "this_is_my_table",
+  // Time & Rhythm
+  "night_owl",
+  "early_bird",
+  "weekend_warrior",
+  // POI Category
+  "bookworm",
+  "culture_vulture",
+  "foodie",
+  "nightlifer",
+  // Social
+  "social_butterfly",
+  "connector",
+  "come_join_me",
+  // Exclusive
+  "pioneer",
+];
+
+const VALID_CATEGORIES: readonly BadgeCategory[] = [
+  "milestone",
+  "exploration",
+  "loyalty",
+  "time",
+  "poi_category",
+  "social",
+  "exclusive",
+];
+
+describe("BADGE_CATALOG — completeness", () => {
+  it("contains exactly 20 badges", () => {
+    expect(BADGE_CATALOG.length).toBe(20);
+  });
+
+  it("catalog IDs match expected IDs exactly (both directions)", () => {
+    expect(BADGE_CATALOG.map((b) => b.id).sort()).toEqual([...EXPECTED_IDS].sort());
+  });
+
+  it("has no duplicate IDs", () => {
+    const ids = BADGE_CATALOG.map((b) => b.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+});
+
+describe("BADGE_CATALOG — field integrity", () => {
+  it.each(BADGE_CATALOG as unknown as BadgeDefinition[])(
+    "$id has all required non-empty fields",
+    (badge) => {
+      expect(typeof badge.id).toBe("string");
+      expect(badge.id.length).toBeGreaterThan(0);
+
+      expect(typeof badge.name).toBe("string");
+      expect(badge.name.length).toBeGreaterThan(0);
+
+      expect(typeof badge.description).toBe("string");
+      expect(badge.description.length).toBeGreaterThan(0);
+
+      expect(typeof badge.criteriaHint).toBe("string");
+      expect(badge.criteriaHint.length).toBeGreaterThan(0);
+
+      expect(typeof badge.icon).toBe("string");
+      expect(badge.icon.length).toBeGreaterThan(0);
+
+      expect(VALID_CATEGORIES).toContain(badge.category);
+    },
+  );
+
+  it("badge IDs use only lowercase letters and underscores", () => {
+    for (const badge of BADGE_CATALOG) {
+      expect(badge.id).toMatch(/^[a-z_]+$/);
+    }
+  });
+});
+
+describe("BADGE_CATALOG — Pioneer", () => {
+  it("Pioneer badge exists and is exclusive", () => {
+    const pioneer = BADGE_BY_ID.get("pioneer");
+    expect(pioneer).toBeDefined();
+    expect(pioneer?.category).toBe("exclusive");
+  });
+
+  it("Pioneer criteriaHint mentions auto-award on signup", () => {
+    const pioneer = BADGE_BY_ID.get("pioneer");
+    expect(pioneer?.criteriaHint.toLowerCase()).toMatch(/\bautomatic(ally)?\b|\bsign[- ]?up\b/);
+  });
+});
+
+describe("BADGE_BY_ID — lookup map", () => {
+  it("has same size as catalog", () => {
+    expect(BADGE_BY_ID.size).toBe(BADGE_CATALOG.length);
+  });
+
+  it("resolves every catalog ID to its definition", () => {
+    for (const badge of BADGE_CATALOG) {
+      const found = BADGE_BY_ID.get(badge.id);
+      expect(found).toBeDefined();
+      expect(found?.name).toBe(badge.name);
+    }
+  });
+
+  it("returns undefined for unknown badge ID", () => {
+    expect(BADGE_BY_ID.get("not_a_real_badge")).toBeUndefined();
+  });
+});

--- a/lib/badges/catalog.ts
+++ b/lib/badges/catalog.ts
@@ -80,7 +80,7 @@ export const BADGE_CATALOG = [
     id: "cartographer",
     name: "Cartographer",
     description: "No corner of the map left unvisited.",
-    criteriaHint: "Check in to a place in every POI category.",
+    criteriaHint: "Check in to many different places across the city.",
     category: "exploration",
     icon: "🗺️",
   },

--- a/supabase/migrations/029_user_badges.sql
+++ b/supabase/migrations/029_user_badges.sql
@@ -1,0 +1,24 @@
+-- user_badges: immutable log of badges awarded to users, scoped per semester.
+-- No authenticated INSERT policy — only SECURITY DEFINER triggers can award badges.
+-- Triggers use ON CONFLICT DO NOTHING for idempotent re-evaluation.
+
+CREATE TABLE public.user_badges (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  badge_id    text        NOT NULL CHECK (badge_id ~ '^[a-z_]+$'),
+  semester_id uuid        NOT NULL REFERENCES public.semesters(id),
+  awarded_at  timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT uq_user_badges_user_badge_semester UNIQUE (user_id, badge_id, semester_id)
+);
+
+ALTER TABLE public.user_badges ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own badges"
+  ON public.user_badges FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+CREATE INDEX idx_user_badges_user_semester ON public.user_badges (user_id, semester_id);
+
+ALTER PUBLICATION supabase_realtime ADD TABLE public.user_badges;

--- a/supabase/migrations/030_pioneer_auto_award.sql
+++ b/supabase/migrations/030_pioneer_auto_award.sql
@@ -1,0 +1,51 @@
+-- Extend handle_new_user to auto-award the Pioneer badge on signup.
+-- Pioneer is awarded once, tied to the user's resolved semester.
+-- Skipped silently when no semesters exist (resolved_semester_id IS NULL).
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS trigger AS $$
+DECLARE
+  resolved_semester_id uuid;
+BEGIN
+  -- 1. Active semester
+  SELECT id INTO resolved_semester_id
+  FROM public.semesters
+  WHERE start_date <= CURRENT_DATE AND end_date >= CURRENT_DATE
+  LIMIT 1;
+
+  -- 2. Next upcoming semester
+  IF resolved_semester_id IS NULL THEN
+    SELECT id INTO resolved_semester_id
+    FROM public.semesters
+    WHERE start_date > CURRENT_DATE
+    ORDER BY start_date ASC
+    LIMIT 1;
+  END IF;
+
+  -- 3. Most recent past semester
+  IF resolved_semester_id IS NULL THEN
+    SELECT id INTO resolved_semester_id
+    FROM public.semesters
+    WHERE end_date < CURRENT_DATE
+    ORDER BY end_date DESC
+    LIMIT 1;
+  END IF;
+
+  -- 4. No semesters exist
+  IF resolved_semester_id IS NULL THEN
+    RAISE WARNING 'No semesters exist in database for new user %. semester_id will be null.', new.id;
+  END IF;
+
+  INSERT INTO public.profiles (id, display_name, semester_id)
+  VALUES (new.id, new.raw_user_meta_data->>'display_name', resolved_semester_id);
+
+  -- Award Pioneer badge on signup. Skipped when no semester resolved.
+  -- ON CONFLICT DO NOTHING makes the insert idempotent.
+  IF resolved_semester_id IS NOT NULL THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (new.id, 'pioneer', resolved_semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog;

--- a/supabase/migrations/031_check_in_badge_evaluator.sql
+++ b/supabase/migrations/031_check_in_badge_evaluator.sql
@@ -1,0 +1,191 @@
+-- Badge evaluator for check-in-triggered badges (16 of 20).
+-- Fires AFTER INSERT on check_ins; all counts include the new row.
+-- Social badges (social_butterfly, connector, come_join_me) are in migration 032.
+-- Pioneer is awarded at signup in handle_new_user (migration 030).
+--
+-- Thresholds:
+--   first_step          total check-ins >= 1
+--   getting_started     total check-ins >= 5
+--   semester_regular    total check-ins >= 25
+--   copenhagen_veteran  total check-ins >= 50
+--   all_five            distinct POI categories this semester = 5
+--   cartographer        unique POIs this semester >= 20
+--   local_secret        total community check-ins at this POI (all time, post-insert) <= 10
+--   regular             visits to this POI this semester >= 3
+--   this_is_my_table    visits to this POI >= 5 AND no other user has more
+--   night_owl           check-in hour (Copenhagen TZ) in [0, 4]
+--   early_bird          check-in hour in [5, 7]
+--   weekend_warrior     check-in day = Saturday or Sunday (Copenhagen TZ)
+--   bookworm            check-ins in study_spots this semester >= 3
+--   culture_vulture     check-ins in culture this semester >= 3
+--   foodie              check-ins in food_drink this semester >= 3
+--   nightlifer          check-ins in nightlife this semester >= 3
+
+CREATE OR REPLACE FUNCTION award_check_in_badges()
+RETURNS trigger AS $$
+DECLARE
+  v_total_checkins    int;
+  v_unique_pois       int;
+  v_distinct_cats     int;
+  v_this_poi          int;
+  v_study_spots       int;
+  v_culture           int;
+  v_food_drink        int;
+  v_nightlife         int;
+  v_community         int;
+  v_checkin_hour      int;
+  v_checkin_dow       int;
+  v_top_visitor       bool;
+BEGIN
+  -- One pass: all user/semester aggregates (includes NEW row — AFTER INSERT)
+  SELECT
+    COUNT(*)                                               AS total,
+    COUNT(DISTINCT ci.poi_id)                             AS unique_pois,
+    COUNT(DISTINCT p.category)                            AS distinct_cats,
+    COUNT(*) FILTER (WHERE ci.poi_id = NEW.poi_id)        AS this_poi,
+    COUNT(*) FILTER (WHERE p.category = 'study_spots')   AS study_spots,
+    COUNT(*) FILTER (WHERE p.category = 'culture')       AS culture,
+    COUNT(*) FILTER (WHERE p.category = 'food_drink')    AS food_drink,
+    COUNT(*) FILTER (WHERE p.category = 'nightlife')     AS nightlife
+  INTO
+    v_total_checkins, v_unique_pois, v_distinct_cats,
+    v_this_poi, v_study_spots, v_culture, v_food_drink, v_nightlife
+  FROM public.check_ins ci
+  JOIN public.pois p ON p.id = ci.poi_id
+  WHERE ci.user_id = NEW.user_id
+    AND ci.semester_id = NEW.semester_id;
+
+  -- Community check-ins at this POI across all users and semesters
+  SELECT COUNT(*) INTO v_community
+  FROM public.check_ins
+  WHERE poi_id = NEW.poi_id;
+
+  -- Time components in Copenhagen timezone
+  v_checkin_hour := EXTRACT(HOUR FROM NEW.checked_in_at AT TIME ZONE 'Europe/Copenhagen')::int;
+  v_checkin_dow  := EXTRACT(DOW  FROM NEW.checked_in_at AT TIME ZONE 'Europe/Copenhagen')::int;
+
+  -- Top visitor: no other user has strictly more visits at this POI this semester
+  SELECT NOT EXISTS (
+    SELECT 1
+    FROM public.check_ins
+    WHERE poi_id     = NEW.poi_id
+      AND semester_id = NEW.semester_id
+      AND user_id    != NEW.user_id
+    GROUP BY user_id
+    HAVING COUNT(*) > v_this_poi
+  ) INTO v_top_visitor;
+
+  -- ── Milestones ────────────────────────────────────────────────────────────
+
+  IF v_total_checkins >= 1 THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'first_step', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  IF v_total_checkins >= 5 THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'getting_started', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  IF v_total_checkins >= 25 THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'semester_regular', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  IF v_total_checkins >= 50 THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'copenhagen_veteran', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  -- ── Exploration ───────────────────────────────────────────────────────────
+
+  IF v_distinct_cats >= 5 THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'all_five', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  IF v_unique_pois >= 20 THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'cartographer', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  IF v_community <= 10 THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'local_secret', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  -- ── Loyalty ───────────────────────────────────────────────────────────────
+
+  IF v_this_poi >= 3 THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'regular', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  IF v_this_poi >= 5 AND v_top_visitor THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'this_is_my_table', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  -- ── Time & Rhythm ─────────────────────────────────────────────────────────
+
+  IF v_checkin_hour < 5 THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'night_owl', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  IF v_checkin_hour >= 5 AND v_checkin_hour < 8 THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'early_bird', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  -- DOW: 0 = Sunday, 6 = Saturday
+  IF v_checkin_dow IN (0, 6) THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'weekend_warrior', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  -- ── POI Category ──────────────────────────────────────────────────────────
+
+  IF v_study_spots >= 3 THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'bookworm', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  IF v_culture >= 3 THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'culture_vulture', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  IF v_food_drink >= 3 THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'foodie', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  IF v_nightlife >= 3 THEN
+    INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+    VALUES (NEW.user_id, 'nightlifer', NEW.semester_id)
+    ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog;
+
+CREATE TRIGGER trg_award_check_in_badges
+  AFTER INSERT ON public.check_ins
+  FOR EACH ROW EXECUTE FUNCTION award_check_in_badges();

--- a/supabase/migrations/032_social_badge_evaluator.sql
+++ b/supabase/migrations/032_social_badge_evaluator.sql
@@ -1,0 +1,89 @@
+-- Badge evaluator for social badges (3 of 20).
+-- Fires AFTER UPDATE on presence_joins when confirmed flips false → true.
+--
+-- Join counts are not semester-scoped (live_presence has no semester_id).
+-- Counts are all-time; badge is awarded into the user's current profile.semester_id.
+--
+-- Thresholds:
+--   social_butterfly  joiner's total confirmed joins (all time) >= 3
+--   connector         distinct confirmed joiners across broadcaster's presences >= 3
+--   come_join_me      >= 1 confirmed join on any of broadcaster's presences
+
+CREATE OR REPLACE FUNCTION award_social_badges()
+RETURNS trigger AS $$
+DECLARE
+  v_broadcaster_id       uuid;
+  v_joiner_semester      uuid;
+  v_broadcaster_semester uuid;
+  v_joiner_joins         int;
+  v_broadcaster_joins    int;
+BEGIN
+  -- Resolve broadcaster (may be NULL if presence was dismissed/expired and deleted)
+  SELECT user_id INTO v_broadcaster_id
+  FROM public.live_presence
+  WHERE id = NEW.presence_id;
+
+  IF v_broadcaster_id IS NULL THEN
+    RAISE WARNING 'award_social_badges: live_presence % not found for join %. Broadcaster badges skipped.',
+      NEW.presence_id, NEW.id;
+  END IF;
+
+  -- Resolve semesters from profiles
+  SELECT semester_id INTO v_joiner_semester
+  FROM public.profiles
+  WHERE id = NEW.joiner_user_id;
+
+  IF v_broadcaster_id IS NOT NULL THEN
+    SELECT semester_id INTO v_broadcaster_semester
+    FROM public.profiles
+    WHERE id = v_broadcaster_id;
+  END IF;
+
+  -- ── social_butterfly (joiner) ────────────────────────────────────────────
+
+  IF v_joiner_semester IS NOT NULL THEN
+    -- AFTER UPDATE: triggering row is already confirmed=true, so count includes it.
+    SELECT COUNT(*) INTO v_joiner_joins
+    FROM public.presence_joins
+    WHERE joiner_user_id = NEW.joiner_user_id
+      AND confirmed = true;
+
+    IF v_joiner_joins >= 3 THEN
+      INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+      VALUES (NEW.joiner_user_id, 'social_butterfly', v_joiner_semester)
+      ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+    END IF;
+  END IF;
+
+  -- ── connector + come_join_me (broadcaster) ───────────────────────────────
+
+  IF v_broadcaster_id IS NOT NULL AND v_broadcaster_semester IS NOT NULL THEN
+    -- AFTER UPDATE: triggering row's joiner is included in this count.
+    SELECT COUNT(DISTINCT pj.joiner_user_id) INTO v_broadcaster_joins
+    FROM public.presence_joins pj
+    JOIN public.live_presence lp ON lp.id = pj.presence_id
+    WHERE lp.user_id = v_broadcaster_id
+      AND pj.confirmed = true;
+
+    IF v_broadcaster_joins >= 1 THEN
+      INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+      VALUES (v_broadcaster_id, 'come_join_me', v_broadcaster_semester)
+      ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+    END IF;
+
+    IF v_broadcaster_joins >= 3 THEN
+      INSERT INTO public.user_badges (user_id, badge_id, semester_id)
+      VALUES (v_broadcaster_id, 'connector', v_broadcaster_semester)
+      ON CONFLICT ON CONSTRAINT uq_user_badges_user_badge_semester DO NOTHING;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog;
+
+CREATE TRIGGER trg_award_social_badges
+  AFTER UPDATE ON public.presence_joins
+  FOR EACH ROW
+  WHEN (OLD.confirmed = false AND NEW.confirmed = true)
+  EXECUTE FUNCTION award_social_badges();

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -33,6 +33,45 @@ export type Database = {
   };
   public: {
     Tables: {
+      user_badges: {
+        Row: {
+          awarded_at: string;
+          badge_id: string;
+          id: string;
+          semester_id: string;
+          user_id: string;
+        };
+        Insert: {
+          awarded_at?: string;
+          badge_id: string;
+          id?: string;
+          semester_id: string;
+          user_id: string;
+        };
+        Update: {
+          awarded_at?: string;
+          badge_id?: string;
+          id?: string;
+          semester_id?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "user_badges_semester_id_fkey";
+            columns: ["semester_id"];
+            isOneToOne: false;
+            referencedRelation: "semesters";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "user_badges_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       check_ins: {
         Row: {
           checked_in_at: string;


### PR DESCRIPTION
## Summary

Implements the Phase 6 badge criteria engine for all 20 badges. Logic lives in PostgreSQL SECURITY DEFINER triggers (not client-side) so clients can never bypass award conditions. A Realtime subscription surfaces new badges to the user as an animated toast, and the Passport screen now shows live earned/total state.

## Changes

- `migration 029` — `user_badges` table: RLS (SELECT own only), Realtime publication, idempotent UNIQUE constraint
- `migration 030` — Pioneer auto-award in `handle_new_user` on signup
- `migration 031` — `award_check_in_badges` trigger (16 badges): milestones, exploration, loyalty, time/rhythm, POI category
- `migration 032` — `award_social_badges` trigger (3 badges): social_butterfly, connector, come_join_me on presence join confirm
- `useUserBadges` hook — fetches awarded badge IDs for current semester; surfaces to Passport badge grid
- `useNewBadges` hook — Realtime `postgres_changes` INSERT subscription; exposes new badge definition for toast
- `BadgeUnlockToast` component — animated overlay, auto-dismisses after 3 s, gold badge name
- `app/(app)/_layout.tsx` — wires `useNewBadges` + `BadgeUnlockToast` into app root
- `passport.tsx` — unlocked state per badge cell, earned count, loading + error states for badges section
- `catalog.test.ts` — 29 tests: exact 20 badge IDs (bidirectional), field integrity, Pioneer invariants, BADGE_BY_ID

## Test plan

- `npx jest` — all tests pass (29 catalog tests + 7 useUserBadges tests)
- Smoke test on device: check in at a POI → `first_step` badge toast appears, Passport grid updates
- Pioneer badge visible in Passport immediately after signup
- Social badges: confirm a presence join, check `social_butterfly` / `come_join_me` award