### PR TITLE
test(badges): cover useNewBadges hook and BadgeUnlockToast

### DIFF
--- a/components/__tests__/BadgeUnlockToast.test.tsx
+++ b/components/__tests__/BadgeUnlockToast.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { act, create } from "react-test-renderer";
+import { BadgeUnlockToast } from "../BadgeUnlockToast";
+import type { BadgeDefinition } from "@/lib/badges/catalog";
+
+const BADGE_A: BadgeDefinition = {
+  id: "first_check_in",
+  name: "First Step",
+  description: "Made your very first check-in.",
+  criteriaHint: "Check in anywhere for the first time.",
+  category: "milestone",
+  icon: "👣",
+};
+
+const BADGE_B: BadgeDefinition = {
+  id: "pioneer",
+  name: "Pioneer",
+  description: "One of the summer 2026 cohort.",
+  criteriaHint: "Auto-awarded on signup.",
+  category: "exclusive",
+  icon: "🚀",
+};
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("BadgeUnlockToast — auto-dismiss", () => {
+  it("calls onDismiss after 3s when a badge is shown", () => {
+    const onDismiss = jest.fn();
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<BadgeUnlockToast badge={BADGE_A} onDismiss={onDismiss} />);
+    });
+
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      root!.unmount();
+    });
+  });
+
+  it("clears the original timer when badge changes mid-display", () => {
+    const onDismiss = jest.fn();
+    let root: ReturnType<typeof create>;
+    act(() => {
+      root = create(<BadgeUnlockToast badge={BADGE_A} onDismiss={onDismiss} />);
+    });
+
+    // 2.5s in — original timer has not fired yet.
+    act(() => {
+      jest.advanceTimersByTime(2500);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    // Swap to a new badge — original 3s timer should be cleared.
+    act(() => {
+      root!.update(<BadgeUnlockToast badge={BADGE_B} onDismiss={onDismiss} />);
+    });
+
+    // 500ms more reaches the ORIGINAL 3s deadline — if the timer wasn't
+    // cleared, onDismiss would fire here. It must not.
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    // 2500ms more completes the NEW 3s timer (total 3000ms since swap).
+    act(() => {
+      jest.advanceTimersByTime(2500);
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      root!.unmount();
+    });
+  });
+});

