### PR TITLE
chore(tests): type confirmJoins mock-result casts (closes #53)

### DIFF
--- a/lib/__tests__/presenceJoins.test.ts
+++ b/lib/__tests__/presenceJoins.test.ts
@@ -255,7 +255,7 @@ describe("confirmJoins", () => {
 
     expect(mock.from).toHaveBeenCalledWith("live_presence");
     const lpFrom = mock.from.mock.results.find(
-      (r: any) => typeof r.value.select === "function",
+      (r: { value?: { select?: unknown } }) => typeof r.value?.select === "function",
     )!.value;
     expect(lpFrom.select).toHaveBeenCalledWith("id");
     const eqResult = lpFrom.select.mock.results[0].value;
@@ -270,7 +270,7 @@ describe("confirmJoins", () => {
 
     expect(mock.from).toHaveBeenCalledWith("presence_joins");
     const pjFrom = mock.from.mock.results.find(
-      (r: any) => typeof r.value.update === "function",
+      (r: { value?: { update?: unknown } }) => typeof r.value?.update === "function",
     )!.value;
     expect(pjFrom.update).toHaveBeenCalledWith({ confirmed: true }, { count: "exact" });
 


### PR DESCRIPTION
## Summary
- Replaces two `(r: any)` casts in `lib/__tests__/presenceJoins.test.ts` `confirmJoins` block with typed mock-result shapes
- Uses `{ value?: { select?: unknown } }` / `{ value?: { update?: unknown } }` — optional because jest `MockResult<any>.value` can be undefined when the mock is in incomplete state
- No behaviour change; satisfies strict-TS / no-unannotated-`any` invariant

Closes #53.

## Test plan
- [x] `npx jest lib/__tests__/presenceJoins.test.ts` — 22/22 pass
- [x] Type-check hook passes on edited file