### PR TITLE
feat(semesters): seed through Fall 2028 + pg_cron auto-generator

### DIFF
--- a/supabase/migrations/034_seed_semesters.sql
+++ b/supabase/migrations/034_seed_semesters.sql
@@ -1,0 +1,21 @@
+-- Seed known DIS semesters through Fall 2028 and add UNIQUE constraint
+-- on name for idempotent future inserts (pg_cron job in next migration).
+--
+-- DIS semester calendar (approximate, stable year-to-year):
+--   Spring: Jan 25 – May 15
+--   Summer: May 15 – Aug 15
+--   Fall:   Aug 25 – Dec 20
+
+-- Idempotency key for ON CONFLICT
+ALTER TABLE public.semesters
+  ADD CONSTRAINT uq_semesters_name UNIQUE (name);
+
+-- Seed through Fall 2028. Existing rows (Summer 2026, Fall 2026) skipped.
+INSERT INTO public.semesters (name, start_date, end_date) VALUES
+  ('Spring 2027', '2027-01-25', '2027-05-15'),
+  ('Summer 2027', '2027-05-15', '2027-08-15'),
+  ('Fall 2027',   '2027-08-25', '2027-12-20'),
+  ('Spring 2028', '2028-01-25', '2028-05-15'),
+  ('Summer 2028', '2028-05-15', '2028-08-15'),
+  ('Fall 2028',   '2028-08-25', '2028-12-20')
+ON CONFLICT (name) DO NOTHING;

--- a/supabase/migrations/035_semester_cron_job.sql
+++ b/supabase/migrations/035_semester_cron_job.sql
@@ -29,7 +29,12 @@ BEGIN
 END;
 $$;
 
--- 3. Schedule: 1st of every month at midnight UTC
+-- 3. Restrict access: maintenance function should not be callable by anon/authenticated via RPC.
+--    Supabase auto-grants EXECUTE to anon/authenticated on all public functions, so explicit
+--    revokes are required. The cron job runs as postgres and does not need these grants.
+REVOKE EXECUTE ON FUNCTION public.generate_upcoming_semesters() FROM PUBLIC, anon, authenticated;
+
+-- 4. Schedule: 1st of every month at midnight UTC
 SELECT cron.schedule(
   'generate-semesters',
   '0 0 1 * *',

--- a/supabase/migrations/035_semester_cron_job.sql
+++ b/supabase/migrations/035_semester_cron_job.sql
@@ -1,0 +1,40 @@
+-- Enable pg_cron and schedule monthly auto-generation of DIS semester rows.
+-- Ensures handle_new_user (migration 028) always finds a valid semester.
+
+-- 1. Enable pg_cron
+CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA pg_catalog;
+GRANT USAGE ON SCHEMA cron TO postgres;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA cron TO postgres;
+
+-- 2. Function: generate semesters for current year + next year
+CREATE OR REPLACE FUNCTION public.generate_upcoming_semesters()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  yr int;
+BEGIN
+  FOR yr IN SELECT generate_series(
+    EXTRACT(YEAR FROM CURRENT_DATE)::int,
+    EXTRACT(YEAR FROM CURRENT_DATE)::int + 1
+  ) LOOP
+    INSERT INTO public.semesters (name, start_date, end_date) VALUES
+      ('Spring ' || yr, make_date(yr, 1, 25), make_date(yr, 5, 15)),
+      ('Summer ' || yr, make_date(yr, 5, 15), make_date(yr, 8, 15)),
+      ('Fall '   || yr, make_date(yr, 8, 25), make_date(yr, 12, 20))
+    ON CONFLICT (name) DO NOTHING;
+  END LOOP;
+END;
+$$;
+
+-- 3. Schedule: 1st of every month at midnight UTC
+SELECT cron.schedule(
+  'generate-semesters',
+  '0 0 1 * *',
+  $$SELECT public.generate_upcoming_semesters()$$
+);
+
+-- 4. Run immediately to fill any gaps
+SELECT public.generate_upcoming_semesters();

--- a/supabase/migrations/035_semester_cron_job.sql
+++ b/supabase/migrations/035_semester_cron_job.sql
@@ -36,5 +36,5 @@ SELECT cron.schedule(
   $$SELECT public.generate_upcoming_semesters()$$
 );
 
--- 4. Run immediately to fill any gaps
+-- 4. Run immediately to fill any gaps (also inserts Spring 2026 if missing)
 SELECT public.generate_upcoming_semesters();


### PR DESCRIPTION
## Summary
- **Migration 034** — adds `UNIQUE` constraint on `semesters.name` and seeds 6 semester rows (Spring 2027 through Fall 2028) via `ON CONFLICT DO NOTHING`
- **Migration 035** — enables `pg_cron`, creates `generate_upcoming_semesters()` function (generates current year + next year), schedules it monthly (`0 0 1 * *`), and runs immediately to fill gaps
- Self-sustaining: always maintains ~2 years of semester runway without manual migrations

Closes #37

## Test plan
- [x] 454 tests pass (`npx jest`)
- [x] Verified 9 semester rows in DB (Spring 2026 – Fall 2028) via Supabase MCP
- [x] Verified `cron.job` contains `generate-semesters` entry with correct schedule
- [ ] Monitor `cron.job_run_details` after May 1st to confirm first automated run

🤖 Generated with [Claude Code](https://claude.com/claude-code)