--- a/components/__tests__/BadgeUnlockToast.test.tsx
+++ b/components/__tests__/BadgeUnlockToast.test.tsx
@@ -4,7 +4,7 @@ import { BadgeUnlockToast } from "../BadgeUnlockToast";
 import type { BadgeDefinition } from "@/lib/badges/catalog";
 
 const BADGE_A: BadgeDefinition = {
-  id: "first_check_in",
+  id: "first_step",
   name: "First Step",
   description: "Made your very first check-in.",
   criteriaHint: "Check in anywhere for the first time.",

--- a/components/passport/__tests__/BadgeDetailModal.test.tsx
+++ b/components/passport/__tests__/BadgeDetailModal.test.tsx
@@ -4,7 +4,7 @@ import { BadgeDetailModal } from "../BadgeDetailModal";
 import type { BadgeDefinition } from "@/lib/badges/catalog";
 
 const MOCK_BADGE: BadgeDefinition = {
-  id: "first_check_in",
+  id: "first_step",
   name: "First Step",
   description: "Made your very first check-in.",
   criteriaHint: "Check in anywhere for the first time.",

--- a/hooks/__tests__/useNewBadges.test.ts
+++ b/hooks/__tests__/useNewBadges.test.ts
@@ -1,0 +1,193 @@
+import React from "react";
+import { act, create } from "react-test-renderer";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+type InsertPayload = { new: { badge_id: string } };
+type InsertHandler = (payload: InsertPayload) => void;
+
+// ---------------------------------------------------------------------------
+// Mock leaf fns (mock* prefix — only lookups inside factory must be lazy)
+// ---------------------------------------------------------------------------
+const mockUseAuth = jest.fn();
+
+const mockChannel = {
+  on: jest.fn(),
+  subscribe: jest.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+jest.mock("@/lib/supabase", () => ({
+  supabase: {
+    channel: jest.fn(() => mockChannel),
+    removeChannel: jest.fn(),
+  },
+}));
+
+jest.mock("@/hooks/useAuth", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+import { useNewBadges, type NewBadgesState } from "../useNewBadges";
+import { supabase } from "@/lib/supabase";
+import { BADGE_BY_ID } from "@/lib/badges/catalog";
+
+const channelFn = supabase.channel as unknown as jest.Mock;
+const removeChannelFn = supabase.removeChannel as unknown as jest.Mock;
+
+// ---------------------------------------------------------------------------
+// renderHook helper (mirrors hooks/__tests__/useUserBadges.test.ts)
+// ---------------------------------------------------------------------------
+type HookResult<T> = { current: T };
+let activeRenderer: ReturnType<typeof create> | null = null;
+
+afterEach(() => {
+  if (activeRenderer) {
+    act(() => {
+      activeRenderer!.unmount();
+    });
+    activeRenderer = null;
+  }
+});
+
+function renderHook<T>(useHook: () => T): HookResult<T> {
+  const result: HookResult<T> = { current: undefined as unknown as T };
+  function TestComponent() {
+    result.current = useHook();
+    return null;
+  }
+  act(() => {
+    activeRenderer = create(React.createElement(TestComponent));
+  });
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Constants + setup
+// ---------------------------------------------------------------------------
+const USER_ID = "user-1";
+const OTHER_USER_ID = "user-2";
+
+let capturedInsertHandler: InsertHandler | null = null;
+
+// Guard against silent drift if the catalog ever renames "pioneer".
+beforeAll(() => {
+  expect(BADGE_BY_ID.has("pioneer")).toBe(true);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  capturedInsertHandler = null;
+
+  mockChannel.on.mockImplementation(
+    (_event: string, _cfg: unknown, handler: InsertHandler) => {
+      capturedInsertHandler = handler;
+      return mockChannel;
+    },
+  );
+  mockChannel.subscribe.mockReturnValue(mockChannel);
+
+  const { AppState } = require("react-native");
+  AppState.currentState = "active";
+
+  mockUseAuth.mockReturnValue({ session: { user: { id: USER_ID } } });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("useNewBadges — INSERT handling", () => {
+  it("sets newBadge when INSERT arrives with known badge_id", () => {
+    const result = renderHook(() => useNewBadges());
+
+    expect(capturedInsertHandler).not.toBeNull();
+    act(() => {
+      capturedInsertHandler!({ new: { badge_id: "pioneer" } });
+    });
+
+    expect(result.current.newBadge?.id).toBe("pioneer");
+  });
+
+  it("ignores INSERT when AppState is not active (app backgrounded)", () => {
+    // Mount while active so subscribe-time state isn't what's under test;
+    // then flip to background so the in-handler guard is exercised.
+    const result = renderHook(() => useNewBadges());
+
+    const { AppState } = require("react-native");
+    AppState.currentState = "background";
+    act(() => {
+      capturedInsertHandler!({ new: { badge_id: "pioneer" } });
+    });
+
+    expect(result.current.newBadge).toBeNull();
+  });
+
+  it("silently no-ops when badge_id is not in catalog", () => {
+    const result = renderHook(() => useNewBadges());
+
+    act(() => {
+      capturedInsertHandler!({ new: { badge_id: "ghost_badge_not_in_catalog" } });
+    });
+
+    expect(result.current.newBadge).toBeNull();
+  });
+});
+
+describe("useNewBadges — channel lifecycle", () => {
+  it("removes channel on unmount", () => {
+    renderHook(() => useNewBadges());
+
+    expect(channelFn).toHaveBeenCalledWith(`new-badges-${USER_ID}`);
+    expect(removeChannelFn).not.toHaveBeenCalled();
+
+    act(() => {
+      activeRenderer!.unmount();
+    });
+    activeRenderer = null;
+
+    expect(removeChannelFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes old channel and creates new one when userId changes", () => {
+    const result: HookResult<NewBadgesState> = {
+      current: undefined as unknown as NewBadgesState,
+    };
+    function TestComponent() {
+      result.current = useNewBadges();
+      return null;
+    }
+
+    act(() => {
+      activeRenderer = create(React.createElement(TestComponent));
+    });
+    expect(channelFn).toHaveBeenCalledWith(`new-badges-${USER_ID}`);
+    expect(removeChannelFn).not.toHaveBeenCalled();
+
+    mockUseAuth.mockReturnValue({ session: { user: { id: OTHER_USER_ID } } });
+    act(() => {
+      activeRenderer!.update(React.createElement(TestComponent));
+    });
+
+    expect(removeChannelFn).toHaveBeenCalledTimes(1);
+    expect(channelFn).toHaveBeenCalledWith(`new-badges-${OTHER_USER_ID}`);
+  });
+});
+
+describe("useNewBadges — dismiss", () => {
+  it("clears newBadge when dismiss is called", () => {
+    const result = renderHook(() => useNewBadges());
+
+    act(() => {
+      capturedInsertHandler!({ new: { badge_id: "pioneer" } });
+    });
+    expect(result.current.newBadge?.id).toBe("pioneer");
+
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(result.current.newBadge).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for the badge unlock path flagged in PR #39 review and tracked in #42. Locks in behavior for the Realtime subscription, in-handler AppState guard, channel lifecycle, and the 3-second toast auto-dismiss timer.

## Changes

- `hooks/__tests__/useNewBadges.test.ts` (new, 6 tests):
  - Realtime INSERT dispatch → `newBadge` set
  - `AppState !== "active"` guard → INSERT ignored (flipped post-mount so the in-handler guard is genuinely exercised)
  - Unknown `badge_id` → silent no-op
  - `removeChannel` called on unmount
  - Channel swap on `userId` change (old removed, new created)
  - `dismiss()` clears `newBadge`
- `components/__tests__/BadgeUnlockToast.test.tsx` (new, 2 tests):
  - 3s `AUTO_DISMISS_MS` timer fires `onDismiss` once
  - Mid-display badge swap clears the original timer (probe at old deadline confirms no fire) and restarts a fresh 3s timer on the new badge

Follows existing mock/`react-test-renderer` conventions from `useUserBadges.test.ts` and `BadgeDetailModal.test.tsx`. Uses `jest.useFakeTimers()` for the toast timer assertions.

Out of scope (per #42): `CHANNEL_ERROR` / `TIMED_OUT` status-handler logging.

## Test plan

- [x] `npx jest components/__tests__/BadgeUnlockToast.test.tsx` — 2/2 pass
- [x] `npx jest hooks/__tests__/useNewBadges.test.ts` — 6/6 pass
- [x] Full suite: 484/484 pass
- [x] `npx tsc --noEmit` clean
- [x] Rebased onto latest `main`

Closes #42