### PR TITLE
chore(notifications): remove deprecated shouldShowAlert

### DIFF
--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -46,7 +46,6 @@ setupNotificationCategories().catch((err) => {
 // notification types are added in Phase 7.
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
-    shouldShowAlert: true,
     shouldShowBanner: true,
     shouldShowList: true,
     shouldPlaySound: false,


### PR DESCRIPTION
## Summary
- Removes `shouldShowAlert: true` from `lib/notifications.ts` notification handler
- `shouldShowBanner` and `shouldShowList` already replace it (added previously)
- Silences Expo deprecation warning that fires on every cold start

Closes #44

## Test plan
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Verify `npx jest` passes (454 tests)
- [ ] Device build: notifications still surface as banners + list entries